### PR TITLE
Bright star guiding

### DIFF
--- a/pyobs/images/processors/misc/__init__.py
+++ b/pyobs/images/processors/misc/__init__.py
@@ -12,3 +12,4 @@ from .softbin import SoftBin
 from .broadcast import Broadcast
 from .circular_mask import CircularMask
 from .image_source_filter import ImageSourceFilter
+from .catalog_circular_mask import CatalogCircularMask

--- a/pyobs/images/processors/misc/catalog_circular_mask.py
+++ b/pyobs/images/processors/misc/catalog_circular_mask.py
@@ -1,0 +1,49 @@
+import logging
+from typing import Any, Tuple
+
+import numpy as np
+
+from pyobs.images.processor import ImageProcessor
+from pyobs.images import Image
+
+log = logging.getLogger(__name__)
+
+
+class CatalogCircularMask(ImageProcessor):
+    """Mask catalog for central circle with given radius."""
+
+    __module__ = "pyobs.images.processors.misc"
+
+    def __init__(self, radius: float, center: Tuple[str, str] = ("CRPIX1", "CRPIX2"), **kwargs: Any):
+        """Init an image processor that masks out everything except for a central circle.
+
+        Args:
+            radius: radius of the central circle in pixels
+            center: fits-header keywords defining the pixel coordinates of the center of the circle
+        """
+        ImageProcessor.__init__(self, **kwargs)
+
+        # init
+        self._center = center
+        self._radius = radius
+
+    async def __call__(self, image: Image) -> Image:
+        """Remove everything outside the given radius from the image.
+
+        Args:
+            image: Image to mask.
+
+        Returns:
+            Image with masked Catalog.
+        """
+
+        center_x, center_y = image.header[self._center[0]], image.header[self._center[1]]
+
+        catalog = image.safe_catalog
+        mask = (catalog["x"] - center_x) ** 2 + (catalog["y"] - center_y) ** 2 <= self._radius**2
+        image.catalog = catalog[mask]
+
+        return image
+
+
+__all__ = ["CatalogCircularMask"]

--- a/pyobs/images/processors/misc/catalog_circular_mask.py
+++ b/pyobs/images/processors/misc/catalog_circular_mask.py
@@ -24,7 +24,7 @@ class CatalogCircularMask(ImageProcessor):
 
         Args:
             radius: radius of the central circle in pixels
-            center: fits-header keywords defining the pixel coordinates of the center of the circle
+            center: fits-header keywords or pixel coordinates defining the center of the circle
         """
         ImageProcessor.__init__(self, **kwargs)
 

--- a/pyobs/images/processors/offsets/__init__.py
+++ b/pyobs/images/processors/offsets/__init__.py
@@ -2,6 +2,7 @@
 Offsets
 -------
 """
+from .brighteststar_guiding import BrightestStarGuiding
 from .offsets import Offsets
 from .astrometry import AstrometryOffsets
 from .brighteststar import BrightestStarOffsets
@@ -18,6 +19,7 @@ __all__ = [
     "ProjectedOffsets",
     "FitsHeaderOffsets",
     "BrightestStarOffsets",
+    "BrightestStarGuiding",
     "DummyOffsets",
-    "DummySkyOffsets"
+    "DummySkyOffsets",
 ]

