### PR TITLE
Fix: SSHFile thread leakage

### DIFF
--- a/pyobs/vfs/sshfile.py
+++ b/pyobs/vfs/sshfile.py
@@ -127,6 +127,7 @@ class SSHFile(VFSFile):
 
         # set flag
         self._open = False
+        self._ssh.close()
 
     async def _upload(self) -> None:
         """If in write mode, actually send the file to the SSH server."""


### PR DESCRIPTION
The ssh connection is not closed when the SSHFile is closed, leading to thread leakage as the connection is opened in another thread.

This pull request fixes this by closing the ssh connection when the SSHFile is closed.