### PR TITLE
Added exception handler image processor decorator

### DIFF
--- a/pyobs/images/processors/__init__.py
+++ b/pyobs/images/processors/__init__.py
@@ -2,3 +2,7 @@
 Image Processors (pyobs.images.processors)
 ------------------------------------------
 """
+
+from .exceptionhandler import (ExceptionHandler)
+
+__all__ = ["ExceptionHandler"]

--- a/pyobs/images/processors/exceptionhandler.py
+++ b/pyobs/images/processors/exceptionhandler.py
@@ -1,0 +1,41 @@
+import logging
+from typing import Union, Dict, Any, Optional
+
+from pyobs.images import ImageProcessor, Image
+from pyobs.object import get_object
+
+import pyobs.utils.exceptions as exc
+log = logging.getLogger(__name__)
+
+
+class ExceptionHandler(ImageProcessor):
+
+    __module__ = "pyobs.images.processors"
+
+    def __init__(self, processor: Union[ImageProcessor, Dict[str, Any]], error_header: Optional[str] = None) -> None:
+        super().__init__()
+
+        self._processor: ImageProcessor = get_object(processor, ImageProcessor)  # type: ignore
+        self._error_header = error_header
+
+    async def __call__(self, image: Image) -> Image:
+        try:
+            return await self._processor(image)
+        except exc.ImageError as e:
+            return await self._handle_error(image, e)
+
+    async def _handle_error(self, image: Image, error: exc.ImageError) -> Image:
+        log.warning(error.message)
+
+        output_image = image.copy()
+
+        if self._error_header is not None:
+            output_image.header[self._error_header] = 1
+
+        return output_image
+
+    async def reset(self) -> None:
+        await self._processor.reset()
+
+
+__all__ = ["ExceptionHandler"]

--- a/tests/images/processors/test_exceptionhandler.py
+++ b/tests/images/processors/test_exceptionhandler.py
@@ -1,0 +1,49 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from pyobs.images import ImageProcessor, Image
+from pyobs.images.processors import ExceptionHandler
+
+import pyobs.utils.exceptions as exc
+
+class MockImageProcessor(ImageProcessor):
+
+    async def __call__(self, image: Image) -> Image:
+        return image
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_no_exception() -> None:
+    image = Image()
+    exception_handler = ExceptionHandler(MockImageProcessor())
+
+    result = await exception_handler(image)
+
+    assert image == result
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_exception(caplog) -> None:
+    image = Image()
+    exception_handler = ExceptionHandler(MockImageProcessor())
+    exception_handler._processor = Mock(side_effect=exc.ImageError("Some error"))
+
+    with caplog.at_level(logging.WARNING):
+        result = await exception_handler(image)
+
+    assert caplog.messages[0] == "Some error"
+
+    assert image is not result
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_exception_w_header() -> None:
+    image = Image()
+    exception_handler = ExceptionHandler(MockImageProcessor(), "WCSERR")
+    exception_handler._processor = Mock(side_effect=exc.ImageError("Some error"))
+
+    result = await exception_handler(image)
+
+    assert result.header["WCSERR"] == 1


### PR DESCRIPTION
This is an alternative suggestion to implementing the exception handling in the image processor base class.
Doing this in the base class would introduce two new attributes `suppress_exception: bool` which toggles the exception handling and `error_header: Optional[str]` which defines the error header flat. This introduces the problem that the `error_header` attribute can be set without the `suppress_exception` attribute being true, which could lead to errors in config management. 
The alternative decorator approach removes the need for the first attribute.
A config with this could look like this

```yaml

[...]
pipeline:

  - class: pyobs.images.processors.detection.SepSourceDetection
  - class: pyobs.image.processors.ExceptionHandler
      processor:
        class: pyobs.images.processors.astrometry.AstrometryDotNet
          url: ...
          radius: 5
      error_header: "WCSERR"
[...]

```

I'm open to feedback.