--- a/pyobs/images/processors/offsets/brighteststar_guiding.py
+++ b/pyobs/images/processors/offsets/brighteststar_guiding.py
@@ -1,0 +1,79 @@
+import logging
+from typing import Tuple, Any, Optional
+
+from astropy.coordinates import Angle
+from astropy.table import Table, Row
+from astropy.wcs import WCS
+from pandas._typing import npt
+
+from pyobs.images import Image
+from pyobs.images.meta import PixelOffsets, OnSkyDistance
+from .offsets import Offsets
+
+log = logging.getLogger(__name__)
+
+
+class BrightestStarGuiding(Offsets):
+    """Calculates offsets from the center of the image to the brightest star."""
+
+    __module__ = "pyobs.images.processors.offsets"
+
+    def __init__(self, center_header_cards: Tuple[str, str] = ("CRPIX1", "CRPIX2"), **kwargs: Any):
+        """Initializes a new auto guiding system."""
+        Offsets.__init__(self, **kwargs)
+
+        self._center_header_cards = center_header_cards
+        self._ref_image: Optional[Tuple[npt.NDArray[float], npt.NDArray[float]]] = None
+        self._ref_pos: Optional[Tuple[float, float]] = None
+
+    async def __call__(self, image: Image) -> Image:
+        """Processes an image and sets x/y pixel offset to reference in offset attribute.
+
+        Args:
+            image: Image to process.
+
+        Returns:
+            Original image.
+
+        Raises:
+            ValueError: If offset could not be found.
+        """
+
+        catalog = image.safe_catalog
+        if catalog is None or len(catalog) < 1:
+            log.warning("No catalog found in image.")
+            return image
+
+        if not self._reference_initialized():
+            log.info("Initialising auto-guiding with new image...")
+            self._ref_image = image
+            self._ref_pos = self._get_brightest_star_position(catalog)
+            return image
+
+        star_pos = self._get_brightest_star_position(catalog)
+
+        offset = (star_pos[0] - self._ref_pos[0], star_pos[1] - self._ref_pos[1])
+        on_sky_distance = self._calc_on_sky_distance(image, self._ref_pos, star_pos)
+
+        image.set_meta(PixelOffsets(*offset))
+        image.set_meta(OnSkyDistance(on_sky_distance))
+        return image
+
+    def _reference_initialized(self):
+        return self._ref_image is not None
+
+    @staticmethod
+    def _get_brightest_star_position(catalog: Table) -> Tuple[float, float]:
+        brightest_star: Row = max(catalog, key=lambda row: row["flux"])
+        return brightest_star["x"], brightest_star["y"]
+
+    @staticmethod
+    def _calc_on_sky_distance(image: Image, ref_pos: Tuple[float, float], star_pos: Tuple[float, float]) -> Angle:
+        wcs = WCS(image.header)
+        reference_coordinates = wcs.pixel_to_world(*ref_pos)
+        star_coordinates = wcs.pixel_to_world(*star_pos)
+
+        return reference_coordinates.separation(star_coordinates)
+
+
+__all__ = ["BrightestStarGuiding"]

--- a/pyobs/images/processors/offsets/brighteststar_guiding.py
+++ b/pyobs/images/processors/offsets/brighteststar_guiding.py
@@ -68,6 +68,7 @@ class BrightestStarGuiding(Offsets):
     @staticmethod
     def _get_brightest_star_position(catalog: Table) -> Tuple[float, float]:
         brightest_star: Row = max(catalog, key=lambda row: row["flux"])
+        log.info("Found brightest star at x=%.2f, y=%.2f", brightest_star["x"], brightest_star["y"])
         return brightest_star["x"], brightest_star["y"]
 
     def _calc_altaz_offset(self, image: Image, star_pos: Tuple[float, float]):
@@ -81,13 +82,12 @@ class BrightestStarGuiding(Offsets):
         # get offset
         daz, dalt = altaz_ref.spherical_offsets_to(altaz_target)
 
-        return dalt.arcsec, daz.arcsec
+        return dalt.arcsec/2, daz.arcsec/2
 
     def _get_radec_ref_target(self, image: Image, star_pos):
-        wcs_ref = WCS(self._ref_image.header)
-        ref = wcs_ref.pixel_to_world(*self._ref_pos)
-        wcs_target = WCS(image.header)
-        target = wcs_target.pixel_to_world(*star_pos)
+        wcs = WCS(image.header)
+        ref = wcs.pixel_to_world(*self._ref_pos)
+        target = wcs.pixel_to_world(*star_pos)
         return ref, target
 
 

--- a/pyobs/images/processors/offsets/brighteststar_guiding.py
+++ b/pyobs/images/processors/offsets/brighteststar_guiding.py
@@ -70,10 +70,10 @@ class BrightestStarGuiding(Offsets):
         brightest_star: Row = max(catalog, key=lambda row: row["flux"])
         return brightest_star["x"], brightest_star["y"]
 
-    def _calc_altaz_offset(self, image: Image,  star_pos: Tuple[float, float]):
+    def _calc_altaz_offset(self, image: Image, star_pos: Tuple[float, float]):
         radec_ref, radec_target = self._get_radec_ref_target(image, star_pos)
         hdr = image.header
