### PR TITLE
don't crash when a telescope does not provide a focus

### DIFF
--- a/pyobs/modules/guiding/base.py
+++ b/pyobs/modules/guiding/base.py
@@ -194,10 +194,11 @@ class BaseGuiding(PyObsModule, TableStorageMixin, IAutoGuiding, IFitsHeaderProvi
                 return
 
             # check focus
-            if abs(image.header['TEL-FOCU'] - self._last_header['TEL-FOCU']) > 0.05:
-                log.warning('Focus difference between current and last image is too large, resetting reference...')
-                self._reset_guiding(image=image)
-                return
+            if 'TEL-FOCU' in image.header:
+                if abs(image.header['TEL-FOCU'] - self._last_header['TEL-FOCU']) > 0.05:
+                    log.warning('Focus difference between current and last image is too large, resetting reference...')
+                    self._reset_guiding(image=image)
+                    return
 
         # remember header
         self._last_header = image.header


### PR DESCRIPTION
This fixes a crash for telescopes that do not provide a focus in the FITS header.