### PR TITLE
added interface for latitude longitude telescopes

### DIFF
--- a/pyobs/interfaces/ILatLon.py
+++ b/pyobs/interfaces/ILatLon.py
@@ -1,0 +1,28 @@
+from .interface import Interface
+
+
+class ILatLon(Interface):
+    """Base interface for everything that can move to Lat/Lon coordinates."""
+
+    def move_latlon(self, lat: float, lon: float, *args, **kwargs):
+        """Moves to given coordinates.
+
+        Args:
+            lat: Latitude in deg to move to.
+            lon: Longitude in deg to move to.
+
+        Raises:
+            ValueError: If device could not move.
+        """
+        raise NotImplementedError
+
+    def get_latlon(self, *args, **kwargs) -> (float, float):
+        """Returns current Latitude and Longitude.
+
+        Returns:
+            Tuple of current Latitude and Longitude in degrees.
+        """
+        raise NotImplementedError
+
+
+__all__ = ['ILatLon']

--- a/pyobs/interfaces/__init__.py
+++ b/pyobs/interfaces/__init__.py
@@ -1,6 +1,7 @@
 from .IAbortable import IAbortable
 from .IAcquisition import IAcquisition
 from .IAltAz import IAltAz
+from .ILatLon import ILatLon
 from .IAltAzOffsets import IAltAzOffsets
 from .IAutoFocus import IAutoFocus
 from .IAutoGuiding import IAutoGuiding


### PR DESCRIPTION
This adds an interface similar to `IRaDec` and `IAltAz` which supports setting geographical latitude and longitude coordinates. Like for example Carrington coordinates for the sun.