-        location = EarthLocation(lat=hdr["LATITUDE"]*u.deg, lon=hdr["LONGITUD"]*u.deg, height=hdr["HEIGHT"]*u.m)
+        location = EarthLocation(lat=hdr["LATITUDE"] * u.deg, lon=hdr["LONGITUD"] * u.deg, height=hdr["HEIGHT"] * u.m)
         frame = AltAz(obstime=Time(image.header["DATE-OBS"]), location=location)
         altaz_ref = radec_ref.transform_to(frame)
         altaz_target = radec_target.transform_to(frame)
@@ -81,12 +81,13 @@ class BrightestStarGuiding(Offsets):
         # get offset
         daz, dalt = altaz_ref.spherical_offsets_to(altaz_target)
 
-        return dalt.arcsec/2, daz.arcsec/2
+        return dalt.arcsec, daz.arcsec
 
     def _get_radec_ref_target(self, image: Image, star_pos):
-        wcs = WCS(image.header)
-        ref = wcs.pixel_to_world(*self._ref_pos)
-        target = wcs.pixel_to_world(*star_pos)
+        wcs_ref = WCS(self._ref_image.header)
+        ref = wcs_ref.pixel_to_world(*self._ref_pos)
+        wcs_target = WCS(image.header)
+        target = wcs_target.pixel_to_world(*star_pos)
         return ref, target
 
 

--- a/pyobs/images/processors/offsets/brighteststar_guiding.py
+++ b/pyobs/images/processors/offsets/brighteststar_guiding.py
@@ -82,7 +82,7 @@ class BrightestStarGuiding(Offsets):
         # get offset
         daz, dalt = altaz_ref.spherical_offsets_to(altaz_target)
 
-        return dalt.arcsec/2, daz.arcsec/2
+        return dalt.arcsec, daz.arcsec
 
     def _get_radec_ref_target(self, image: Image, star_pos):
         wcs = WCS(image.header)

--- a/pyobs/utils/offsets/applyaltazoffsets.py
+++ b/pyobs/utils/offsets/applyaltazoffsets.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 import numpy as np
-from astropy.coordinates import EarthLocation, AltAz
+from astropy.coordinates import EarthLocation, AltAz, Angle
 import astropy.units as u
 
 from pyobs.images import Image
@@ -53,8 +53,8 @@ class ApplyAltAzOffsets(ApplyOffsets):
         if image.has_meta(AltAzOffsets):
             # offsets are Alt/Az, so get them directly
             offsets = image.get_meta(AltAzOffsets)
-            log.info("Found Alt/Az shift of dra=%.2f, ddec=%.2f.", offsets.dalt, offsets.daz)
-            dalt, daz = offsets.dalt * u.arcsec, offsets.daz * u.arcsec
+            log.info("Found Alt/Az shift of dalt=%.2f, daz=%.2f.", offsets.dalt, offsets.daz)
+            dalt, daz = Angle(offsets.dalt * u.arcsec), Angle(offsets.daz * u.arcsec)
 
         elif image.has_meta(RaDecOffsets):
             raise NotImplementedError()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pyobs-core"
 packages = [{ include = "pyobs" }]
-version = "1.12.8"
+version = "1.13.0"
 description = "robotic telescope software"
 authors = ["Tim-Oliver Husser <thusser@uni-goettingen.de>"]
 license = "MIT"

--- a/tests/images/processors/misc/test_catalog_circular_mask.py
+++ b/tests/images/processors/misc/test_catalog_circular_mask.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from astropy.table import Table
+from pyobs.images import Image
+from pyobs.images.processors.misc import CatalogCircularMask
+
+
+@pytest.mark.asyncio
+async def test_call():
+    radius = 1
+    mask = CatalogCircularMask(radius=radius)
+    data = np.ones((4, 4))
+    catalog = Table([[1, 3], [1, 3]], names=("x", "y"))
+    image = Image(data, catalog=catalog)
+    image.header["CRPIX1"] = 1.5
+    image.header["CRPIX2"] = 1.5
+    image.header["XBINNING"] = 1
+    image.header["YBINNING"] = 1
+    masked_image = await mask(image)
+    expected_output_catalog = Table([[1], [1]], names=("x", "y"))
+    assert masked_image.catalog == expected_output_catalog


### PR DESCRIPTION
Allows guiding on the brightest star in the image. The CircularCatalogMask only masks the catalog, not the image itself. If the guide star position is known, it can be specified in the config of the mask.