### PR TITLE
Exception handling rollout: default logging, real types over the wire, typed leaves, docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* RPC calls over XMPP now carry a correlation id end to end: the origin-side log line for a
+  domain exception (``Module.execute()``'s catch block) includes ``(call_id=...)``, and the same
+  id is attached to the exception the caller receives as ``exception.call_id`` -- reusing
+  XEP-0009's existing per-call ``iq["id"]`` rather than adding new plumbing. Lets an operator
+  debugging a caller-side ``FocusError`` jump straight to the matching detailed log on the module
+  that actually raised it, instead of neither side's log line pointing at the other. Purely
+  additive, no migration required; not set for ``LocalComm``/``MultiModule`` calls, which are
+  already in the same log stream as the caller. Fourth step of the exception-handling rollout in
+  ``DESIGN_exception_handling.md`` (tracks #446).
 * Constructing a ``PyobsError`` is now side-effect-free, ordinary Python. ``raise
   exc.FocusError(...)`` always raises a ``FocusError`` -- it no longer risks silently coming back
   as a ``SevereError`` instead, which could happen because the old severity-escalation metaclass

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,21 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* New ``InvalidArgumentError`` for bad-argument validation on RPC-exposed methods (unknown filter
+  name, invalid focus value, invalid config parameter, out-of-range ``grab_sequence`` count/delay,
+  ...) -- previously these stayed as plain ``ValueError``, which works fine locally (``LocalComm``,
+  direct calls, tests) but silently degrades to ``UnclassifiedError`` the moment the same call
+  crosses XMPP, since ``ValueError`` is a builtin and never in the registry. That inconsistency is
+  exactly the kind of bug that only shows up once code moves from a local test to a networked
+  deployment. Fixed for ``IConfig.get_config_value``/``get_config_value_options``/
+  ``set_config_value``, ``IDataSequence.grab_sequence``, ``ITrackingMode.set_tracking_mode``,
+  ``IFocuser.set_focus``, ``IFilters.set_filter``, ``IMode.set_mode``, and
+  ``IWeather.get_sensor_value`` (its ``MockWeather`` implementation only -- the real ``Weather``
+  class's ``ValueError`` is about a malformed station response, not a bad argument, and is left
+  as-is). Also reused the existing ``DeviceBusyError`` for ``FlatField.flat_field``/
+  ``FlatFieldScheduler.run``'s "already running" check, which was never actually about a bad
+  argument either. Scoped out first (see ``DESIGN_exception_handling.md``) before touching
+  anything: real driver repos (e.g. ``pyobs-sbig``) likely have the identical ``ValueError``
+  pattern for real hardware and would need the same companion fix, not reachable from this PR.
 * Fixed ``UnclassifiedError.original_type`` silently not surviving the wire: ``Module.execute()``
   wraps a non-domain exception (``IndexError``, a vendor SDK exception, ...) as
   ``UnclassifiedError`` before ``rpc.py`` ever sees it, but ``fault_to_xml`` was serializing the

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,29 @@
 v2.0.0.dev18 (unreleased)
 *************************
-* Every RPC-exposed method raising a domain ``PyObsError`` now logs a quiet INFO line locally by
+* A remote domain exception now arrives at the caller as its real type, catchable directly (e.g.
+  ``except exc.FocusError:`` around a proxy call actually fires now) -- previously every remote
+  failure, transport or domain, arrived wrapped in ``InvocationError`` (now retired entirely), so a
+  caller could only catch the broad wrapper and manually unwrap ``.exception``. Exception classes
+  are now resolved via a registry (``PyobsError.resolve()``, populated automatically via
+  ``__init_subclass__``) instead of a ``getattr`` lookup restricted to ``pyobs.utils.exceptions``,
+  so a domain exception can now live anywhere (a driver package, a ``pyobs-core`` submodule) and
+  still survive the wire, keyed by fully-qualified name rather than bare class name. An exception
+  that can't be resolved (a raw builtin, a vendor SDK exception, or a domain type whose defining
+  module was never imported in this process) arrives as the new ``UnclassifiedError`` instead of
+  silently degrading to a generic ``RemoteError`` with only the message surviving -- the original
+  type's qualified name is preserved as ``UnclassifiedError.original_type``. ``UnclassifiedError``
+  joins ``ModuleError``/``SevereError`` as unsuppressible and always-loud.
+  ``PyObsError`` is renamed to ``PyobsError`` (naming consistency with ``PyobsArchive``,
+  ``PyobsCLI``, etc.) and its constructor is now ``PyobsError(message=None, **context)``, storing
+  every keyword generically as an attribute -- ``RemoteError``/``RemoteTimeoutError``/
+  ``ForbiddenError`` no longer have their own constructors, so direct construction now takes
+  ``module=``/``sender=``/``method=`` as keywords instead of fixed positional arguments. Breaking
+  change for any external code constructing these directly, catching ``exc.PyObsError``/
+  ``exc.InvocationError`` by name, or relying on a remote failure always arriving as some
+  ``RemoteError`` subclass (``pyobs-gui``'s ``base.py``/``mainwindow.py`` reference ``PyObsError``
+  by name and need the rename applied). Second step of the exception-handling rollout in
+  ``DESIGN_exception_handling.md`` (tracks #446).
+* Every RPC-exposed method raising a domain ``PyobsError`` now logs a quiet INFO line locally by
   default, without a traceback -- previously this only happened for methods explicitly decorated
   with ``@raises(...)`` (used on exactly two methods), and every other domain exception logged at
   ERROR with a full traceback despite the caller already receiving the same error. ``@raises`` no

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,32 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* First sweep of concrete exception-typing gaps (goal 5: specific types over generic ones/bare
+  builtins). New cross-cutting types in ``pyobs.utils.exceptions``: ``DeviceBusyError`` ("this
+  device can't service this request right now, back off and retry") and ``NotSupportedError``
+  ("this module doesn't implement this optional capability at all"). ``CameraException``
+  (``BaseCamera``) and ``AcquireLockFailed`` (``LockWithAbort``, a plain ``Exception`` that leaked
+  out of ``move_radec``/``move_altaz``/``set_focus``/``stop_motion``/roof ``init``/``park``
+  unconverted) are retired -- both meant the same thing, "device busy," now unified as
+  ``DeviceBusyError``. The telescope/roof ``init()``/``park()`` boundary specifically translates a
+  lock-acquisition failure (or any other failure) into ``InitError``/``ParkError`` instead, per
+  ``IMotion``'s own documented contract, following ``BaseCamera.__expose()``'s existing
+  catch-and-translate pattern. Capability-check ``NotImplementedError`` sites (an alt/az-only
+  telescope's ``move_radec``, ``ScienceFrameAutoGuiding.set_exposure_time``, a dummy telescope's
+  ``set_focus_offset``) now raise ``NotSupportedError`` instead. ``BaseTelescope`` gained
+  ``MissingObserverError``/``AltitudeLimitError``/``BodyResolutionError``/
+  ``InvalidOrbitalElementsError`` (all ``MotionError``) for its previously-bare ``ValueError``
+  sites. ``FocusModel`` gained ``WeatherDataError``/``FocusTimeoutError``/``MissingSensorError``
+  (all ``FocusError``). New ``ScriptError`` (``pyobs.robotic.scripts``) wraps whatever a script's
+  ``run()`` raises that isn't already a domain exception, following the same pattern;
+  ``AutoFocusScript.can_run()`` now checks for a target itself instead of only discovering its
+  absence after ``run()`` has already started. ``BaseVideo``/``BaseSpectrograph.grab_data()``'s
+  "no image" ``ValueError`` sites now raise ``GrabImageError``, matching ``BaseCamera``. All new
+  leaf types live next to the code that raises them (``basetelescope.py``, ``focusmodel.py``,
+  ``pyobs.robotic.scripts``), not bolted onto ``exceptions.py``, now that the registry from the
+  previous step lets a domain exception survive the wire regardless of which module defines it.
+  Fifth step of the exception-handling rollout in ``DESIGN_exception_handling.md`` (tracks #446);
+  remaining items in that sweep (``ScriptRunner``'s per-script leaves if ever wanted, driver-repo
+  ``AbortedError``/``NotImplementedError`` fixes) are out of scope for a ``pyobs-core`` PR alone.
 * RPC calls over XMPP now carry a correlation id end to end: the origin-side log line for a
   domain exception (``Module.execute()``'s catch block) includes ``(call_id=...)``, and the same
   id is attached to the exception the caller receives as ``exception.call_id`` -- reusing

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,50 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* Fixed ``UnclassifiedError.original_type`` silently not surviving the wire: ``Module.execute()``
+  wraps a non-domain exception (``IndexError``, a vendor SDK exception, ...) as
+  ``UnclassifiedError`` before ``rpc.py`` ever sees it, but ``fault_to_xml`` was serializing the
+  wrapper's own class name instead of the original type it was tagged with -- since
+  ``UnclassifiedError`` itself is a registered type, the caller reconstructed a fresh one with
+  ``original_type`` never set, making a remote ``IndexError`` and a remote ``ValueError``
+  indistinguishable. Now serializes the original type name instead, so the caller's own registry
+  lookup runs against it and correctly repopulates ``original_type`` on the (still-unresolvable)
+  ``UnclassifiedError`` it falls back to. Also fixed in the same pass: every exception crossing the
+  wire had its message doubled (``"<ClassName> <ClassName> message"``) once displayed, because the
+  message field serialized ``str(exception)`` (already ``"<ClassName> message"``) instead of the
+  raw message, which reconstruction then fed back in as the new instance's own message before
+  formatting it again.
+* Docstring sweep across every interface flagged by the exception-handling audit (16 of 27
+  documented interfaces had at least one mismatch) -- ``Raises:`` clauses now match what's
+  actually raised: ``IFocuser``/``IPointingRaDec``/``IPointingAltAz``/``IPointingBody``/
+  ``IPointingOrbitalElements``/the Heliocentric*/Helioprojective family gain
+  ``NotSupportedError``/``MissingObserverError``/``AltitudeLimitError``/``BodyResolutionError``/
+  ``InvalidOrbitalElementsError`` (or a note that they propagate from the underlying RA/Dec move);
+  ``IAutoFocus``/``IAcquisition`` now document the types their own ``@raises`` already declared
+  instead of a stale ``ValueError``; ``IData``/``IDataSequence`` document ``DeviceBusyError``;
+  ``IFocusModel`` documents its three new leaf types; ``IExposureTime``/``IFlatField``/``IWeather``
+  gain the clauses their implementations already needed. ``FlatField.set_filter``'s docstring
+  copy-paste bug ("If binning could not be set" on a filter setter) is fixed. The handful of
+  interfaces with zero concrete implementers anywhere in this repo (``ICalibrate``, ``ISyncTarget``,
+  ``IMultiFiber.set_fiber``, ``IPointingSeries``, ``IRotation``, ``IScriptRunner.run_script``) gain
+  a plausible ``Raises:`` clause so a future implementer has a contract to follow instead of
+  guessing -- the same guess that produced several of the mismatches this sweep fixes. Documentation
+  only, no behavior changes. Note: several interface methods still document plain ``ValueError``
+  for bad-argument validation (as opposed to domain operation failures) -- deliberately not
+  promoted to typed exceptions in this sweep; see ``DESIGN_exception_handling.md``'s "Still open"
+  section for the tradeoff.
+* Documented the ``AbortedError`` contract on every ``abort_event``-taking hook in
+  ``pyobs-core`` (``BaseCamera``/``BaseSpectrograph._expose()``, ``BaseTelescope._move_radec``/
+  ``_move_altaz``) -- nothing had ever told driver authors which type to use for "this was
+  cancelled, not a real failure," so two of pyobs-core's own in-tree implementations
+  (``DummyCamera``, ``DummySpectrograph``) had each independently guessed a different wrong type
+  (``InterruptedError``, ``ValueError``) for the exact same condition. Both now raise
+  ``exc.AbortedError``, as does ``_DummyTelescopeBase.set_focus``'s equivalent abort check. (Two
+  more instances of the same guessed-wrong-type pattern, in ``pyobs-sbig``/``pyobs-fli``, are a
+  companion fix in those repos, not something this PR can reach.)
+* Documented the domain/transport split in ``pyobs/utils/exceptions.py`` as a deliberate axis:
+  ``RemoteError`` and its subtree (``RemoteTimeoutError``, ``ForbiddenError``) mean "the call
+  itself didn't reach/return," which doesn't benefit from the same fine-grained-per-reason
+  treatment domain exceptions get -- documentation only, no behavior change.
 * First sweep of concrete exception-typing gaps (goal 5: specific types over generic ones/bare
   builtins). New cross-cutting types in ``pyobs.utils.exceptions``: ``DeviceBusyError`` ("this
   device can't service this request right now, back off and retry") and ``NotSupportedError``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,16 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* Every RPC-exposed method raising a domain ``PyObsError`` now logs a quiet INFO line locally by
+  default, without a traceback -- previously this only happened for methods explicitly decorated
+  with ``@raises(...)`` (used on exactly two methods), and every other domain exception logged at
+  ERROR with a full traceback despite the caller already receiving the same error. ``@raises`` no
+  longer controls log level (documentation value only, for now); ``Module`` gained
+  ``_disable_exception_logging(*exception_types)`` for a module to opt a high-frequency exception
+  type out of even the quiet line entirely, since the caller already has it.
+  ``ModuleError``/``SevereError`` are exempt from both the quiet default and the opt-out -- they
+  always log loudly, since both mean "this needs a human's attention at the source," not "an
+  anticipated domain failure." Part of the first step of the exception-handling rollout in
+  ``DESIGN_exception_handling.md`` (tracks #446).
 * ``ICamera``/``ISpectrograph`` no longer inherit ``IExposure`` -- they're now pure ``IData``
   identity interfaces ("this module produces images/spectra"), not "...and has an exposure
   clock." ``BaseCamera`` and ``BaseSpectrograph`` (which push real ``ExposureState``) now declare

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,26 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* Constructing a ``PyobsError`` is now side-effect-free, ordinary Python. ``raise
+  exc.FocusError(...)`` always raises a ``FocusError`` -- it no longer risks silently coming back
+  as a ``SevereError`` instead, which could happen because the old severity-escalation metaclass
+  intercepted *construction*, not raising or catching. ``SevereError`` is retired entirely: nothing
+  in this repo or any sibling project ever caught it specifically, its only real consumer was
+  ``register_exception``'s ``callback`` (already used everywhere; production code never actually
+  set ``throw=True``), which already does the meaningful part itself (``set_state(ModuleState.ERROR)``).
+  ``register_exception``/``handle_exception`` move from module-level free functions with
+  process-global state to ``Module._register_exception()``/an internal ``_record_exception()``,
+  called from ``Module.execute()``'s catch block (the same chokepoint that already classifies and
+  logs) -- fixing a real cross-instance bug as a byproduct, where two ``Module`` instances in the
+  same process (e.g. under ``MultiModule``, or two instances watching the same remote module) used
+  to share one counter. Ten in-tree call sites plus one in ``pyobs-alpaca`` need the mechanical
+  ``exc.register_exception(...)`` -> ``self._register_exception(...)`` rename (the ``throw``
+  parameter is gone with the substitution it existed for). Also: any non-``PyobsError`` exception
+  escaping a module's method body is now wrapped as ``UnclassifiedError`` right in ``execute()``,
+  not only on the XMPP fault path, so ``LocalComm``/``MultiModule`` get the same safety net as XMPP;
+  ``RPC._on_jabber_rpc_method_call`` no longer logs domain exceptions itself since ``execute()``
+  already did (it still logs failures that never reach ``execute()``, like malformed RPC
+  parameters). Third step of the exception-handling rollout in ``DESIGN_exception_handling.md``
+  (tracks #446).
 * A remote domain exception now arrives at the caller as its real type, catchable directly (e.g.
   ``except exc.FocusError:`` around a proxy call actually fires now) -- previously every remote
   failure, transport or domain, arrived wrapped in ``InvocationError`` (now retired entirely), so a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,13 +9,20 @@ v2.0.0.dev18 (unreleased)
   deployment. Fixed for ``IConfig.get_config_value``/``get_config_value_options``/
   ``set_config_value``, ``IDataSequence.grab_sequence``, ``ITrackingMode.set_tracking_mode``,
   ``IFocuser.set_focus``, ``IFilters.set_filter``, ``IMode.set_mode``, and
-  ``IWeather.get_sensor_value`` (its ``MockWeather`` implementation only -- the real ``Weather``
-  class's ``ValueError`` is about a malformed station response, not a bad argument, and is left
-  as-is). Also reused the existing ``DeviceBusyError`` for ``FlatField.flat_field``/
+  ``IWeather.get_sensor_value`` (``MockWeather``'s implementation -- the real ``Weather`` class's
+  own ``ValueError`` there is about a malformed station response, not a bad argument; see the next
+  entry). Also reused the existing ``DeviceBusyError`` for ``FlatField.flat_field``/
   ``FlatFieldScheduler.run``'s "already running" check, which was never actually about a bad
   argument either. Scoped out first (see ``DESIGN_exception_handling.md``) before touching
   anything: real driver repos (e.g. ``pyobs-sbig``) likely have the identical ``ValueError``
   pattern for real hardware and would need the same companion fix, not reachable from this PR.
+* New ``WeatherResponseError`` (``pyobs.modules.weather.weather``) for ``Weather.get_sensor_value``
+  getting back a station response missing its ``time``/``value`` fields -- a different shape of
+  problem from the bad-argument case above (an external dependency being flaky, not a caller
+  mistake), same reasoning as ``BodyResolutionError``: plausibly transient, worth retrying, not the
+  caller's fault. ``WeatherStatus.status``'s similar-looking ``ValueError`` (``weather_state.py``)
+  turned out to be unreachable from any RPC caller at all -- it only fires inside a background
+  polling loop that already catches it broadly and just logs a warning -- so it's left untouched.
 * Fixed ``UnclassifiedError.original_type`` silently not surviving the wire: ``Module.execute()``
   wraps a non-domain exception (``IndexError``, a vendor SDK exception, ...) as
   ``UnclassifiedError`` before ``rpc.py`` ever sees it, but ``fault_to_xml`` was serializing the

--- a/DESIGN_exception_handling.md
+++ b/DESIGN_exception_handling.md
@@ -1320,3 +1320,50 @@ it's a real, independent bug worth its own issue regardless of this design doc's
   `searchpattern2.py`: out of scope for this PR, not a blocker, but should be called out alongside
   it (companion fix or explicitly-deferred note) rather than left undiscovered, since it wasn't
   caught by the original repo list above.
+
+## Still open (not resolved by this doc)
+
+- **Bad-argument-validation `ValueError`s are deliberately not promoted to `PyobsError` leaf
+  types, but that means they still degrade to `UnclassifiedError` over RPC.** Steps 5/8's sweep
+  only promotes *domain operation failures* (e.g. "camera is busy," "body not resolvable") to
+  specific types; plain input validation (e.g. `IFilters.set_filter`'s "unknown filter name",
+  `IFocuser.set_focus`'s "invalid focus value", `IMultiFiber.set_fiber`'s "invalid fiber name")
+  intentionally stays as ordinary `ValueError`, matching Python's own convention for API misuse and
+  matching how the interface audit already treated these as clean matches, not gaps. But since
+  `ValueError` is a builtin, not a `PyobsError` subclass, it's never in the registry -- a caller
+  writing `except ValueError:` around a *remote* proxy call does not catch it (it arrives as
+  `UnclassifiedError` instead); only same-process callers (`LocalComm`) see a real `ValueError`.
+  This was a deliberate scope call, not an oversight -- flagged explicitly per the project owner's
+  request during the docstring sweep (step 8) so it's easy to find later, in case a future caller
+  actually needs to distinguish "bad argument" domain-uniformly over RPC. Promoting these would be
+  a much larger sweep (dozens of call sites across nearly every setter-shaped interface method) and
+  is deliberately not part of this rollout.
+
+## Bug found and fixed after the rollout: `original_type` didn't actually survive the wire
+
+Prompted by the project owner asking, after step 8, "are we catching ALL exceptions on the callee
+side, what happens to `IndexError`/etc.?" -- tracing it through turned up a real gap `UnclassifiedError`
+was supposed to close but didn't.
+
+`Module.execute()` wraps any non-`PyobsError` into `UnclassifiedError(str(raised),
+original_type=...)` *before* `rpc.py` ever sees it (that's the whole point of centralizing
+classification in step 3). But `fault_to_xml` only ever serialized the wrapper's own class name --
+`"pyobs.utils.exceptions.UnclassifiedError"` -- which *resolves successfully* on the caller's side
+(it's a registered type!), so the caller reconstructed a fresh `UnclassifiedError(msg,
+remote_module=sender)` with `original_type` never set at all. `original_type` is a local attribute,
+not part of the two things that actually cross the wire (qualified class name + message), so it was
+silently lost in transit every time -- a remote `IndexError` and a remote `ValueError` arrived as
+indistinguishable `UnclassifiedError`s with no way to tell them apart, even in the message text.
+(`LocalComm` never had this problem -- no serialization step, so the real attribute survives.)
+
+**Fix**: `fault_to_xml` now serializes `original_type` instead of the wrapper's own class name,
+whenever the exception carries one. The caller's own registry lookup then runs against the
+*original* name -- for a builtin/vendor type that's never registered, it correctly falls back to
+`UnclassifiedError` again, but this time with `original_type` actually populated, matching what the
+class's own docstring already claimed.
+
+Found and fixed in the same pass: `fault_to_xml` was also serializing `str(exception)`
+(`"<ClassName> message"`) instead of the raw `.message` for the message field. Reconstruction
+passes that string straight back in as the new instance's `message`, so the *caller's* own
+`__str__` formatted it a second time on top -- every exception that ever crossed the wire arrived
+with a doubled `"<ClassName> <ClassName> message"` once displayed. Now serializes the raw message.

--- a/DESIGN_exception_handling.md
+++ b/DESIGN_exception_handling.md
@@ -1351,10 +1351,14 @@ three shapes:
    `FlatField.flat_field`, `FlatFieldScheduler.run`. **Done**: reused the *existing*
    `DeviceBusyError`, no new type needed.
 3. **Malformed external data** (a weather station's API response, not a caller mistake) --
-   `Weather.get_sensor_value`, `WeatherState.status`'s setter. **Deliberately left as `ValueError`
-   for now** -- a different shape of problem (arguably deserves its own type like
-   `BodyResolutionError` did, not the generic bad-argument bucket), not scoped or implemented in
-   this pass.
+   `Weather.get_sensor_value`. **Done**: new `WeatherResponseError(PyobsError)` in
+   `weather.py` (co-located, per §5's relocation convention), the same reasoning as
+   `BodyResolutionError` -- plausibly transient, worth retrying, not the caller's fault.
+   `WeatherState.status`'s setter (`weather_state.py:25`) turned out, on closer look, to be a
+   mis-scoping on my part: it's only ever called from `_update()`'s background polling loop, which
+   already wraps it in a broad `except Exception: log.warning(...)` -- it never reaches an RPC
+   caller at all, so it's out of scope entirely (same shape as `focusmodel.py`'s
+   `_on_focus_found`/`_calc_focus_model`), not something needing a type change.
 
 ### Original "still open" note, for history
 

--- a/DESIGN_exception_handling.md
+++ b/DESIGN_exception_handling.md
@@ -1321,7 +1321,42 @@ it's a real, independent bug worth its own issue regardless of this design doc's
   it (companion fix or explicitly-deferred note) rather than left undiscovered, since it wasn't
   caught by the original repo list above.
 
-## Still open (not resolved by this doc)
+## Bad-argument `ValueError`s: scoped and partially promoted after the rollout
+
+Originally flagged as "still open" (below, kept for history): bad-argument-validation `ValueError`s
+were deliberately left un-promoted during steps 5/8, but since `ValueError` is a builtin, never in
+the `PyobsError` registry, a caller writing `except ValueError:` around a *remote* proxy call
+doesn't catch it (arrives as `UnclassifiedError` instead) even though the identical code works
+fine locally (`LocalComm`, direct calls, tests) -- a real "works in dev, breaks in prod" footgun,
+raised by the project owner after the rollout closed.
+
+Scoped it out before touching anything: of ~60 raw `raise ValueError` sites in `pyobs/modules/`,
+most are constructor/config-time validation, internal event-handler checks, or background-task-only
+code -- never reachable via RPC at all, irrelevant to this problem. What's actually left sorts into
+three shapes:
+
+1. **Genuine bad-argument validation on RPC-exposed methods** -- `IConfig.get_config_value`/
+   `get_config_value_options`/`set_config_value` (`module.py`), `IDataSequence.grab_sequence`'s
+   count/delay (`basecamera.py`), `ITrackingMode.set_tracking_mode`, `IFocuser.set_focus`,
+   `IFilters.set_filter` (all `_dummytelescopebase.py`), `IMode.set_mode` (`dummymode.py`),
+   `IWeather.get_sensor_value` (`mockweather.py`) -- 7 methods, ~16 sites. **Done**: new shared
+   `InvalidArgumentError(PyobsError)`, one type reused everywhere (same shape as `DeviceBusyError`/
+   `NotSupportedError`), not a bespoke leaf per method -- goal 5's own test says no caller reacts
+   differently to "unknown filter" vs. "invalid focus value." Real driver repos likely have the
+   identical pattern for real hardware (e.g. `pyobs-sbig/sbigfiltercamera.py:142`'s own
+   `ValueError(f"Unknown filter: {filter_name}")` for the same `IFilters.set_filter` condition) --
+   companion fix in those repos, not reachable from this PR, same shape as the `AbortedError`
+   situation.
+2. **"Already busy/running" state preconditions, not actually bad arguments** --
+   `FlatField.flat_field`, `FlatFieldScheduler.run`. **Done**: reused the *existing*
+   `DeviceBusyError`, no new type needed.
+3. **Malformed external data** (a weather station's API response, not a caller mistake) --
+   `Weather.get_sensor_value`, `WeatherState.status`'s setter. **Deliberately left as `ValueError`
+   for now** -- a different shape of problem (arguably deserves its own type like
+   `BodyResolutionError` did, not the generic bad-argument bucket), not scoped or implemented in
+   this pass.
+
+### Original "still open" note, for history
 
 - **Bad-argument-validation `ValueError`s are deliberately not promoted to `PyobsError` leaf
   types, but that means they still degrade to `UnclassifiedError` over RPC.** Steps 5/8's sweep
@@ -1338,6 +1373,12 @@ it's a real, independent bug worth its own issue regardless of this design doc's
   actually needs to distinguish "bad argument" domain-uniformly over RPC. Promoting these would be
   a much larger sweep (dozens of call sites across nearly every setter-shaped interface method) and
   is deliberately not part of this rollout.
+
+  **Update**: `IMultiFiber.set_fiber` has zero concrete implementers anywhere in this repo (see
+  step 8's audit), so there's no real raise site to migrate here the way there was for the 7
+  methods above -- but its docstring's `ValueError` placeholder was updated to
+  `InvalidArgumentError` anyway, so a future implementer follows the now-established convention
+  instead of the retired one.
 
 ## Bug found and fixed after the rollout: `original_type` didn't actually survive the wire
 

--- a/DESIGN_exception_handling.md
+++ b/DESIGN_exception_handling.md
@@ -1246,9 +1246,9 @@ around it; the rest are incremental sweeps with no fixed order among themselves.
      `lco/task.py:202-203` (→ `except exc.AbortedError:` directly, since `InvocationError` is
      gone). This is the one place in the rollout that isn't purely additive, so it can't be split
      further — all five have to move together with the unwrap fix.
-   - `pyobs-monet`'s `searchpattern2.py:134-141` has the same reliance on the old wrapping (see
-     "Resolved during design" below) but is out of scope for now — deferred, not a blocker for
-     this step.
+   - `pyobs-monet`'s `searchpattern2.py:134-141` and `pyobs-iagvt`'s `sungrid.py:134` both have the
+     same reliance on the old wrapping (see "Resolved during design" below) but are out of scope
+     for now — deferred, not a blocker for this step.
 3. Collapse the two catch/log sites into `Module.execute()` (proposal §3's classification/logging
    portion) — mechanical once (2) is in place, and extends the `UnclassifiedError` safety net to
    `LocalComm`/`MultiModule`, not just XMPP. Retire the `SevereError` substitution in the same pass
@@ -1309,3 +1309,14 @@ it's a real, independent bug worth its own issue regardless of this design doc's
   exception type explicitly — a bare `except Exception:` swallowing the same wrapped failure
   elsewhere wouldn't show up this way, so a changelog callout for proposal §2 is still worth doing
   when it lands, independent of `searchpattern2.py` specifically.
+- **`pyobs-iagvt` was missing from that cross-repo pass and has the identical gap.**
+  `pyobs_iagvt/modules/sungrid.py:134` does
+  `except (ValueError, InvocationError) as e: log.info(f"Something went wrong: {str(e)}")` around
+  `_do_the_wiggle()` (`sungrid.py:91-106`), which itself does proxy calls to a telescope and camera
+  (`sungrid.py:93`) — the same shape as `pyobs-monet/searchpattern2.py`, relying on remote domain
+  exceptions arriving wrapped in `InvocationError` rather than as their real type. Once proposal §2
+  lands (raising the reconstructed type directly, retiring `InvocationError`), this `except` clause
+  silently stops catching remote domain failures from that call. Same disposition as
+  `searchpattern2.py`: out of scope for this PR, not a blocker, but should be called out alongside
+  it (companion fix or explicitly-deferred note) rather than left undiscovered, since it wasn't
+  caught by the original repo list above.

--- a/docs/source/api/robotic/scripts.rst
+++ b/docs/source/api/robotic/scripts.rst
@@ -115,6 +115,10 @@ Script base class
    :members:
    :show-inheritance:
 
+.. autoexception:: pyobs.robotic.scripts.ScriptError
+   :members:
+   :show-inheritance:
+
 
 Built-in scripts
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/api/utils/exceptions.rst
+++ b/docs/source/api/utils/exceptions.rst
@@ -80,6 +80,13 @@ InitError
    :members:
    :undoc-members:
 
+InvalidArgumentError
+^^^^^^^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.InvalidArgumentError
+   :members:
+   :undoc-members:
+
 LoggedException
 ^^^^^^^^^^^^^^^
 

--- a/docs/source/api/utils/exceptions.rst
+++ b/docs/source/api/utils/exceptions.rst
@@ -3,6 +3,13 @@ Exceptions (pyobs.utils.exceptions)
 
 .. automodule:: pyobs.utils.exceptions
 
+PyobsError
+^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.PyobsError
+   :members:
+   :undoc-members:
+
 AbortedError
 ^^^^^^^^^^^^
 
@@ -10,10 +17,38 @@ AbortedError
    :members:
    :undoc-members:
 
+AcquisitionError
+^^^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.AcquisitionError
+   :members:
+   :undoc-members:
+
+DeviceBusyError
+^^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.DeviceBusyError
+   :members:
+   :undoc-members:
+
 ExceptionHandler
 ^^^^^^^^^^^^^^^^
 
 .. autoexception:: pyobs.utils.exceptions.ExceptionHandler
+   :members:
+   :undoc-members:
+
+ForbiddenError
+^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.ForbiddenError
+   :members:
+   :undoc-members:
+
+FocusError
+^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.FocusError
    :members:
    :undoc-members:
 
@@ -45,13 +80,6 @@ InitError
    :members:
    :undoc-members:
 
-InvocationError
-^^^^^^^^^^^^^^^
-
-.. autoexception:: pyobs.utils.exceptions.InvocationError
-   :members:
-   :undoc-members:
-
 LoggedException
 ^^^^^^^^^^^^^^^
 
@@ -80,17 +108,17 @@ MoveError
    :members:
    :undoc-members:
 
+NotSupportedError
+^^^^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.NotSupportedError
+   :members:
+   :undoc-members:
+
 ParkError
 ^^^^^^^^^
 
 .. autoexception:: pyobs.utils.exceptions.ParkError
-   :members:
-   :undoc-members:
-
-PyObsError
-^^^^^^^^^^
-
-.. autoexception:: pyobs.utils.exceptions.PyObsError
    :members:
    :undoc-members:
 
@@ -108,17 +136,9 @@ RemoteTimeoutError
    :members:
    :undoc-members:
 
-SevereError
-^^^^^^^^^^^
+UnclassifiedError
+^^^^^^^^^^^^^^^^^
 
-.. autoexception:: pyobs.utils.exceptions.SevereError
+.. autoexception:: pyobs.utils.exceptions.UnclassifiedError
    :members:
    :undoc-members:
-
-_Meta
-^^^^^
-
-.. autoexception:: pyobs.utils.exceptions._Meta
-   :members:
-   :undoc-members:
-

--- a/pyobs/comm/xmpp/rpc.py
+++ b/pyobs/comm/xmpp/rpc.py
@@ -96,11 +96,22 @@ def fault_to_xml(exception: Exception) -> ET.Element:
     value_elem = ET.Element(f"{{{_NS}}}value")
     pyobs_fault = ET.Element(f"{{{_PYOBS_NS}}}fault")
     exc_elem = ET.Element("exception")
-    # fully-qualified name, not the bare class name -- domain exceptions can live anywhere,
-    # not just in pyobs.utils.exceptions (see PyobsError._registry / resolve())
-    exc_elem.text = f"{type(exception).__module__}.{type(exception).__qualname__}"
+    # Fully-qualified name, not the bare class name -- domain exceptions can live anywhere, not
+    # just in pyobs.utils.exceptions (see PyobsError._registry / resolve()). If this is an
+    # UnclassifiedError wrapping something that was never a PyobsError to begin with (see
+    # Module.execute()'s classification), serialize the ORIGINAL type's name instead of
+    # "UnclassifiedError" itself -- original_type never crosses the wire as an attribute (only the
+    # class name and message do), so this is the only way it survives to the caller. The caller's
+    # own registry lookup then decides fresh: an unregistered builtin/vendor type still correctly
+    # falls back to UnclassifiedError, but this time with original_type actually populated.
+    original_type = getattr(exception, "original_type", None)
+    exc_elem.text = original_type if original_type else f"{type(exception).__module__}.{type(exception).__qualname__}"
     msg_elem = ET.Element("message")
-    msg_elem.text = str(exception)
+    # the raw message, not str(exception) -- str() already prepends "<ClassName>", and
+    # reconstruction on the caller's side passes this straight back in as the new instance's
+    # message, so serializing str() here would bake in a doubled "<ClassName> <ClassName> ..." once
+    # the caller's own __str__ formats it again
+    msg_elem.text = getattr(exception, "message", None) or str(exception)
     pyobs_fault.append(exc_elem)
     pyobs_fault.append(msg_elem)
     value_elem.append(pyobs_fault)

--- a/pyobs/comm/xmpp/rpc.py
+++ b/pyobs/comm/xmpp/rpc.py
@@ -223,9 +223,12 @@ class RPC:
             self._client.plugin["xep_0009"].forbidden(iq).send()
 
         except Exception as e:
-            if isinstance(e, exc.PyobsError):
-                e.log(log, "ERROR", f"Exception in call to {pmethod}: {e}", exc_info=True)
-            else:
+            # Module.execute() already classified and logged anything raised by the call itself
+            # (every transport gets the same treatment there now), so there's nothing left to do
+            # here but serialize and send the fault -- except for failures that never reached
+            # execute() at all (e.g. malformed RPC parameters during deserialization above), which
+            # this is the only place that will ever log
+            if not isinstance(e, exc.PyobsError):
                 log.exception("Unexpected exception in %s.", pmethod)
             self._client.plugin["xep_0009"].send_fault(iq, fault_to_xml(e))
 

--- a/pyobs/comm/xmpp/rpc.py
+++ b/pyobs/comm/xmpp/rpc.py
@@ -96,7 +96,9 @@ def fault_to_xml(exception: Exception) -> ET.Element:
     value_elem = ET.Element(f"{{{_NS}}}value")
     pyobs_fault = ET.Element(f"{{{_PYOBS_NS}}}fault")
     exc_elem = ET.Element("exception")
-    exc_elem.text = type(exception).__name__
+    # fully-qualified name, not the bare class name -- domain exceptions can live anywhere,
+    # not just in pyobs.utils.exceptions (see PyobsError._registry / resolve())
+    exc_elem.text = f"{type(exception).__module__}.{type(exception).__qualname__}"
     msg_elem = ET.Element("message")
     msg_elem.text = str(exception)
     pyobs_fault.append(exc_elem)
@@ -107,16 +109,17 @@ def fault_to_xml(exception: Exception) -> ET.Element:
 
 
 def xml_to_fault(fault_elem: ET.Element) -> tuple[str, str]:
-    """Parse <fault> and return (exception_class_name, message)."""
+    """Parse <fault> and return (exception_qualified_name, message)."""
+    _fallback_name = f"{exc.RemoteError.__module__}.{exc.RemoteError.__qualname__}"
     value_elem = fault_elem.find(f"{{{_NS}}}value")
     if value_elem is None:
-        return "RemoteError", "Unknown error"
+        return _fallback_name, "Unknown error"
     pyobs_fault = value_elem.find(f"{{{_PYOBS_NS}}}fault")
     if pyobs_fault is None:
-        return "RemoteError", "Unknown error"
+        return _fallback_name, "Unknown error"
     exc_el = pyobs_fault.find("exception")
     msg_el = pyobs_fault.find("message")
-    exc_name = (exc_el.text if exc_el is not None else None) or "RemoteError"
+    exc_name = (exc_el.text if exc_el is not None else None) or _fallback_name
     msg = (msg_el.text if msg_el is not None else None) or ""
     return exc_name, msg
 
@@ -220,7 +223,7 @@ class RPC:
             self._client.plugin["xep_0009"].forbidden(iq).send()
 
         except Exception as e:
-            if isinstance(e, exc.PyObsError):
+            if isinstance(e, exc.PyobsError):
                 e.log(log, "ERROR", f"Exception in call to {pmethod}: {e}", exc_info=True)
             else:
                 log.exception("Unexpected exception in %s.", pmethod)
@@ -269,18 +272,18 @@ class RPC:
         fault_elem = iq["rpc_query"]["method_response"]["fault"]
         exc_name, msg = xml_to_fault(fault_elem)
 
-        exception_class = getattr(exc, exc_name, None)
-        if exception_class is None or not issubclass(exception_class, Exception):
-            exception_class = exc.RemoteError
-
         sender = iq["from"].node
-        if issubclass(exception_class, exc.RemoteError):
-            exception = exception_class(message=msg, module=sender)
+        exception_class = exc.PyobsError.resolve(exc_name)
+        if exception_class is not None:
+            # real registered type (e.g. FocusError) -- raised as itself, not wrapped
+            exception: exc.PyobsError = exception_class(msg, remote_module=sender)
         else:
-            exception = exception_class(msg)
+            # unresolvable: never a PyobsError to begin with, or its defining module was never
+            # imported in this process -- the qualified name string still survives as original_type
+            exception = exc.UnclassifiedError(msg, original_type=exc_name, remote_module=sender)
 
         if not future.done():
-            future.set_exception(exc.InvocationError(module=sender, exception=exception))
+            future.set_exception(exception)
 
     async def _on_jabber_rpc_error(self, iq: Any) -> None:
         pmethod = self._client.plugin["xep_0009"].extract_method(iq["rpc_query"])
@@ -295,12 +298,16 @@ class RPC:
 
         sender = iq["from"].node
         e = {
-            "item-not-found": exc.RemoteError(sender, f"No remote handler for {pmethod} at {iq['from']}!"),
-            "forbidden": exc.RemoteError(sender, f"Forbidden to invoke {pmethod} at {iq['from']}!"),
-            "undefined-condition": exc.RemoteError(sender, f"Unexpected problem invoking {pmethod} at {iq['from']}!"),
-            "service-unavailable": exc.RemoteError(sender, f"Service at {iq['from']} is unavailable."),
-            "remote-server-not-found": exc.RemoteError(sender, f"Could not find remote server for {iq['from']}."),
-        }.get(condition, exc.RemoteError(sender, f"Unexpected exception at {iq['from']}!"))
+            "item-not-found": exc.RemoteError(f"No remote handler for {pmethod} at {iq['from']}!", module=sender),
+            "forbidden": exc.RemoteError(f"Forbidden to invoke {pmethod} at {iq['from']}!", module=sender),
+            "undefined-condition": exc.RemoteError(
+                f"Unexpected problem invoking {pmethod} at {iq['from']}!", module=sender
+            ),
+            "service-unavailable": exc.RemoteError(f"Service at {iq['from']} is unavailable.", module=sender),
+            "remote-server-not-found": exc.RemoteError(
+                f"Could not find remote server for {iq['from']}.", module=sender
+            ),
+        }.get(condition, exc.RemoteError(f"Unexpected exception at {iq['from']}!", module=sender))
 
         callback.set_exception(e)
 

--- a/pyobs/comm/xmpp/rpc.py
+++ b/pyobs/comm/xmpp/rpc.py
@@ -173,6 +173,13 @@ class RPC:
         iq.enable("rpc_query")
         pmethod = iq["rpc_query"]["method_call"]["method_name"]
 
+        # XEP-0009 already assigns this per call (used elsewhere as the Future dict key) -- reuse
+        # it as a correlation id so an operator can jump from a caller-side exception straight to
+        # the matching origin-side log line, instead of neither side pointing at the other
+        call_id: str | slixmpp.JID = iq["id"]
+        if isinstance(call_id, slixmpp.JID):
+            call_id = call_id.node
+
         try:
             if self._handler is None:
                 return
@@ -211,7 +218,7 @@ class RPC:
                     response.send()
 
             # Call method
-            return_value = await self._handler.execute(pmethod, *params, sender=iq["from"].user)
+            return_value = await self._handler.execute(pmethod, *params, sender=iq["from"].user, call_id=call_id)
 
             # Serialize return value
             return_type = hints.get("return", type(None))
@@ -284,6 +291,10 @@ class RPC:
             # unresolvable: never a PyobsError to begin with, or its defining module was never
             # imported in this process -- the qualified name string still survives as original_type
             exception = exc.UnclassifiedError(msg, original_type=exc_name, remote_module=sender)
+
+        # same correlation id Module.execute() logged on the origin side -- an operator can jump
+        # straight from this caller-side exception to the matching detailed log line, by id
+        setattr(exception, "call_id", jid)
 
         if not future.done():
             future.set_exception(exception)

--- a/pyobs/comm/xmpp/xmppcomm.py
+++ b/pyobs/comm/xmpp/xmppcomm.py
@@ -503,10 +503,10 @@ class XmppComm(Comm):
             # RPC layer's jabber_rpc_error event handling ever gets a chance to act on it,
             # so the IQ-level "forbidden" condition (see Module ACLs) has to be read here.
             if e.iq["error"]["condition"] == "forbidden":
-                raise exc.RemoteError(client, f"Forbidden to invoke {method} on {client}.")
-            raise exc.RemoteError(client, f"Could not call {method} on {client}.")
+                raise exc.RemoteError(f"Forbidden to invoke {method} on {client}.", module=client)
+            raise exc.RemoteError(f"Could not call {method} on {client}.", module=client)
         except slixmpp.exceptions.IqTimeout:
-            raise exc.RemoteTimeoutError(client, f"Call to {method} on {client} timed out.")
+            raise exc.RemoteTimeoutError(f"Call to {method} on {client} timed out.", module=client)
 
     async def _got_online(self, msg: Any) -> None:
         """If a new client connects, add it to list.

--- a/pyobs/interfaces/IAcquisition.py
+++ b/pyobs/interfaces/IAcquisition.py
@@ -59,7 +59,10 @@ class IAcquisition(IRunning, IAbortable, metaclass=ABCMeta):
             Result with time, ra, dec, alt, az, and an offset in whichever frame the mount supports.
 
         Raises:
-            ValueError: If target could not be acquired.
+            AbortedError: If the acquisition was aborted.
+            GeneralError: If a dependency (e.g. the camera) failed.
+            ImageError: If the calculated offset was too large or otherwise unusable.
+            AcquisitionError: If target could not be acquired within the given tolerance.
         """
         ...
 

--- a/pyobs/interfaces/IAutoFocus.py
+++ b/pyobs/interfaces/IAutoFocus.py
@@ -54,7 +54,8 @@ class IAutoFocus(IRunning, IAbortable, metaclass=ABCMeta):
             Result of autofocus.
 
         Raises:
-            ValueError: If focus could not be obtained.
+            AbortedError: If the autofocus series was aborted.
+            FocusError: If focus could not be obtained.
         """
         ...
 

--- a/pyobs/interfaces/ICalibrate.py
+++ b/pyobs/interfaces/ICalibrate.py
@@ -11,7 +11,11 @@ class ICalibrate(Interface, metaclass=ABCMeta):
 
     @abstractmethod
     async def calibrate(self, **kwargs: Any) -> None:
-        """Calibrate the device."""
+        """Calibrate the device.
+
+        Raises:
+            GeneralError: If calibration failed.
+        """
         ...
 
 

--- a/pyobs/interfaces/IConfig.py
+++ b/pyobs/interfaces/IConfig.py
@@ -33,7 +33,7 @@ class IConfig(Interface, metaclass=ABCMeta):
             Current value.
 
         Raises:
-            ValueError: If config item of given name does not exist.
+            InvalidArgumentError: If config item of given name does not exist.
         """
         ...
 
@@ -46,7 +46,8 @@ class IConfig(Interface, metaclass=ABCMeta):
             value: New value.
 
         Raises:
-            ValueError: If config item of given name does not exist or value is invalid.
+            InvalidArgumentError: If config item of given name does not exist.
+            ValueError: If value is invalid.
         """
         ...
 

--- a/pyobs/interfaces/IData.py
+++ b/pyobs/interfaces/IData.py
@@ -20,6 +20,7 @@ class IData(Interface, metaclass=ABCMeta):
             Name of image that was taken.
 
         Raises:
+            DeviceBusyError: If the device is already busy (exposing or running a sequence).
             GrabImageError: If there was a problem grabbing the image.
         """
         ...

--- a/pyobs/interfaces/IDataSequence.py
+++ b/pyobs/interfaces/IDataSequence.py
@@ -38,7 +38,7 @@ class IDataSequence(IAbortable, metaclass=ABCMeta):
                 during the wait.
 
         Raises:
-            GrabImageError: If the device is already busy (exposing or already running a
+            DeviceBusyError: If the device is already busy (exposing or already running a
                 sequence).
         """
         ...

--- a/pyobs/interfaces/IDataSequence.py
+++ b/pyobs/interfaces/IDataSequence.py
@@ -38,6 +38,7 @@ class IDataSequence(IAbortable, metaclass=ABCMeta):
                 during the wait.
 
         Raises:
+            InvalidArgumentError: If count or delay is out of range.
             DeviceBusyError: If the device is already busy (exposing or already running a
                 sequence).
         """

--- a/pyobs/interfaces/IExposureTime.py
+++ b/pyobs/interfaces/IExposureTime.py
@@ -31,6 +31,8 @@ class IExposureTime(Interface, metaclass=ABCMeta):
 
         Raises:
             ValueError: If exposure time could not be set.
+            NotSupportedError: If this module doesn't support setting exposure time directly (e.g.
+                it's dictated by something else, like incoming science frames).
         """
         ...
 

--- a/pyobs/interfaces/IFilters.py
+++ b/pyobs/interfaces/IFilters.py
@@ -35,7 +35,7 @@ class IFilters(IMotion, metaclass=ABCMeta):
             filter_name: Name of filter to set.
 
         Raises:
-            ValueError: If an invalid filter was given.
+            InvalidArgumentError: If an invalid filter was given.
             MoveError: If filter wheel cannot be moved.
         """
         ...

--- a/pyobs/interfaces/IFlatField.py
+++ b/pyobs/interfaces/IFlatField.py
@@ -23,7 +23,7 @@ class IFlatField(IAbortable, metaclass=ABCMeta):
             Number of images actually taken and total exposure time in seconds
 
         Raises:
-            ValueError: If a flat-fielding run is already in progress.
+            DeviceBusyError: If a flat-fielding run is already in progress.
         """
         ...
 

--- a/pyobs/interfaces/IFlatField.py
+++ b/pyobs/interfaces/IFlatField.py
@@ -21,6 +21,9 @@ class IFlatField(IAbortable, metaclass=ABCMeta):
 
         Returns:
             Number of images actually taken and total exposure time in seconds
+
+        Raises:
+            ValueError: If a flat-fielding run is already in progress.
         """
         ...
 

--- a/pyobs/interfaces/IFocusModel.py
+++ b/pyobs/interfaces/IFocusModel.py
@@ -21,7 +21,13 @@ class IFocusModel(Interface, metaclass=ABCMeta):
 
     @abstractmethod
     async def set_optimal_focus(self, **kwargs: Any) -> None:
-        """Sets optimal focus."""
+        """Sets optimal focus.
+
+        Raises:
+            WeatherDataError: If the weather station returned an invalid temperature reading.
+            FocusTimeoutError: If a temperature module didn't respond in time.
+            MissingSensorError: If a configured sensor isn't in a module's temperature data.
+        """
         ...
 
 

--- a/pyobs/interfaces/IFocuser.py
+++ b/pyobs/interfaces/IFocuser.py
@@ -31,7 +31,7 @@ class IFocuser(IMotion, metaclass=ABCMeta):
             focus: New focus value in mm.
 
         Raises:
-            ValueError: If given value is invalid.
+            InvalidArgumentError: If given value is invalid.
             AbortedError: If movement was aborted.
             MoveError: If telescope cannot be moved.
         """

--- a/pyobs/interfaces/IFocuser.py
+++ b/pyobs/interfaces/IFocuser.py
@@ -31,8 +31,9 @@ class IFocuser(IMotion, metaclass=ABCMeta):
             focus: New focus value in mm.
 
         Raises:
+            ValueError: If given value is invalid.
+            AbortedError: If movement was aborted.
             MoveError: If telescope cannot be moved.
-            InterruptedError: If movement was aborted.
         """
         ...
 
@@ -45,6 +46,7 @@ class IFocuser(IMotion, metaclass=ABCMeta):
 
         Raises:
             ValueError: If given value is invalid.
+            NotSupportedError: If this module doesn't support a separate focus offset.
             MoveError: If telescope cannot be moved.
         """
         ...

--- a/pyobs/interfaces/IMode.py
+++ b/pyobs/interfaces/IMode.py
@@ -36,7 +36,7 @@ class IMode(Interface, metaclass=ABCMeta):
             group: Name of the group to set the mode for.
 
         Raises:
-            ValueError: If an invalid mode or group was given.
+            InvalidArgumentError: If an invalid mode or group was given.
             MoveError: If mode selector cannot be moved.
         """
         ...

--- a/pyobs/interfaces/IMultiFiber.py
+++ b/pyobs/interfaces/IMultiFiber.py
@@ -44,7 +44,7 @@ class IMultiFiber(Interface, metaclass=ABCMeta):
             fiber: Name of fiber to set.
 
         Raises:
-            ValueError: If fiber name is invalid.
+            InvalidArgumentError: If fiber name is invalid.
         """
         ...
 

--- a/pyobs/interfaces/IMultiFiber.py
+++ b/pyobs/interfaces/IMultiFiber.py
@@ -42,6 +42,9 @@ class IMultiFiber(Interface, metaclass=ABCMeta):
 
         Args:
             fiber: Name of fiber to set.
+
+        Raises:
+            ValueError: If fiber name is invalid.
         """
         ...
 

--- a/pyobs/interfaces/IPointingAltAz.py
+++ b/pyobs/interfaces/IPointingAltAz.py
@@ -34,6 +34,8 @@ class IPointingAltAz(Interface, metaclass=ABCMeta):
             az: Az in deg to move to.
 
         Raises:
+            NotSupportedError: If this device doesn't support Alt/Az pointing.
+            AltitudeLimitError: If the destination is below the configured altitude limit.
             MoveError: If device could not be moved.
         """
         ...

--- a/pyobs/interfaces/IPointingBody.py
+++ b/pyobs/interfaces/IPointingBody.py
@@ -20,8 +20,11 @@ class IPointingBody(Interface, metaclass=ABCMeta):
                   asteroid/comet designation known to JPL Horizons).
 
         Raises:
-            MoveError: If telescope could not be moved.
-            ValueError: If body name is not resolvable.
+            NotSupportedError: If this device doesn't support body tracking.
+            BodyResolutionError: If body name is not resolvable.
+            MoveError: If telescope could not be moved. Also propagates whatever the underlying
+                RA/Dec move raises (e.g. MissingObserverError, AltitudeLimitError), since tracking
+                a body is implemented as resolving it and then moving there.
         """
         ...
 

--- a/pyobs/interfaces/IPointingHeliocentricPolar.py
+++ b/pyobs/interfaces/IPointingHeliocentricPolar.py
@@ -33,7 +33,9 @@ class IPointingHeliocentricPolar(Interface, metaclass=ABCMeta):
             psi: Position angle around the solar disk, in degrees.
 
         Raises:
-            MoveError: If device could not be moved.
+            MoveError: If device could not be moved. Also propagates whatever the underlying
+                RA/Dec move raises (e.g. MissingObserverError, AltitudeLimitError), since this is
+                typically implemented as converting to RA/Dec and then moving there.
         """
         ...
 

--- a/pyobs/interfaces/IPointingHeliographicStonyhurst.py
+++ b/pyobs/interfaces/IPointingHeliographicStonyhurst.py
@@ -35,7 +35,9 @@ class IPointingHeliographicStonyhurst(Interface, metaclass=ABCMeta):
             lat: Latitude in deg to track.
 
         Raises:
-            MoveError: If device could not be moved.
+            MoveError: If device could not be moved. Also propagates whatever the underlying
+                RA/Dec move raises (e.g. MissingObserverError, AltitudeLimitError), since this is
+                typically implemented as converting to RA/Dec and then moving there.
         """
         ...
 

--- a/pyobs/interfaces/IPointingHelioprojective.py
+++ b/pyobs/interfaces/IPointingHelioprojective.py
@@ -34,7 +34,9 @@ class IPointingHelioprojective(Interface, metaclass=ABCMeta):
             theta_y: The theta_y coordinate.
 
         Raises:
-            MoveError: If device could not be moved.
+            MoveError: If device could not be moved. Also propagates whatever the underlying
+                RA/Dec move raises (e.g. MissingObserverError, AltitudeLimitError), since this is
+                typically implemented as converting to RA/Dec and then moving there.
         """
         ...
 

--- a/pyobs/interfaces/IPointingOrbitalElements.py
+++ b/pyobs/interfaces/IPointingOrbitalElements.py
@@ -37,9 +37,12 @@ class IPointingOrbitalElements(Interface, metaclass=ABCMeta):
             elements: Orbital elements of the body to track.
 
         Raises:
-            MoveError: If telescope could not be moved.
-            ValueError: If elements are incomplete or inconsistent (neither mean_anomaly
-                nor perihelion_time given).
+            NotSupportedError: If this device doesn't support orbital-element tracking.
+            InvalidOrbitalElementsError: If elements are incomplete or inconsistent (neither
+                mean_anomaly nor perihelion_time given).
+            MoveError: If telescope could not be moved. Also propagates whatever the underlying
+                RA/Dec move raises (e.g. MissingObserverError, AltitudeLimitError), since tracking
+                orbital elements is implemented as propagating them and then moving there.
         """
         ...
 

--- a/pyobs/interfaces/IPointingRaDec.py
+++ b/pyobs/interfaces/IPointingRaDec.py
@@ -34,6 +34,9 @@ class IPointingRaDec(Interface, metaclass=ABCMeta):
             dec: Dec in deg to track.
 
         Raises:
+            NotSupportedError: If this device doesn't support RA/Dec pointing.
+            MissingObserverError: If no observer is configured.
+            AltitudeLimitError: If the destination is below the configured altitude limit.
             MoveError: If device could not be moved.
         """
         ...

--- a/pyobs/interfaces/IPointingSeries.py
+++ b/pyobs/interfaces/IPointingSeries.py
@@ -12,7 +12,11 @@ class IPointingSeries(Interface, metaclass=ABCMeta):
 
     @abstractmethod
     async def add_pointing_measurement(self, **kwargs: Any) -> None:
-        """Add a new measurement to the pointing series."""
+        """Add a new measurement to the pointing series.
+
+        Raises:
+            GeneralError: If the measurement could not be added.
+        """
         ...
 
 

--- a/pyobs/interfaces/IRotation.py
+++ b/pyobs/interfaces/IRotation.py
@@ -24,7 +24,11 @@ class IRotation(IMotion, metaclass=ABCMeta):
 
     @abstractmethod
     async def set_rotation(self, angle: Annotated[float, Unit.DEGREES], **kwargs: Any) -> None:
-        """Sets the rotation angle to the given value in degrees."""
+        """Sets the rotation angle to the given value in degrees.
+
+        Raises:
+            MoveError: If the device could not be rotated.
+        """
         ...
 
 

--- a/pyobs/interfaces/IRunnable.py
+++ b/pyobs/interfaces/IRunnable.py
@@ -11,7 +11,13 @@ class IRunnable(IAbortable, metaclass=ABCMeta):
 
     @abstractmethod
     async def run(self, **kwargs: Any) -> None:
-        """Perform module task"""
+        """Perform module task
+
+        Raises:
+            ValueError: If this task is already running.
+            ScriptError: ScriptRunner-based implementations wrap whatever the underlying script
+                raises that isn't already a domain exception.
+        """
         ...
 
 

--- a/pyobs/interfaces/IRunnable.py
+++ b/pyobs/interfaces/IRunnable.py
@@ -14,7 +14,7 @@ class IRunnable(IAbortable, metaclass=ABCMeta):
         """Perform module task
 
         Raises:
-            ValueError: If this task is already running.
+            DeviceBusyError: If this task is already running.
             ScriptError: ScriptRunner-based implementations wrap whatever the underlying script
                 raises that isn't already a domain exception.
         """

--- a/pyobs/interfaces/IScriptRunner.py
+++ b/pyobs/interfaces/IScriptRunner.py
@@ -15,6 +15,9 @@ class IScriptRunner(Interface, metaclass=ABCMeta):
 
         Args:
             script: Script to run.
+
+        Raises:
+            ScriptError: If the script failed.
         """
         ...
 

--- a/pyobs/interfaces/ISyncTarget.py
+++ b/pyobs/interfaces/ISyncTarget.py
@@ -12,7 +12,11 @@ class ISyncTarget(Interface, metaclass=ABCMeta):
 
     @abstractmethod
     async def sync_target(self, **kwargs: Any) -> None:
-        """Synchronize device on current target."""
+        """Synchronize device on current target.
+
+        Raises:
+            GeneralError: If synchronization failed.
+        """
         ...
 
 

--- a/pyobs/interfaces/ITrackingMode.py
+++ b/pyobs/interfaces/ITrackingMode.py
@@ -46,7 +46,7 @@ class ITrackingMode(Interface, metaclass=ABCMeta):
 
         Raises:
             MoveError: If mode could not be set.
-            ValueError: If mode is not in this module's capabilities.
+            InvalidArgumentError: If mode is not in this module's capabilities.
         """
         ...
 

--- a/pyobs/interfaces/IWeather.py
+++ b/pyobs/interfaces/IWeather.py
@@ -45,7 +45,7 @@ class IWeather(IStartStop, metaclass=ABCMeta):
 
         Raises:
             InvalidArgumentError: If station or sensor is unknown.
-            ValueError: If the underlying weather station's response is malformed.
+            WeatherResponseError: If the underlying weather station's response is malformed.
         """
         ...
 

--- a/pyobs/interfaces/IWeather.py
+++ b/pyobs/interfaces/IWeather.py
@@ -42,6 +42,9 @@ class IWeather(IStartStop, metaclass=ABCMeta):
 
         Returns:
             Current reading for the given sensor.
+
+        Raises:
+            ValueError: If station or sensor is unknown.
         """
         ...
 

--- a/pyobs/interfaces/IWeather.py
+++ b/pyobs/interfaces/IWeather.py
@@ -44,7 +44,8 @@ class IWeather(IStartStop, metaclass=ABCMeta):
             Current reading for the given sensor.
 
         Raises:
-            ValueError: If station or sensor is unknown.
+            InvalidArgumentError: If station or sensor is unknown.
+            ValueError: If the underlying weather station's response is malformed.
         """
         ...
 

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -30,10 +30,6 @@ from pyobs.utils.enums import ExposureStatus, ImageType
 log = logging.getLogger(__name__)
 
 
-class CameraException(Exception):
-    pass
-
-
 class ExposureInfo(NamedTuple):
     """Info about a running exposure."""
 
@@ -349,12 +345,13 @@ class BaseCamera(
             Name of image that was taken.
 
         Raises:
+            DeviceBusyError: If the camera is already busy (exposing or running a sequence).
             GrabImageError: If there was a problem grabbing the image.
         """
 
         # are we exposing?
         if self._camera_status != ExposureStatus.IDLE:
-            raise CameraException("Cannot start new exposure because camera is not idle.")
+            raise exc.DeviceBusyError("Cannot start new exposure because camera is not idle.")
         await self._change_exposure_status(ExposureStatus.EXPOSING)
 
         # expose
@@ -384,7 +381,7 @@ class BaseCamera(
                 Does not apply after the last image.
 
         Raises:
-            CameraException: If camera is already busy (exposing or already running a sequence).
+            DeviceBusyError: If camera is already busy (exposing or already running a sequence).
         """
         if count < 1:
             raise ValueError("count must be >= 1.")
@@ -393,7 +390,7 @@ class BaseCamera(
 
         # already running a sequence, or mid-exposure outside of one?
         if self._sequence_count_left > 0 or self._camera_status != ExposureStatus.IDLE:
-            raise CameraException("Cannot start new sequence because camera is not idle.")
+            raise exc.DeviceBusyError("Cannot start new sequence because camera is not idle.")
 
         log.info("Starting sequence of %d images...", count)
         self._sequence_count_left = count
@@ -546,4 +543,4 @@ class BaseCamera(
                 image.data = image.data[::-1, ::-1]
 
 
-__all__ = ["BaseCamera", "CameraException"]
+__all__ = ["BaseCamera"]

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -268,7 +268,7 @@ class BaseCamera(
             if image is None or image.safe_data is None:
                 raise exc.GrabImageError("Could not take image.")
 
-        except exc.PyObsError:
+        except exc.PyobsError:
             # exposure was not successful (aborted?), so reset everything and re-raise
             self._exposure = None
             raise
@@ -406,7 +406,7 @@ class BaseCamera(
             while self._sequence_count_left > 0:
                 try:
                     await self.grab_data(broadcast=broadcast)
-                except exc.PyObsError:
+                except exc.PyobsError:
                     log.exception("Grab failed during sequence, aborting sequence.")
                     break
                 self._sequence_count_left -= 1

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -382,12 +382,13 @@ class BaseCamera(
                 Does not apply after the last image.
 
         Raises:
+            InvalidArgumentError: If count or delay is out of range.
             DeviceBusyError: If camera is already busy (exposing or already running a sequence).
         """
         if count < 1:
-            raise ValueError("count must be >= 1.")
+            raise exc.InvalidArgumentError("count must be >= 1.")
         if delay < 0:
-            raise ValueError("delay must be >= 0.")
+            raise exc.InvalidArgumentError("delay must be >= 0.")
 
         # already running a sequence, or mid-exposure outside of one?
         if self._sequence_count_left > 0 or self._camera_status != ExposureStatus.IDLE:

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -113,7 +113,7 @@ class BaseCamera(
         self._sequence_delay_abort = asyncio.Event()
 
         # register exception
-        exc.register_exception(exc.GrabImageError, 3, timespan=600, callback=self._default_remote_error_callback)
+        self._register_exception(exc.GrabImageError, 3, timespan=600, callback=self._default_remote_error_callback)
 
     async def open(self) -> None:
         """Open module."""

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -222,6 +222,7 @@ class BaseCamera(
             The actual image.
 
         Raises:
+            AbortedError: If the exposure was cancelled via abort_event.
             GrabImageError: If exposure was not successful.
         """
         ...

--- a/pyobs/modules/camera/basespectrograph.py
+++ b/pyobs/modules/camera/basespectrograph.py
@@ -12,6 +12,7 @@ from pyobs.events import ExposureStatusChangedEvent, NewSpectrumEvent
 from pyobs.interfaces import ExposureState, IExposure, ISpectrograph
 from pyobs.mixins.fitsheader import SpectrumFitsHeaderMixin
 from pyobs.modules import Module, timeout
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ExposureStatus
 
 log = logging.getLogger(__name__)
@@ -169,17 +170,21 @@ class BaseSpectrograph(Module, SpectrumFitsHeaderMixin, ISpectrograph, IExposure
 
         Returns:
             Name of image that was taken.
+
+        Raises:
+            DeviceBusyError: If the spectrograph is already busy (exposing).
+            GrabImageError: If there was a problem grabbing the spectrum.
         """
 
         # are we exposing?
         if self._spectrograph_status != ExposureStatus.IDLE:
-            raise ValueError("Cannot start new exposure because spectrograph is not idle.")
+            raise exc.DeviceBusyError("Cannot start new exposure because spectrograph is not idle.")
         await self._change_exposure_status(ExposureStatus.EXPOSING)
 
         # expose
         hdu, filename = await self.__expose(broadcast)
         if hdu is None:
-            raise ValueError("Could not take spectrum.")
+            raise exc.GrabImageError("Could not take spectrum.")
         else:
             if filename is None:
                 raise ValueError("Spectrum has not been saved, so cannot be retrieved by filename.")

--- a/pyobs/modules/camera/basespectrograph.py
+++ b/pyobs/modules/camera/basespectrograph.py
@@ -81,6 +81,7 @@ class BaseSpectrograph(Module, SpectrumFitsHeaderMixin, ISpectrograph, IExposure
             The actual image and, if present, a filename.
 
         Raises:
+            AbortedError: If the exposure was cancelled via abort_event.
             ValueError: If exposure was not successful.
         """
         ...

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -17,6 +17,7 @@ from pyobs.images import Image
 from pyobs.interfaces import IExposureTime, IImageType, ImageTypeState, IVideo, VideoCapabilities
 from pyobs.mixins.fitsheader import ImageFitsHeaderMixin
 from pyobs.modules import Module, timeout
+from pyobs.utils import exceptions as exc
 from pyobs.utils.cache import DataCache
 from pyobs.utils.enums import ImageType
 
@@ -451,6 +452,9 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         Returns:
             Name of image that was taken.
+
+        Raises:
+            GrabImageError: If there was a problem grabbing the image.
         """
 
         # activate camera
@@ -473,7 +477,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         # no image?
         if image_request.image is None or image_request.filename is None:
-            raise ValueError("Could not take image.")
+            raise exc.GrabImageError("Could not take image.")
 
         # finished
         return image_request.filename

--- a/pyobs/modules/camera/dummycamera.py
+++ b/pyobs/modules/camera/dummycamera.py
@@ -38,6 +38,7 @@ from pyobs.interfaces import (
     WindowState,
 )
 from pyobs.modules.camera.basecamera import BaseCamera
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ExposureStatus, ImageFormat, ImageType
 from pyobs.utils.time import Time
 
@@ -292,7 +293,7 @@ class DummyCamera(BaseCamera, IWindow, IBinning, ICooling, IGain, IImageFormat):
             if abort_event.is_set() or not self._exposing:
                 self._exposing = False
                 await self._change_exposure_status(ExposureStatus.IDLE)
-                raise InterruptedError("Exposure was aborted.")
+                raise exc.AbortedError("Exposure was aborted.")
             await asyncio.sleep(exposure_time / steps)
         self._exposing = False
 

--- a/pyobs/modules/camera/dummyspectrograph.py
+++ b/pyobs/modules/camera/dummyspectrograph.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy.io import fits
 
 from pyobs.modules.camera.basespectrograph import BaseSpectrograph
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ExposureStatus
 
 log = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ class DummySpectrograph(BaseSpectrograph):
             The actual image and, if present, a filename.
 
         Raises:
-            ValueError: If exposure was not successful.
+            AbortedError: If the exposure was cancelled via abort_event.
         """
 
         # do exposure
@@ -50,7 +51,7 @@ class DummySpectrograph(BaseSpectrograph):
             if abort_event.is_set() or not self._exposing:
                 self._exposing = False
                 await self._change_exposure_status(ExposureStatus.IDLE)
-                raise ValueError("Exposure was aborted.")
+                raise exc.AbortedError("Exposure was aborted.")
             time.sleep(exposure_time / steps)
         self._exposing = False
 

--- a/pyobs/modules/flatfield/flatfield.py
+++ b/pyobs/modules/flatfield/flatfield.py
@@ -181,9 +181,6 @@ class FlatField(Module, IFlatField, IBinning, IFilters):
 
         Args:
             filter_name: Name of filter to set.
-
-        Raises:
-            ValueError: If binning could not be set.
         """
         self._filter = filter_name
         await self.comm.set_state(IFilters, FilterState(filter=filter_name))

--- a/pyobs/modules/flatfield/flatfield.py
+++ b/pyobs/modules/flatfield/flatfield.py
@@ -194,11 +194,14 @@ class FlatField(Module, IFlatField, IBinning, IFilters):
 
         Returns:
             Number of images actually taken and total exposure time in seconds
+
+        Raises:
+            DeviceBusyError: If a flat-fielding run is already in progress.
         """
 
         # check
         if self._running:
-            raise ValueError("Already running.")
+            raise exc.DeviceBusyError("Already running.")
         self._running = True
 
         try:

--- a/pyobs/modules/flatfield/flatfield.py
+++ b/pyobs/modules/flatfield/flatfield.py
@@ -90,15 +90,15 @@ class FlatField(Module, IFlatField, IBinning, IFilters):
 
         # register exceptions
         if isinstance(camera, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=camera, callback=self._default_remote_error_callback
             )
         if isinstance(telescope, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=telescope, callback=self._default_remote_error_callback
             )
         if isinstance(filters, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=filters, callback=self._default_remote_error_callback
             )
 

--- a/pyobs/modules/flatfield/scheduler.py
+++ b/pyobs/modules/flatfield/scheduler.py
@@ -7,6 +7,7 @@ from pyobs.modules import Module, timeout
 from pyobs.object import get_object
 from pyobs.robotic.utils.skyflats.priorities.base import SkyflatPriorities
 from pyobs.robotic.utils.skyflats.scheduler import Scheduler
+from pyobs.utils import exceptions as exc
 from pyobs.utils.parallel import event_wait
 from pyobs.utils.time import Time
 
@@ -77,11 +78,15 @@ class FlatFieldScheduler(Module, IRunnable):
 
     @timeout(7200)
     async def run(self, **kwargs: Any) -> None:
-        """Perform flat-fielding"""
+        """Perform flat-fielding
+
+        Raises:
+            DeviceBusyError: If a flat-fielding run is already in progress.
+        """
 
         # check
         if self._running:
-            raise ValueError("Already running.")
+            raise exc.DeviceBusyError("Already running.")
         self._running = True
 
         try:

--- a/pyobs/modules/focus/focusmodel.py
+++ b/pyobs/modules/focus/focusmodel.py
@@ -15,11 +15,31 @@ if TYPE_CHECKING:
 from pyobs.events import Event, FilterChangedEvent, FocusFoundEvent
 from pyobs.interfaces import IFilters, IFocuser, IFocusModel, IReady, ITemperatures, IWeather
 from pyobs.modules import Module, timeout
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import WeatherSensors
 from pyobs.utils.publisher import CsvPublisher
 from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
+
+
+class WeatherDataError(exc.FocusError):
+    """The weather station returned an invalid/missing reading -- plausibly transient, worth retrying."""
+
+    pass
+
+
+class FocusTimeoutError(exc.FocusError):
+    """Timed out waiting for a temperature reading from another module -- plausibly transient, worth retrying."""
+
+    pass
+
+
+class MissingSensorError(exc.FocusError):
+    """The configured sensor name isn't in the responding module's temperature data -- a config
+    bug, retrying never fixes it."""
+
+    pass
 
 
 class FocusModel(Module, IFocusModel):
@@ -227,7 +247,9 @@ class FocusModel(Module, IFocusModel):
             Optimum focus calculated from model.
 
         Raises:
-            ValueError: If anything went wrong.
+            WeatherDataError: If the weather station returned an invalid temperature reading.
+            FocusTimeoutError: If a temperature module didn't respond in time.
+            MissingSensorError: If a configured sensor isn't in a module's temperature data.
         """
 
         # get values for variables
@@ -263,6 +285,11 @@ class FocusModel(Module, IFocusModel):
 
         Returns:
             Dictionary containing all values required by the model.
+
+        Raises:
+            WeatherDataError: If the weather station returned an invalid temperature reading.
+            FocusTimeoutError: If a temperature module didn't respond in time.
+            MissingSensorError: If a configured sensor isn't in a module's temperature data.
         """
 
         # variables for model evaluation
@@ -275,7 +302,7 @@ class FocusModel(Module, IFocusModel):
             async with self.proxy(self._weather, IWeather) as weather:
                 reading = await weather.get_sensor_value(self._temp_station, self._temp_sensor)
                 if reading.value is None:
-                    raise ValueError("Received invalid temperature from weather station.")
+                    raise WeatherDataError("Received invalid temperature from weather station.")
 
             # get temperature
             variables["temp"] = reading.value
@@ -293,7 +320,7 @@ class FocusModel(Module, IFocusModel):
                     try:
                         temp_state = await proxy.wait_for_state(ITemperatures)
                     except TimeoutError:
-                        raise ValueError(f"Timeout waiting for temperatures from module {cfg['module']}.")
+                        raise FocusTimeoutError(f"Timeout waiting for temperatures from module {cfg['module']}.")
                     module_temps[cfg["module"]] = (
                         {r.name: r.value for r in temp_state.readings} if temp_state is not None else {}
                     )
@@ -304,7 +331,9 @@ class FocusModel(Module, IFocusModel):
 
             # store, what we need
             if cfg["sensor"] not in module_temps[cfg["module"]]:
-                raise ValueError(f"Temperature for sensor {cfg['sensor']} not in data from module {cfg['module']}.")
+                raise MissingSensorError(
+                    f"Temperature for sensor {cfg['sensor']} not in data from module {cfg['module']}."
+                )
             variables[var] = module_temps[cfg["module"]][cfg["sensor"]]
 
         # log
@@ -319,7 +348,9 @@ class FocusModel(Module, IFocusModel):
             filter_name: Name of filter to use.
 
         Raises:
-            ValueError: If anything went wrong.
+            WeatherDataError: If the weather station returned an invalid temperature reading.
+            FocusTimeoutError: If a temperature module didn't respond in time.
+            MissingSensorError: If a configured sensor isn't in a module's temperature data.
         """
 
         # get focus
@@ -336,7 +367,9 @@ class FocusModel(Module, IFocusModel):
         """Sets optimal focus.
 
         Raises:
-            ValueError: If anything went wrong.
+            WeatherDataError: If the weather station returned an invalid temperature reading.
+            FocusTimeoutError: If a temperature module didn't respond in time.
+            MissingSensorError: If a configured sensor isn't in a module's temperature data.
         """
         await self._set_optimal_focus()
 

--- a/pyobs/modules/focus/focusseries.py
+++ b/pyobs/modules/focus/focusseries.py
@@ -79,11 +79,11 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
 
         # register exceptions
         if isinstance(camera, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=camera, callback=self._default_remote_error_callback
             )
         if isinstance(focuser, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=focuser, callback=self._default_remote_error_callback
             )
 

--- a/pyobs/modules/focus/focusseries.py
+++ b/pyobs/modules/focus/focusseries.py
@@ -164,7 +164,7 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
                     foc_state = focuser.get_state(IFocuser)
                     guess = foc_state.focus if foc_state is not None else 0.0
                     log.info("Using current focus of %.2fmm as initial guess.", guess)
-        except exc.RemoteError:
+        except exc.PyobsError:
             raise exc.FocusError("Could not fetch current focus value.")
 
         # define array of focus values to iterate
@@ -191,7 +191,7 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
                     else:
                         await focuser.set_focus(float(foc))
 
-            except exc.RemoteError:
+            except exc.PyobsError:
                 raise exc.FocusError("Could not set new focus value.")
 
             # do exposure
@@ -200,7 +200,7 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
                 raise exc.AbortedError()
             try:
                 filename = await self._take_image(exposure_time)
-            except exc.RemoteError:
+            except exc.PyobsError:
                 log.error("Could not take image.")
                 continue
 

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -550,6 +550,11 @@ class Module(Object, IModule, IConfig):
 
         # check acl, exempting get_permitted_methods itself so a denied caller can still ask what it's denied from
         sender = kwargs.get("sender", "")
+        # correlation id (XEP-0009's per-call iq id, passed through by the XMPP transport) -- lets
+        # an operator jump from a caller-side exception straight to this log line by id, instead of
+        # neither side pointing at the other. Not set for LocalComm/MultiModule, which are already
+        # in the same log stream as the caller.
+        call_id = kwargs.get("call_id", None)
         if method != "get_permitted_methods" and self._acl_denied(sender, method):
             if self._acl_mode == "enforce":
                 raise exc.ForbiddenError(
@@ -594,15 +599,18 @@ class Module(Object, IModule, IConfig):
             else:
                 original_type = f"{type(raised).__module__}.{type(raised).__qualname__}"
                 e = exc.UnclassifiedError(str(raised), original_type=original_type)
+            setattr(e, "call_id", call_id)
+
+            call_id_suffix = f" (call_id={call_id})" if call_id else ""
 
             # ModuleError/UnclassifiedError always need local attention -- never suppressible, always loud.
             if isinstance(e, self._UNSUPPRESSIBLE):
-                e.log(log, "ERROR", f"Exception was raised in call to {method}: {e}", exc_info=True)
+                e.log(log, "ERROR", f"Exception was raised in call to {method}{call_id_suffix}: {e}", exc_info=True)
             else:
                 # every other domain exception logs as a quiet INFO line by default -- a module opts
                 # out per-type via _disable_exception_logging, it doesn't opt in per-method anymore.
                 if not isinstance(e, self._disabled_exception_logging):
-                    e.log(log, "INFO", f"Exception was raised in call to {method}: {e}", exc_info=False)
+                    e.log(log, "INFO", f"Exception was raised in call to {method}{call_id_suffix}: {e}", exc_info=False)
                 # else: caller already has it; nothing to log locally
 
             self._record_exception(e)

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import Any, TypeVar, cast
 
 import packaging.version
@@ -161,12 +162,18 @@ class Module(Object, IModule, IConfig):
         # exception types this module has opted out of logging locally (see _disable_exception_logging)
         self._disabled_exception_logging: tuple[type[exc.PyobsError], ...] = ()
 
+        # severity-escalation state (see _register_exception/_record_exception) -- instance-scoped,
+        # not module-level globals, so two Module instances in the same process (e.g. under
+        # MultiModule) never share counters
+        self._exception_log: dict[type[exc.PyobsError], list[exc.LoggedException]] = {}
+        self._remote_exception_log: dict[tuple[type[exc.PyobsError], str], list[exc.LoggedException]] = {}
+        self._exception_handlers: list[exc.ExceptionHandler] = []
+
     # exception types that always need local attention, regardless of _disable_exception_logging:
-    # ModuleError means the module itself is broken; SevereError means a normally-fine failure mode
-    # has started repeating past a threshold; UnclassifiedError means something escaped un-typed
-    # across an RPC boundary. None of the three are part of the deliberate per-type logging
-    # contract a module author gets to opt out of.
-    _UNSUPPRESSIBLE: tuple[type[exc.PyobsError], ...] = (exc.ModuleError, exc.SevereError, exc.UnclassifiedError)
+    # ModuleError means the module itself is broken; UnclassifiedError means something escaped
+    # un-typed, either locally or across an RPC boundary. Neither is part of the deliberate
+    # per-type logging contract a module author gets to opt out of.
+    _UNSUPPRESSIBLE: tuple[type[exc.PyobsError], ...] = (exc.ModuleError, exc.UnclassifiedError)
 
     def _disable_exception_logging(self, *exceptions: type[exc.PyobsError]) -> None:
         """Declare that the given PyobsError types (and their subclasses) fire often enough that even the
@@ -180,6 +187,100 @@ class Module(Object, IModule, IConfig):
             if issubclass(e, self._UNSUPPRESSIBLE):
                 raise ValueError(f"{e.__name__} cannot be silenced -- it always needs local attention.")
         self._disabled_exception_logging = self._disabled_exception_logging + exceptions
+
+    def _register_exception(
+        self,
+        exc_type: type[exc.PyobsError],
+        limit: int,
+        timespan: float | None = None,
+        module: str | None = None,
+        callback: Callable[[exc.PyobsError], Coroutine[Any, Any, None]] | None = None,
+    ) -> None:
+        """Watch for repeated occurrences of exc_type -- optionally scoped to a specific remote
+        module -- and fire callback once limit occurrences are seen (optionally within timespan
+        seconds). Call from __init__.
+
+        Args:
+            exc_type: Exception type (or a shared ancestor, e.g. RemoteError) to watch for.
+            limit: Number of occurrences that triggers the callback.
+            timespan: If given, only count occurrences within the last timespan seconds.
+            module: If given, only count occurrences tagged as coming from this remote module
+                (see _record_exception) instead of ones raised locally.
+            callback: Coroutine called with the triggering exception once the threshold is hit.
+        """
+        self._exception_handlers.append(exc.ExceptionHandler(exc_type, limit, timespan, module, callback))
+
+    def _record_exception(self, exception: exc.PyobsError) -> None:
+        """Records exception for severity tracking (see _register_exception) and fires any handler
+        whose threshold is now met. Call from execute()'s catch block -- every exception it lets
+        through is already a PyobsError by then (see execute()'s UnclassifiedError wrapping)."""
+        module = getattr(exception, "remote_module", None)
+        self._store_exception(exception, module)
+
+        triggered = self._check_exception_severity()
+        handlers = [h for h in triggered if self._exception_matches(exception, h.exc_type)]
+        for h in handlers:
+            if h.callback is not None:
+                asyncio.create_task(h.callback(exception))
+
+    def _exception_matches(self, exception: Exception, exc_type: type[exc.PyobsError]) -> bool:
+        """Whether exception should count as an instance of exc_type for severity-handler matching:
+        true isinstance, or -- mirroring _store_exception's RemoteError special case below --
+        anything tagged with remote_module counts as a RemoteError even though its own type no
+        longer literally subclasses it now that faults raise as their real type instead of wrapped."""
+        if isinstance(exception, exc_type):
+            return True
+        return exc_type is exc.RemoteError and getattr(exception, "remote_module", None) is not None
+
+    def _store_exception(self, exception: exc.PyobsError, module: str | None) -> None:
+        # get all classes from mro -- plus RemoteError if this crossed an RPC boundary (module is
+        # not None, i.e. the exception carries a remote_module tag from rpc.py's fault
+        # reconstruction), even though a directly-reraised domain type (e.g. GrabImageError) no
+        # longer subclasses RemoteError itself now that faults raise as their real type instead of
+        # wrapped (see rpc.py, Assessment §A). Preserves
+        # _register_exception(exc.RemoteError, ..., module=X)-style "this module keeps failing
+        # remotely, regardless of the specific type" handlers (e.g. AutoFocusSeries).
+        classes: list[type] = list(type(exception).__mro__)
+        if module is not None and exc.RemoteError not in classes:
+            classes.append(exc.RemoteError)
+
+        for e in classes:
+            # only pyobs exceptions
+            if not issubclass(e, exc.PyobsError):
+                continue
+
+            # is it handled by any handler?
+            if not any(e == h.exc_type for h in self._exception_handlers):
+                continue
+
+            # log
+            le = exc.LoggedException(time=time.time(), exception=exception)
+
+            # store it
+            if module is None:
+                self._exception_log.setdefault(e, []).append(le)
+            else:
+                self._remote_exception_log.setdefault((e, module), []).append(le)
+
+    def _check_exception_severity(self) -> list[exc.ExceptionHandler]:
+        """Checks all handlers against all recorded exceptions and returns those whose threshold is met."""
+        triggered: list[exc.ExceptionHandler] = []
+        for h in self._exception_handlers:
+            if h.module is None:
+                exceptions = self._exception_log.get(h.exc_type, [])
+            else:
+                exceptions = self._remote_exception_log.get((h.exc_type, h.module), [])
+
+            if h.timespan is None:
+                count = len(exceptions)
+            else:
+                earliest = time.time() - h.timespan
+                count = len([le for le in exceptions if le.time >= earliest])
+
+            if count >= h.limit:
+                triggered.append(h)
+
+        return triggered
 
     async def open(self) -> None:
         # open comm
@@ -482,17 +583,29 @@ class Module(Object, IModule, IConfig):
 
         try:
             response = await func(*func_args, **ba.arguments, **func_kwargs)
-        except Exception as e:
-            # ModuleError/SevereError/UnclassifiedError always need local attention -- never
-            # suppressible, always loud.
+        except Exception as raised:
+            # classify: anything that isn't a domain PyobsError wasn't part of the deliberate
+            # contract (goal 5) -- wrap it so every transport (XMPP, LocalComm, MultiModule) and
+            # every caller can rely on always receiving a PyobsError, regardless of what actually
+            # escaped. exc_info=True below still captures the real traceback via sys.exc_info(),
+            # and raising a freshly-constructed exception here chains it as __context__ for free.
+            if isinstance(raised, exc.PyobsError):
+                e: exc.PyobsError = raised
+            else:
+                original_type = f"{type(raised).__module__}.{type(raised).__qualname__}"
+                e = exc.UnclassifiedError(str(raised), original_type=original_type)
+
+            # ModuleError/UnclassifiedError always need local attention -- never suppressible, always loud.
             if isinstance(e, self._UNSUPPRESSIBLE):
                 e.log(log, "ERROR", f"Exception was raised in call to {method}: {e}", exc_info=True)
-            elif isinstance(e, exc.PyobsError):
+            else:
                 # every other domain exception logs as a quiet INFO line by default -- a module opts
                 # out per-type via _disable_exception_logging, it doesn't opt in per-method anymore.
                 if not isinstance(e, self._disabled_exception_logging):
                     e.log(log, "INFO", f"Exception was raised in call to {method}: {e}", exc_info=False)
                 # else: caller already has it; nothing to log locally
+
+            self._record_exception(e)
             raise e
 
         return response

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -86,8 +86,10 @@ def timeout(func_timeout: str | int | Callable[..., Any] | None = None) -> Calla
 
 def raises(*exceptions: type[exc.PyObsError]) -> Callable[[F], F]:
     """
-    Decorates a method with information about which pyobs exceptions it raises. These exceptions are
-    logged in this module, but as INFO without stacktrace.
+    Decorates a method with documentation metadata about which pyobs exceptions it raises. Every domain
+    PyObsError already logs as a quiet INFO line by default (see Module.execute()), regardless of whether
+    it's declared here -- this decorator no longer affects logging. It exists purely for documentation
+    purposes: a future cross-check could compare it against a method's docstring or its actual raise sites.
 
     :param exceptions:  One or more exceptions.
     """
@@ -155,6 +157,28 @@ class Module(Object, IModule, IConfig):
         # close
         self._closing = asyncio.Event()
         self._quit_parent: Callable[[], None] | None = None  # set by MultiModule
+
+        # exception types this module has opted out of logging locally (see _disable_exception_logging)
+        self._disabled_exception_logging: tuple[type[exc.PyObsError], ...] = ()
+
+    # exception types that always need local attention, regardless of _disable_exception_logging:
+    # ModuleError means the module itself is broken; SevereError means a normally-fine failure mode
+    # has started repeating past a threshold. Neither is part of the deliberate per-type logging
+    # contract a module author gets to opt out of.
+    _UNSUPPRESSIBLE: tuple[type[exc.PyObsError], ...] = (exc.ModuleError, exc.SevereError)
+
+    def _disable_exception_logging(self, *exceptions: type[exc.PyObsError]) -> None:
+        """Declare that the given PyObsError types (and their subclasses) fire often enough that even the
+        default quiet INFO line is too much, and should not be logged locally at all -- the caller already
+        sees them.
+
+        Args:
+            *exceptions: One or more PyObsError subclasses to silence locally.
+        """
+        for e in exceptions:
+            if issubclass(e, self._UNSUPPRESSIBLE):
+                raise ValueError(f"{e.__name__} cannot be silenced -- it always needs local attention.")
+        self._disabled_exception_logging = self._disabled_exception_logging + exceptions
 
     async def open(self) -> None:
         # open comm
@@ -452,18 +476,15 @@ class Module(Object, IModule, IConfig):
         try:
             response = await func(*func_args, **ba.arguments, **func_kwargs)
         except Exception as e:
-            # something else went wrong, but only log if not a ModuleError
-            if isinstance(e, exc.PyObsError) and not isinstance(e, exc.ModuleError):
-                # in list of named exceptions?
-                level = (
-                    "INFO"
-                    if hasattr(func, "raises")
-                    and isinstance(getattr(func, "raises"), tuple)
-                    and type(e) in getattr(func, "raises")
-                    else "ERROR"
-                )
-                exc_info = level == "ERROR"
-                e.log(log, level, f"Exception was raised in call to {method}: {e}", exc_info=exc_info)
+            # ModuleError/SevereError always need local attention -- never suppressible, always loud.
+            if isinstance(e, exc.ModuleError) or isinstance(e, exc.SevereError):
+                e.log(log, "ERROR", f"Exception was raised in call to {method}: {e}", exc_info=True)
+            elif isinstance(e, exc.PyObsError):
+                # every other domain exception logs as a quiet INFO line by default -- a module opts
+                # out per-type via _disable_exception_logging, it doesn't opt in per-method anymore.
+                if not isinstance(e, self._disabled_exception_logging):
+                    e.log(log, "INFO", f"Exception was raised in call to {method}: {e}", exc_info=False)
+                # else: caller already has it; nothing to log locally
             raise e
 
         return response

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -686,16 +686,16 @@ class Module(Object, IModule, IConfig):
             Current value.
 
         Raises:
-            ValueError: If config item of given name does not exist.
+            InvalidArgumentError: If config item of given name does not exist.
         """
 
         # valid parameter?
         if not name:
-            raise ValueError("No parameter name given.")
+            raise exc.InvalidArgumentError("No parameter name given.")
         if name not in self._config_caps:
-            raise ValueError(f"Invalid parameter {name}")
+            raise exc.InvalidArgumentError(f"Invalid parameter {name}")
         if not self._config_caps[name][0]:
-            raise ValueError("Parameter %s is not remotely accessible.")
+            raise exc.InvalidArgumentError("Parameter %s is not remotely accessible.")
 
         # get getter method and call it
         getter = getattr(self, "_get_config_" + name)
@@ -711,16 +711,16 @@ class Module(Object, IModule, IConfig):
             Possible values.
 
         Raises:
-            ValueError: If config item of given name does not exist.
+            InvalidArgumentError: If config item of given name does not exist.
         """
 
         # valid parameter?
         if not name:
-            raise ValueError("No parameter name given.")
+            raise exc.InvalidArgumentError("No parameter name given.")
         if name not in self._config_caps:
-            raise ValueError(f"Invalid parameter {name}")
+            raise exc.InvalidArgumentError(f"Invalid parameter {name}")
         if not self._config_caps[name][2]:
-            raise ValueError("Parameter %s has no list of possible values.")
+            raise exc.InvalidArgumentError("Parameter %s has no list of possible values.")
 
         # get getter method and call it
         options = getattr(self, "_get_config_options_" + name)
@@ -734,16 +734,17 @@ class Module(Object, IModule, IConfig):
             value: New value.
 
         Raises:
-            ValueError: If config item of given name does not exist or value is invalid.
+            InvalidArgumentError: If config item of given name does not exist.
+            ValueError: If value is invalid.
         """
 
         # valid parameter?
         if not name:
-            raise ValueError("No parameter name given.")
+            raise exc.InvalidArgumentError("No parameter name given.")
         if name not in self._config_caps:
-            raise ValueError(f"Invalid parameter {name}")
+            raise exc.InvalidArgumentError(f"Invalid parameter {name}")
         if not self._config_caps[name][1]:
-            raise ValueError("Parameter %s is not remotely settable.")
+            raise exc.InvalidArgumentError("Parameter %s is not remotely settable.")
 
         # get setter and call it
         setter = getattr(self, "_set_config_" + name)

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -84,10 +84,10 @@ def timeout(func_timeout: str | int | Callable[..., Any] | None = None) -> Calla
     return timeout_decorator
 
 
-def raises(*exceptions: type[exc.PyObsError]) -> Callable[[F], F]:
+def raises(*exceptions: type[exc.PyobsError]) -> Callable[[F], F]:
     """
     Decorates a method with documentation metadata about which pyobs exceptions it raises. Every domain
-    PyObsError already logs as a quiet INFO line by default (see Module.execute()), regardless of whether
+    PyobsError already logs as a quiet INFO line by default (see Module.execute()), regardless of whether
     it's declared here -- this decorator no longer affects logging. It exists purely for documentation
     purposes: a future cross-check could compare it against a method's docstring or its actual raise sites.
 
@@ -159,21 +159,22 @@ class Module(Object, IModule, IConfig):
         self._quit_parent: Callable[[], None] | None = None  # set by MultiModule
 
         # exception types this module has opted out of logging locally (see _disable_exception_logging)
-        self._disabled_exception_logging: tuple[type[exc.PyObsError], ...] = ()
+        self._disabled_exception_logging: tuple[type[exc.PyobsError], ...] = ()
 
     # exception types that always need local attention, regardless of _disable_exception_logging:
     # ModuleError means the module itself is broken; SevereError means a normally-fine failure mode
-    # has started repeating past a threshold. Neither is part of the deliberate per-type logging
+    # has started repeating past a threshold; UnclassifiedError means something escaped un-typed
+    # across an RPC boundary. None of the three are part of the deliberate per-type logging
     # contract a module author gets to opt out of.
-    _UNSUPPRESSIBLE: tuple[type[exc.PyObsError], ...] = (exc.ModuleError, exc.SevereError)
+    _UNSUPPRESSIBLE: tuple[type[exc.PyobsError], ...] = (exc.ModuleError, exc.SevereError, exc.UnclassifiedError)
 
-    def _disable_exception_logging(self, *exceptions: type[exc.PyObsError]) -> None:
-        """Declare that the given PyObsError types (and their subclasses) fire often enough that even the
+    def _disable_exception_logging(self, *exceptions: type[exc.PyobsError]) -> None:
+        """Declare that the given PyobsError types (and their subclasses) fire often enough that even the
         default quiet INFO line is too much, and should not be logged locally at all -- the caller already
         sees them.
 
         Args:
-            *exceptions: One or more PyObsError subclasses to silence locally.
+            *exceptions: One or more PyobsError subclasses to silence locally.
         """
         for e in exceptions:
             if issubclass(e, self._UNSUPPRESSIBLE):
@@ -259,7 +260,8 @@ class Module(Object, IModule, IConfig):
                 caps = proxy.get_capabilities(IModule)
                 module_version = caps.version if caps is not None else ""
                 remote_location = caps.location if caps is not None else None
-        except exc.RemoteError:
+        except exc.PyobsError:
+            # however this failed (transport or domain), we just skip this module
             return True
 
         # log it
@@ -449,7 +451,12 @@ class Module(Object, IModule, IConfig):
         sender = kwargs.get("sender", "")
         if method != "get_permitted_methods" and self._acl_denied(sender, method):
             if self._acl_mode == "enforce":
-                raise exc.ForbiddenError(sender, method)
+                raise exc.ForbiddenError(
+                    f"Caller '{sender}' is not permitted to invoke '{method}'.",
+                    sender=sender,
+                    method=method,
+                    module=sender,
+                )
             else:
                 log.warning('Caller "%s" would be denied calling "%s" (acl mode=log, allowing).', sender, method)
 
@@ -476,10 +483,11 @@ class Module(Object, IModule, IConfig):
         try:
             response = await func(*func_args, **ba.arguments, **func_kwargs)
         except Exception as e:
-            # ModuleError/SevereError always need local attention -- never suppressible, always loud.
-            if isinstance(e, exc.ModuleError) or isinstance(e, exc.SevereError):
+            # ModuleError/SevereError/UnclassifiedError always need local attention -- never
+            # suppressible, always loud.
+            if isinstance(e, self._UNSUPPRESSIBLE):
                 e.log(log, "ERROR", f"Exception was raised in call to {method}: {e}", exc_info=True)
-            elif isinstance(e, exc.PyObsError):
+            elif isinstance(e, exc.PyobsError):
                 # every other domain exception logs as a quiet INFO line by default -- a module opts
                 # out per-type via _disable_exception_logging, it doesn't opt in per-method anymore.
                 if not isinstance(e, self._disabled_exception_logging):
@@ -660,16 +668,18 @@ class Module(Object, IModule, IConfig):
         sender = kwargs.get("sender", "")
         return [name for name in self._methods if not self._acl_denied(sender, name)]
 
-    async def _default_remote_error_callback(self, exception: exc.PyObsError) -> None:
+    async def _default_remote_error_callback(self, exception: exc.PyobsError) -> None:
         """Called on severe errors.
 
         Args:
             exception: Exception that caused severe error.
         """
 
-        # set error string
-        if isinstance(exception, exc.RemoteError):
-            error = f"Servere error in {exception.module} module: {exception}"
+        # set error string -- "module" is a generic context attribute (see PyobsError.__init__), not
+        # guaranteed to be set, even on a RemoteError, so read it defensively
+        module = getattr(exception, "module", None)
+        if isinstance(exception, exc.RemoteError) and module is not None:
+            error = f"Servere error in {module} module: {exception}"
         else:
             error = f"Severe error: {exception}"
         self.set_error_string(error)

--- a/pyobs/modules/pointing/_base.py
+++ b/pyobs/modules/pointing/_base.py
@@ -49,11 +49,11 @@ class BasePointing(Module, PipelineMixin, metaclass=ABCMeta):
 
         # register exceptions
         if isinstance(camera, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=camera, callback=self._default_remote_error_callback
             )
         if isinstance(telescope, str):
-            exc.register_exception(
+            self._register_exception(
                 exc.RemoteError, 3, timespan=600, module=telescope, callback=self._default_remote_error_callback
             )
 

--- a/pyobs/modules/pointing/scienceframeguiding.py
+++ b/pyobs/modules/pointing/scienceframeguiding.py
@@ -5,6 +5,7 @@ from typing import Any
 from pyobs.events import Event, NewImageEvent
 from pyobs.images import Image
 from pyobs.interfaces import ExposureTimeState, IExposureTime
+from pyobs.utils import exceptions as exc
 
 from ._baseguiding import BaseGuiding
 
@@ -43,8 +44,11 @@ class ScienceFrameAutoGuiding(BaseGuiding):
 
         Args:
             exposure_time: Exposure time in secs.
+
+        Raises:
+            NotSupportedError: Exposure time is dictated by incoming science frames, not settable.
         """
-        raise NotImplementedError
+        raise exc.NotSupportedError("Exposure time is dictated by incoming science frames, not settable.")
 
     async def add_image(self, event: Event, sender: str, **kwargs: Any) -> bool:
         """Processes an image asynchronously, returns immediately.

--- a/pyobs/modules/robotic/scriptrunner.py
+++ b/pyobs/modules/robotic/scriptrunner.py
@@ -5,7 +5,8 @@ from typing import Any
 
 from pyobs.interfaces import IRunnable
 from pyobs.modules import Module, timeout
-from pyobs.robotic.scripts import Script
+from pyobs.robotic.scripts import Script, ScriptError
+from pyobs.utils import exceptions as exc
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +46,18 @@ class ScriptRunner(Module, IRunnable):
 
     @timeout(calc_run_timeout)
     async def run(self, **kwargs: Any) -> None:
-        """Run script."""
+        """Run script.
+
+        Raises:
+            ScriptError: If the script failed (e.g. a proxy/network failure reaching a dependency).
+        """
         script = self.get_object(self.script, Script)
-        await script.run(None)
+        try:
+            await script.run(None)
+        except exc.PyobsError:
+            raise
+        except Exception as e:
+            raise ScriptError(str(e)) from e
 
     async def abort(self, **kwargs: Any) -> None:
         """Abort current actions."""

--- a/pyobs/modules/roof/basedome.py
+++ b/pyobs/modules/roof/basedome.py
@@ -21,7 +21,7 @@ class BaseDome(IDome, BaseRoof, metaclass=ABCMeta):
         """Initialize a new base dome."""
         BaseRoof.__init__(self, **kwargs)
 
-        exc.register_exception(exc.MotionError, 3, timespan=600, callback=self._default_remote_error_callback)
+        self._register_exception(exc.MotionError, 3, timespan=600, callback=self._default_remote_error_callback)
 
     async def get_fits_header_before(
         self, namespaces: list[str] | None = None, **kwargs: Any

--- a/pyobs/modules/roof/dummyroof.py
+++ b/pyobs/modules/roof/dummyroof.py
@@ -7,6 +7,7 @@ from typing import Any
 from pyobs.events import RoofClosingEvent, RoofOpenedEvent
 from pyobs.interfaces import IRoof
 from pyobs.modules import timeout
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import MotionStatus
 from pyobs.utils.threads import LockWithAbort
 
@@ -48,19 +49,22 @@ class DummyRoof(BaseRoof, IRoof):
         """Open the roof.
 
         Raises:
-            AcquireLockFailed: If current motion could not be aborted.
+            InitError: If the roof could not be initialized (e.g. another motion is in progress).
         """
 
         if self._is_open():
             return
 
-        async with LockWithAbort(self._lock_motion, self._abort_motion):
-            await self._change_motion_status(MotionStatus.INITIALIZING)
+        try:
+            async with LockWithAbort(self._lock_motion, self._abort_motion):
+                await self._change_motion_status(MotionStatus.INITIALIZING)
 
-            await self._move_roof(self._ROOF_OPEN_PERCENTAGE)
+                await self._move_roof(self._ROOF_OPEN_PERCENTAGE)
 
-            await self._change_motion_status(MotionStatus.IDLE)
-            await self.comm.send_event(RoofOpenedEvent())
+                await self._change_motion_status(MotionStatus.IDLE)
+                await self.comm.send_event(RoofOpenedEvent())
+        except Exception as e:
+            raise exc.InitError(str(e)) from e
 
     def _is_open(self) -> bool:
         return self._open_percentage == self._ROOF_OPEN_PERCENTAGE
@@ -70,19 +74,22 @@ class DummyRoof(BaseRoof, IRoof):
         """Close the roof.
 
         Raises:
-            AcquireLockFailed: If current motion could not be aborted.
+            ParkError: If the roof could not be parked (e.g. another motion is in progress).
         """
 
         if self._is_closed():
             return
 
-        async with LockWithAbort(self._lock_motion, self._abort_motion):
-            await self._change_motion_status(MotionStatus.PARKING)
-            await self.comm.send_event(RoofClosingEvent())
+        try:
+            async with LockWithAbort(self._lock_motion, self._abort_motion):
+                await self._change_motion_status(MotionStatus.PARKING)
+                await self.comm.send_event(RoofClosingEvent())
 
-            await self._move_roof(self._ROOF_CLOSED_PERCENTAGE)
+                await self._move_roof(self._ROOF_CLOSED_PERCENTAGE)
 
-            await self._change_motion_status(MotionStatus.PARKED)
+                await self._change_motion_status(MotionStatus.PARKED)
+        except Exception as e:
+            raise exc.ParkError(str(e)) from e
 
     def _is_closed(self) -> bool:
         return self._open_percentage == self._ROOF_CLOSED_PERCENTAGE
@@ -109,7 +116,7 @@ class DummyRoof(BaseRoof, IRoof):
             device: Name of device to stop, or None for all.
 
         Raises:
-            AcquireLockFailed: If current motion could not be aborted.
+            DeviceBusyError: If current motion could not be aborted.
         """
 
         await self._change_motion_status(MotionStatus.ABORTING)

--- a/pyobs/modules/telescope/_dummytelescopebase.py
+++ b/pyobs/modules/telescope/_dummytelescopebase.py
@@ -39,6 +39,7 @@ from pyobs.interfaces import (
 from pyobs.mixins.fitsnamespace import FitsNamespaceMixin
 from pyobs.modules import timeout
 from pyobs.modules.telescope.basetelescope import BaseTelescope
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import MotionStatus
 from pyobs.utils.threads import LockWithAbort
 from pyobs.utils.time import Time
@@ -326,17 +327,24 @@ class _DummyTelescopeBase(
 
     @timeout(60)
     async def park(self, **kwargs: Any) -> None:
-        """Park telescope."""
+        """Park telescope.
+
+        Raises:
+            ParkError: If the telescope could not be parked (e.g. another motion is in progress).
+        """
         log.info("Parking telescope...")
-        async with LockWithAbort(self._lock_moving, self._abort_move):
-            await self._change_motion_status(MotionStatus.PARKING)
-            self._dest_coords = None
-            try:
-                await asyncio.wait_for(asyncio.shield(self._closing.wait()), timeout=5.0)
-                return
-            except TimeoutError:
-                pass
-            await self._change_motion_status(MotionStatus.PARKED)
+        try:
+            async with LockWithAbort(self._lock_moving, self._abort_move):
+                await self._change_motion_status(MotionStatus.PARKING)
+                self._dest_coords = None
+                try:
+                    await asyncio.wait_for(asyncio.shield(self._closing.wait()), timeout=5.0)
+                    return
+                except TimeoutError:
+                    pass
+                await self._change_motion_status(MotionStatus.PARKED)
+        except Exception as e:
+            raise exc.ParkError(str(e)) from e
         log.info("Telescope parked.")
 
     async def get_fits_header_before(
@@ -358,7 +366,12 @@ class _DummyTelescopeBase(
             await self._change_motion_status(MotionStatus.IDLE)
 
     async def set_focus_offset(self, offset: float, **kwargs: Any) -> None:
-        raise NotImplementedError
+        """Set the focus offset.
+
+        Raises:
+            NotSupportedError: This dummy telescope doesn't support a separate focus offset.
+        """
+        raise exc.NotSupportedError("This dummy telescope does not support a separate focus offset.")
 
 
 __all__ = ["_DummyTelescopeBase"]

--- a/pyobs/modules/telescope/_dummytelescopebase.py
+++ b/pyobs/modules/telescope/_dummytelescopebase.py
@@ -275,7 +275,11 @@ class _DummyTelescopeBase(
 
     @timeout(60)
     async def set_focus(self, focus: float, **kwargs: Any) -> None:
-        """Sets new focus."""
+        """Sets new focus.
+
+        Raises:
+            AbortedError: If setting the focus was cancelled.
+        """
         if focus < 0 or focus > 100:
             raise ValueError("Invalid focus value.")
 
@@ -286,7 +290,7 @@ class _DummyTelescopeBase(
             dfoc = (focus - ifoc) / 300.0
             for i in range(300):
                 if self._abort_focus.is_set():
-                    raise InterruptedError("Setting focus was interrupted.")
+                    raise exc.AbortedError("Setting focus was interrupted.")
                 self._focus = ifoc + i * dfoc
                 await asyncio.sleep(0.01)
             await self._change_motion_status(MotionStatus.POSITIONED, interface="IFocuser")

--- a/pyobs/modules/telescope/_dummytelescopebase.py
+++ b/pyobs/modules/telescope/_dummytelescopebase.py
@@ -261,9 +261,13 @@ class _DummyTelescopeBase(
         await self._move_radec(icrs.ra.degree, icrs.dec.degree, abort_event)
 
     async def set_tracking_mode(self, mode: TrackingMode, **kwargs: Any) -> None:
-        """Switches to the given tracking mode."""
+        """Switches to the given tracking mode.
+
+        Raises:
+            InvalidArgumentError: If mode is not in this module's capabilities.
+        """
         if mode not in self._tracking_modes:
-            raise ValueError(f"Mode {mode} not supported.")
+            raise exc.InvalidArgumentError(f"Mode {mode} not supported.")
         self._tracking_mode = mode
         await self.comm.set_state(ITrackingMode, TrackingModeState(mode=mode))
 
@@ -278,10 +282,11 @@ class _DummyTelescopeBase(
         """Sets new focus.
 
         Raises:
+            InvalidArgumentError: If given value is invalid.
             AbortedError: If setting the focus was cancelled.
         """
         if focus < 0 or focus > 100:
-            raise ValueError("Invalid focus value.")
+            raise exc.InvalidArgumentError("Invalid focus value.")
 
         async with LockWithAbort(self._lock_focus, self._abort_focus):
             log.info("Setting focus to %.2f...", focus)
@@ -298,9 +303,13 @@ class _DummyTelescopeBase(
             await self.comm.set_state(IFocuser, FocuserState(focus=focus, focus_offset=0.0))
 
     async def set_filter(self, filter_name: str, **kwargs: Any) -> None:
-        """Set the current filter."""
+        """Set the current filter.
+
+        Raises:
+            InvalidArgumentError: If an invalid filter was given.
+        """
         if filter_name not in self._filters:
-            raise ValueError("Invalid filter name.")
+            raise exc.InvalidArgumentError("Invalid filter name.")
 
         if filter_name != self._filter_name:
             logging.info("Setting filter to %s", filter_name)

--- a/pyobs/modules/telescope/basetelescope.py
+++ b/pyobs/modules/telescope/basetelescope.py
@@ -301,6 +301,8 @@ class BaseTelescope(
             abort_event: Event that gets triggered when movement should be aborted.
 
         Raises:
+            AbortedError: If cancelled via abort_event (optional -- returning normally once
+                abort_event is set is also valid; see _DummyTelescopeBase for that variant).
             MoveError: If telescope cannot be moved.
         """
         ...
@@ -393,6 +395,8 @@ class BaseTelescope(
             abort_event: Event that gets triggered when movement should be aborted.
 
         Raises:
+            AbortedError: If cancelled via abort_event (optional -- returning normally once
+                abort_event is set is also valid; see _DummyTelescopeBase for that variant).
             MoveError: If telescope cannot be moved.
         """
         ...

--- a/pyobs/modules/telescope/basetelescope.py
+++ b/pyobs/modules/telescope/basetelescope.py
@@ -249,7 +249,7 @@ class BaseTelescope(
         )
 
         # register exception
-        exc.register_exception(exc.MotionError, 3, timespan=600, callback=self._default_remote_error_callback)
+        self._register_exception(exc.MotionError, 3, timespan=600, callback=self._default_remote_error_callback)
 
     @property
     def _position_radec(self) -> tuple[float, float] | None:

--- a/pyobs/modules/telescope/basetelescope.py
+++ b/pyobs/modules/telescope/basetelescope.py
@@ -51,6 +51,33 @@ _MOON_FALLBACK_REFRESH_INTERVAL_SECONDS = 60.0
 _POSITION_NUDGE_INTERVAL_SECONDS = 600.0
 
 
+class MissingObserverError(exc.MotionError):
+    """No observer configured -- a config bug, retrying never fixes it."""
+
+    pass
+
+
+class AltitudeLimitError(exc.MotionError):
+    """Destination altitude is below the configured limit -- an expected, deferrable condition
+    from a scheduler's point of view, not a failure to alert on."""
+
+    pass
+
+
+class BodyResolutionError(exc.MotionError):
+    """Could not resolve a named body's ephemeris -- transient/network-dependent (a Horizons
+    query), worth retrying."""
+
+    pass
+
+
+class InvalidOrbitalElementsError(exc.MotionError):
+    """Orbital elements are incomplete (neither mean_anomaly nor perihelion_time given) -- a
+    config/input bug, retrying never fixes it."""
+
+    pass
+
+
 def _solve_kepler_equation(mean_anomaly: float, eccentricity: float, tol: float = 1e-12, max_iter: int = 50) -> float:
     """Solves M = E - e*sin(E) for the eccentric anomaly E, via Newton-Raphson.
 
@@ -173,7 +200,7 @@ def _propagate_elements(elements: OrbitalElements, t: Time) -> tuple[float, floa
         nu = 2 * math.atan(d)
         r = q * (1 + d**2)
     else:
-        raise ValueError("OrbitalElements must set either mean_anomaly or perihelion_time.")
+        raise InvalidOrbitalElementsError("OrbitalElements must set either mean_anomaly or perihelion_time.")
 
     x_pf = r * math.cos(nu)
     y_pf = r * math.sin(nu)
@@ -287,12 +314,15 @@ class BaseTelescope(
             dec: Dec in deg to track.
 
         Raises:
+            NotSupportedError: If this telescope doesn't support RA/Dec pointing.
+            MissingObserverError: If no observer is configured.
+            AltitudeLimitError: If the destination is below the configured altitude limit.
             MoveError: If telescope cannot be moved.
         """
 
         # no RA/Dec telescope?
         if not isinstance(self, IPointingRaDec):
-            raise NotImplementedError
+            raise exc.NotSupportedError("This telescope does not support RA/Dec pointing.")
 
         # do nothing, if initializing, parking or parked
         if self.motion_status() in [MotionStatus.INITIALIZING, MotionStatus.PARKING, MotionStatus.PARKED]:
@@ -300,7 +330,7 @@ class BaseTelescope(
 
         # check observer
         if self.observer is None:
-            raise ValueError("No observer given.")
+            raise MissingObserverError("No observer given.")
 
         # to alt/az
         ra_dec = SkyCoord(ra * u.deg, dec * u.deg, frame=ICRS)
@@ -308,7 +338,7 @@ class BaseTelescope(
 
         # check altitude
         if alt_az.alt.degree < self._min_altitude:
-            raise ValueError(
+            raise AltitudeLimitError(
                 f"Destination altitude below limit: alt={alt_az.alt.degree:.2f}° "
                 f"az={alt_az.az.degree:.2f}° (min={self._min_altitude:.2f}°) for "
                 f"ra={ra:.5f}° dec={dec:.5f}° at {Time.now().isot} from "
@@ -376,12 +406,14 @@ class BaseTelescope(
             az: Az in deg to move to.
 
         Raises:
+            NotSupportedError: If this telescope doesn't support Alt/Az pointing.
+            AltitudeLimitError: If the destination is below the configured altitude limit.
             MoveError: If telescope cannot be moved.
         """
 
         # no Alt/Az telescope?
         if not isinstance(self, IPointingAltAz):
-            raise NotImplementedError
+            raise exc.NotSupportedError("This telescope does not support Alt/Az pointing.")
 
         # do nothing, if initializing, parking or parked
         if self.motion_status() in [MotionStatus.INITIALIZING, MotionStatus.PARKING, MotionStatus.PARKED]:
@@ -389,7 +421,7 @@ class BaseTelescope(
 
         # check altitude
         if alt < self._min_altitude:
-            raise ValueError(
+            raise AltitudeLimitError(
                 f"Destination altitude below limit: alt={alt:.2f}° az={az:.2f}° "
                 f"(min={self._min_altitude:.2f}°) at {Time.now().isot}."
             )
@@ -505,13 +537,13 @@ class BaseTelescope(
         try:
             return await loop.run_in_executor(None, _query)
         except Exception as e:
-            raise ValueError(f"Could not resolve body '{body}'.") from e
+            raise BodyResolutionError(f"Could not resolve body '{body}'.") from e
 
     async def _resolve_body(self, body: str) -> tuple[float, float]:
         """Resolves a body name to (ra, dec) in degrees, ICRS.
 
         Raises:
-            ValueError: If body name is not resolvable.
+            BodyResolutionError: If body name is not resolvable.
         """
         ra, dec, _, _ = await self._resolve_body_with_rate(body)
         return ra, dec
@@ -524,11 +556,12 @@ class BaseTelescope(
                   asteroid/comet designation known to JPL Horizons).
 
         Raises:
+            NotSupportedError: If this telescope doesn't support body tracking.
             MoveError: If telescope could not be moved.
-            ValueError: If body name is not resolvable.
+            BodyResolutionError: If body name is not resolvable.
         """
         if not isinstance(self, IPointingBody):
-            raise NotImplementedError
+            raise exc.NotSupportedError("This telescope does not support body tracking.")
         ra, dec = await self._resolve_body(body)
         await self.move_radec(ra, dec)
         self._tracked_body = body
@@ -544,13 +577,15 @@ class BaseTelescope(
             elements: Orbital elements of the body to track.
 
         Raises:
+            NotSupportedError: If this telescope doesn't support orbital-element tracking.
             MoveError: If telescope could not be moved.
-            ValueError: If elements are incomplete (neither mean_anomaly nor perihelion_time given).
+            InvalidOrbitalElementsError: If elements are incomplete (neither mean_anomaly nor
+                perihelion_time given).
         """
         if not isinstance(self, IPointingOrbitalElements):
-            raise NotImplementedError
+            raise exc.NotSupportedError("This telescope does not support orbital-element tracking.")
         if elements.mean_anomaly is None and elements.perihelion_time is None:
-            raise ValueError("OrbitalElements must set either mean_anomaly or perihelion_time.")
+            raise InvalidOrbitalElementsError("OrbitalElements must set either mean_anomaly or perihelion_time.")
         ra, dec = _propagate_elements(elements, Time.now())
         await self.move_radec(ra, dec)
         self._tracked_elements = elements

--- a/pyobs/modules/utils/dummymode.py
+++ b/pyobs/modules/utils/dummymode.py
@@ -8,6 +8,7 @@ from pyobs.events import ModeChangedEvent
 from pyobs.interfaces import IMode, IMotion, ModeCapabilities, ModeState
 from pyobs.mixins import MotionStatusMixin
 from pyobs.modules import Module
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import MotionStatus
 
 log = logging.getLogger(__name__)
@@ -55,13 +56,13 @@ class DummyMode(MotionStatusMixin, Module, IMode, IMotion):
             group: Name of the group to set the mode for.
 
         Raises:
-            ValueError: If an invalid mode or group was given.
+            InvalidArgumentError: If an invalid mode or group was given.
             MoveError: If mode selector cannot be moved.
         """
         if not group:
             group = next(iter(self._mode_options.keys()))
         if group not in self._mode_options:
-            raise ValueError(f"Invalid group: {group}")
+            raise exc.InvalidArgumentError(f"Invalid group: {group}")
         await self._change_motion_status(MotionStatus.SLEWING)
         try:
             await asyncio.wait_for(asyncio.shield(self._closing.wait()), timeout=3.0)

--- a/pyobs/modules/weather/mockweather.py
+++ b/pyobs/modules/weather/mockweather.py
@@ -7,6 +7,7 @@ from pyobs.interfaces import FitsHeaderEntry, IFitsHeaderBefore, IRunning, IWeat
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.modules.weather.weather import FITS_HEADERS, SENSOR_UNITS
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import WeatherSensors
 
 DEFAULT_SENSOR_VALUES: dict[WeatherSensors, float] = {
@@ -119,9 +120,12 @@ class MockWeather(Module, IWeather, IFitsHeaderBefore):
 
         Returns:
             Current reading for the given sensor.
+
+        Raises:
+            InvalidArgumentError: If sensor is unknown.
         """
         if sensor not in self._sensors:
-            raise ValueError(f"Unknown sensor: {sensor}")
+            raise exc.InvalidArgumentError(f"Unknown sensor: {sensor}")
 
         return WeatherSensorReading(sensor=sensor, value=self._sensors[sensor], unit=SENSOR_UNITS[sensor])
 

--- a/pyobs/modules/weather/weather.py
+++ b/pyobs/modules/weather/weather.py
@@ -12,10 +12,19 @@ from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.modules.weather.weather_api import WeatherApi
 from pyobs.modules.weather.weather_state import WeatherStatus
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import Unit, WeatherSensors
 from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
+
+
+class WeatherResponseError(exc.PyobsError):
+    """The weather station's API response was malformed or incomplete (missing an expected field)
+    -- plausibly transient (a flaky station/network), worth retrying, as opposed to a caller
+    passing a bad station/sensor name."""
+
+    pass
 
 
 FITS_HEADERS = {
@@ -167,6 +176,9 @@ class Weather(Module, IWeather, IFitsHeaderBefore):
 
         Returns:
             Current reading for the given sensor.
+
+        Raises:
+            WeatherResponseError: If the weather station's response is malformed.
         """
 
         # do request
@@ -174,7 +186,7 @@ class Weather(Module, IWeather, IFitsHeaderBefore):
 
         # to json
         if "time" not in status or "value" not in status:
-            raise ValueError("Time and/or value parameters not found in response from weather station.")
+            raise WeatherResponseError("Time and/or value parameters not found in response from weather station.")
 
         # return reading
         return WeatherSensorReading(

--- a/pyobs/robotic/scripts/__init__.py
+++ b/pyobs/robotic/scripts/__init__.py
@@ -1,3 +1,4 @@
+from .exceptions import ScriptError
 from .script import Script
 
-__all__ = ["Script"]
+__all__ = ["Script", "ScriptError"]

--- a/pyobs/robotic/scripts/exceptions.py
+++ b/pyobs/robotic/scripts/exceptions.py
@@ -1,0 +1,12 @@
+from pyobs.utils import exceptions as exc
+
+
+class ScriptError(exc.PyobsError):
+    """A script failed while running -- e.g. a proxy/network failure reaching a module it depends
+    on. Deliberately a single flat type rather than per-script leaves; mint a more specific one
+    only once a caller actually wants to distinguish a script's failure modes."""
+
+    pass
+
+
+__all__ = ["ScriptError"]

--- a/pyobs/robotic/scripts/imaging/autofocus.py
+++ b/pyobs/robotic/scripts/imaging/autofocus.py
@@ -28,6 +28,11 @@ class AutoFocusScript(Script):
             True if script can run now.
         """
 
+        # we need a target to focus on
+        if data is None or data.task is None or data.task.target is None:
+            self._cant_run_reason = "No target given."
+            return False
+
         # we need a camera
         if not await self.comm.has_proxy(self.autofocus, IAutoFocus):
             self._cant_run_reason = "No autofocus found."

--- a/pyobs/robotic/storage/lco/task.py
+++ b/pyobs/robotic/storage/lco/task.py
@@ -200,17 +200,17 @@ class LcoTask(Task):
                 state="FAILED", reason="Task execution was interrupted.", time_completed=script.exptime_done
             )
 
-        except exc.InvocationError as e:
-            if isinstance(e.exception, exc.AbortedError):
-                log.warning("Task execution was aborted: %s", e.exception)
-                config_status.finish(
-                    state="FAILED", reason="Task execution was aborted.", time_completed=script.exptime_done
-                )
-            else:
-                log.warning("Error during task execution: %s", e.exception)
-                config_status.finish(
-                    state="FAILED", reason="Error during task execution.", time_completed=script.exptime_done
-                )
+        except exc.AbortedError as e:
+            log.warning("Task execution was aborted: %s", e)
+            config_status.finish(
+                state="FAILED", reason="Task execution was aborted.", time_completed=script.exptime_done
+            )
+
+        except exc.PyobsError as e:
+            log.warning("Error during task execution: %s", e)
+            config_status.finish(
+                state="FAILED", reason="Error during task execution.", time_completed=script.exptime_done
+            )
 
         except Exception:
             log.exception("Something went wrong.")

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -122,6 +122,17 @@ class UnclassifiedError(PyobsError):
 
 #######################################
 
+# The hierarchy above this point is domain-level: each type means "the operation failed for
+# reason X," and per goal 5, domain exceptions deliberately multiply into fine-grained leaves so a
+# caller can react differently to each one. RemoteError and its subtree below are the other axis
+# entirely -- they mean "the call itself didn't reach/return" (a transport failure), not "the
+# remote operation failed for a domain reason." That distinction doesn't benefit from the same
+# fine-grained treatment: "the call failed to even happen" doesn't usually need to distinguish
+# *why* the way a domain failure does, so RemoteError's own subtree stays deliberately small.
+# A domain exception raised on the far side of an RPC call no longer travels through this
+# subtree at all (see rpc.py's fault reconstruction) -- it arrives as its own real type directly,
+# tagged with `remote_module`, not wrapped in a RemoteError.
+
 
 class RemoteError(PyobsError):
     """Exception for anything related to the communication between modules."""

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -110,6 +110,19 @@ class NotSupportedError(PyobsError):
     pass
 
 
+class InvalidArgumentError(PyobsError):
+    """The caller passed an argument this method rejects (unknown name, out-of-range value, ...).
+    Unlike a plain ValueError, this survives an RPC round trip as itself, so `except
+    exc.InvalidArgumentError:` around a proxy call actually catches it -- a bare ValueError would
+    silently degrade to UnclassifiedError the moment the call crosses XMPP, even though it works
+    fine locally (LocalComm, direct calls, tests), which is exactly the kind of inconsistency that
+    only shows up once code goes from a local test to a networked deployment. Deliberately one
+    type across every setter-shaped method, not split per method or per argument -- no caller
+    reacts differently to "unknown filter" vs. "invalid focus value."""
+
+    pass
+
+
 class UnclassifiedError(PyobsError):
     """Wraps an exception that isn't part of the deliberate PyobsError contract -- either it never
     was a PyobsError to begin with (a builtin, a vendor SDK exception) and escaped a module's own

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
 from collections.abc import Callable, Coroutine
 from typing import Any, NamedTuple
 
@@ -45,67 +43,59 @@ class PyobsError(Exception):
         return cls._registry.get(qualified_name)
 
 
-class _Meta(type):
-    """Metaclass for defining exceptions."""
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> PyobsError:
-        """Called when you call MyNewClass()"""
-        exception: PyobsError = type.__call__(cls, *args, **kwargs)
-        return handle_exception(exception)
-
-
 #######################################
 
 
-class ModuleError(PyobsError, metaclass=_Meta):
+class ModuleError(PyobsError):
     pass
 
 
-class GeneralError(PyobsError, metaclass=_Meta):
+class GeneralError(PyobsError):
     pass
 
 
-class ImageError(PyobsError, metaclass=_Meta):
+class ImageError(PyobsError):
     pass
 
 
-class MotionError(PyobsError, metaclass=_Meta):
+class MotionError(PyobsError):
     pass
 
 
-class InitError(MotionError, metaclass=_Meta):
+class InitError(MotionError):
     pass
 
 
-class ParkError(MotionError, metaclass=_Meta):
+class ParkError(MotionError):
     pass
 
 
-class MoveError(MotionError, metaclass=_Meta):
+class MoveError(MotionError):
     pass
 
 
-class GrabImageError(PyobsError, metaclass=_Meta):
+class GrabImageError(PyobsError):
     pass
 
 
-class AbortedError(PyobsError, metaclass=_Meta):
+class AbortedError(PyobsError):
     pass
 
 
-class FocusError(PyobsError, metaclass=_Meta):
+class FocusError(PyobsError):
     pass
 
 
-class AcquisitionError(PyobsError, metaclass=_Meta):
+class AcquisitionError(PyobsError):
     pass
 
 
-class UnclassifiedError(PyobsError, metaclass=_Meta):
-    """Wraps an exception that crossed an RPC boundary but couldn't be reconstructed as its real
-    type -- either it was never a PyobsError to begin with (a builtin, a vendor SDK exception), or
-    its defining module was never imported in this process. The original type name survives as
-    `original_type` even when the class itself doesn't."""
+class UnclassifiedError(PyobsError):
+    """Wraps an exception that isn't part of the deliberate PyobsError contract -- either it never
+    was a PyobsError to begin with (a builtin, a vendor SDK exception) and escaped a module's own
+    method body unconverted, or it crossed an RPC boundary and couldn't be reconstructed as its real
+    type because its defining module was never imported in this process. The original type name
+    survives as `original_type` even when the class itself doesn't."""
 
     pass
 
@@ -113,33 +103,23 @@ class UnclassifiedError(PyobsError, metaclass=_Meta):
 #######################################
 
 
-class RemoteError(PyobsError, metaclass=_Meta):
+class RemoteError(PyobsError):
     """Exception for anything related to the communication between modules."""
 
     pass
 
 
-class RemoteTimeoutError(RemoteError, metaclass=_Meta):
+class RemoteTimeoutError(RemoteError):
     pass
 
 
-class ForbiddenError(RemoteError, metaclass=_Meta):
+class ForbiddenError(RemoteError):
     """Raised when a caller is not permitted to invoke a method under the target module's ACL policy."""
 
     pass
 
 
 #######################################
-
-
-class SevereError(PyobsError):
-    """Severe exception that is raised after multiple raised other exceptions."""
-
-    def __init__(self, exception: PyobsError, module: str | None = None):
-        PyobsError.__init__(self, "A severe error has occurred.")
-        self.module = module
-        # never encapsulate a SevereError
-        self.exception: Exception = exception.exception if isinstance(exception, SevereError) else exception
 
 
 class LoggedException(NamedTuple):
@@ -153,155 +133,6 @@ class ExceptionHandler(NamedTuple):
     timespan: float | None = None
     module: str | None = None
     callback: Callable[[PyobsError], Coroutine[Any, Any, None]] | None = None
-    throw: bool = False
-
-
-#######################################
-
-
-_local_exceptions: dict[type[PyobsError], list[LoggedException]] = {}
-_remote_exceptions: dict[tuple[type[PyobsError], str], list[LoggedException]] = {}
-_handlers: list[ExceptionHandler] = []
-
-
-def clear() -> None:
-    _local_exceptions.clear()
-    _remote_exceptions.clear()
-    _handlers.clear()
-
-
-def register_exception(
-    exc_type: type[PyobsError],
-    limit: int,
-    timespan: float | None = None,
-    module: str | None = None,
-    callback: Callable[[PyobsError], Coroutine[Any, Any, None]] | None = None,
-    throw: bool = False,
-) -> None:
-    _handlers.append(ExceptionHandler(exc_type, limit, timespan, module, callback, throw))
-
-
-def handle_exception(exception: PyobsError) -> PyobsError:
-    # get module and store exception -- "remote_module" is set by the RPC layer when reconstructing
-    # a fault from another module (see rpc.py's _on_jabber_rpc_method_fault), not by local raises
-    module = getattr(exception, "remote_module", None)
-
-    # store exception itself
-    _store_exception(exception, module)
-
-    # if there is a child exception, store it as well
-    if hasattr(exception, "exception"):
-        _store_exception(getattr(exception, "exception"), module)
-
-    # now check, whether something is severe
-    triggered_handlers = _check_severity()
-
-    # filter triggered handlers by those that actually handle the exception
-    handlers = list(filter(lambda h: _matches(exception, h.exc_type), triggered_handlers))
-    if hasattr(exception, "exception"):
-        handlers += list(filter(lambda h: _matches(exception.exception, h.exc_type), triggered_handlers))
-
-    # check all handlers
-    for h in handlers:
-        # do we have a callback? then call it!
-        if h.callback is not None:
-            asyncio.create_task(h.callback(exception))
-
-    # if we got any handlers triggered and throw is set on any, escalate to a SevereError
-    if len(handlers) > 0 and any([h.throw for h in handlers]):
-        return SevereError(exception=exception, module=module)
-
-    # TODO: clean up old exceptions
-
-    # else just return exception itself
-    return exception
-
-
-def _matches(exception: Exception, exc_type: type[PyobsError]) -> bool:
-    """Whether `exception` should count as an instance of `exc_type` for severity-handler matching:
-    true isinstance, or -- mirroring _store_exception's RemoteError special case below -- anything
-    tagged with remote_module counts as a RemoteError even though its own type no longer literally
-    subclasses it now that faults raise as their real type instead of wrapped."""
-    if isinstance(exception, exc_type):
-        return True
-    return exc_type is RemoteError and getattr(exception, "remote_module", None) is not None
-
-
-def _store_exception(exception: PyobsError, module: str | None) -> None:
-    # get all classes from mro -- plus RemoteError if this crossed an RPC boundary (module is not
-    # None, i.e. the exception carries a remote_module tag from rpc.py's fault reconstruction), even
-    # though a directly-reraised domain type (e.g. GrabImageError) no longer subclasses RemoteError
-    # itself now that faults raise as their real type instead of wrapped (see rpc.py, Assessment §A).
-    # Preserves register_exception(exc.RemoteError, ..., module=X)-style "this module keeps failing
-    # remotely, regardless of the specific type" handlers (e.g. AutoFocusSeries).
-    classes: list[type] = list(type(exception).__mro__)
-    if module is not None and RemoteError not in classes:
-        classes.append(RemoteError)
-
-    for e in classes:
-        # only pyobs exceptions
-        if not issubclass(e, PyobsError):
-            continue
-
-        # is it handled by any handler?
-        if not any([e == h.exc_type for h in _handlers]):
-            continue
-
-        # log
-        le = LoggedException(time=time.time(), exception=exception)
-
-        # store it
-        if module is None:
-            # add to local exceptions
-            if e not in _local_exceptions:
-                _local_exceptions[e] = []
-            _local_exceptions[e].append(le)
-
-        else:
-            # add to remote exceptions
-            if (e, module) not in _remote_exceptions:
-                _remote_exceptions[e, module] = []
-            _remote_exceptions[e, module].append(le)
-
-
-def _check_severity() -> list[ExceptionHandler]:
-    """Checks all handlers against all raised exceptions and returns a list of triggered exception handlers.
-
-    Returns:
-        List of triggered handlers.
-    """
-
-    # loop all _handlers
-    triggered: list[ExceptionHandler] = []
-    for h in _handlers:
-        # get all exceptions that this handler deals with
-        exceptions = []
-        if h.module is None:
-            # add local exceptions
-            if h.exc_type in _local_exceptions:
-                exceptions.extend(_local_exceptions[h.exc_type])
-        else:
-            # add remote exceptions
-            if (h.exc_type, h.module) in _remote_exceptions:
-                exceptions.extend(_remote_exceptions[h.exc_type, h.module])
-
-        # got a timespan?
-        if h.timespan is None:
-            # count all
-            count = len(exceptions)
-
-        else:
-            # count all within timespan
-            earliest = time.time() - h.timespan
-            count = len(list(filter(lambda le: le.time >= earliest, exceptions)))
-
-        # more than limit?
-        if count >= h.limit:
-            # add to list
-            triggered.append(h)
-
-    # return full list
-    return triggered
 
 
 #######################################

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -12,12 +12,21 @@ TODO: Write docs
 __title__ = "Exceptions"
 
 
-class PyObsError(Exception):
+class PyobsError(Exception):
     """Base class for all exceptions"""
 
-    def __init__(self, message: str | None = None, logged: bool = False):
+    _registry: dict[str, type[PyobsError]] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        PyobsError._registry[f"{cls.__module__}.{cls.__qualname__}"] = cls
+
+    def __init__(self, message: str | None = None, **context: Any) -> None:
         self.message = message
-        self.logged = logged
+        self.logged = False
+        self.context = context
+        for key, value in context.items():
+            setattr(self, key, value)
 
     def __str__(self) -> str:
         msg = f"<{self.__class__.__name__}>"
@@ -31,32 +40,36 @@ class PyObsError(Exception):
         log.log(logging.getLevelName(level), message, **kwargs)
         self.logged = True
 
+    @classmethod
+    def resolve(cls, qualified_name: str) -> type[PyobsError] | None:
+        return cls._registry.get(qualified_name)
+
 
 class _Meta(type):
     """Metaclass for defining exceptions."""
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> PyObsError:
+    def __call__(cls, *args: Any, **kwargs: Any) -> PyobsError:
         """Called when you call MyNewClass()"""
-        exception: PyObsError = type.__call__(cls, *args, **kwargs)
+        exception: PyobsError = type.__call__(cls, *args, **kwargs)
         return handle_exception(exception)
 
 
 #######################################
 
 
-class ModuleError(PyObsError, metaclass=_Meta):
+class ModuleError(PyobsError, metaclass=_Meta):
     pass
 
 
-class GeneralError(PyObsError, metaclass=_Meta):
+class GeneralError(PyobsError, metaclass=_Meta):
     pass
 
 
-class ImageError(PyObsError, metaclass=_Meta):
+class ImageError(PyobsError, metaclass=_Meta):
     pass
 
 
-class MotionError(PyObsError, metaclass=_Meta):
+class MotionError(PyobsError, metaclass=_Meta):
     pass
 
 
@@ -72,74 +85,58 @@ class MoveError(MotionError, metaclass=_Meta):
     pass
 
 
-class GrabImageError(PyObsError, metaclass=_Meta):
+class GrabImageError(PyobsError, metaclass=_Meta):
     pass
 
 
-class AbortedError(PyObsError, metaclass=_Meta):
+class AbortedError(PyobsError, metaclass=_Meta):
     pass
 
 
-class FocusError(PyObsError, metaclass=_Meta):
+class FocusError(PyobsError, metaclass=_Meta):
     pass
 
 
-class AcquisitionError(PyObsError, metaclass=_Meta):
+class AcquisitionError(PyobsError, metaclass=_Meta):
+    pass
+
+
+class UnclassifiedError(PyobsError, metaclass=_Meta):
+    """Wraps an exception that crossed an RPC boundary but couldn't be reconstructed as its real
+    type -- either it was never a PyobsError to begin with (a builtin, a vendor SDK exception), or
+    its defining module was never imported in this process. The original type name survives as
+    `original_type` even when the class itself doesn't."""
+
     pass
 
 
 #######################################
 
 
-class RemoteError(PyObsError, metaclass=_Meta):
+class RemoteError(PyobsError, metaclass=_Meta):
     """Exception for anything related to the communication between modules."""
 
-    def __init__(self, module: str, message: str | None = None):
-        PyObsError.__init__(self, message)
-        self.module = module
+    pass
 
 
 class RemoteTimeoutError(RemoteError, metaclass=_Meta):
     pass
 
 
-class InvocationError(RemoteError, metaclass=_Meta):
-    """Remote exception encapsulating basic exception from other module"""
-
-    def __init__(self, module: str, exception: Exception):
-        RemoteError.__init__(self, module, None)
-        self.module = module
-
-        # never encapsulate a SevereError
-        self.exception: Exception = exception.exception if isinstance(exception, SevereError) else exception
-
-    def __str__(self) -> str:
-        msg = f"<InvocationError> ({self.exception.__class__.__name__})"
-        if hasattr(self.exception, "message"):
-            if self.exception.message is not None:
-                msg += f" {self.exception.message}"
-        else:
-            msg += f": {str(self.exception)}"
-        return msg
-
-
 class ForbiddenError(RemoteError, metaclass=_Meta):
     """Raised when a caller is not permitted to invoke a method under the target module's ACL policy."""
 
-    def __init__(self, sender: str, method: str):
-        RemoteError.__init__(self, sender, f"Caller '{sender}' is not permitted to invoke '{method}'.")
-        self.sender = sender
-        self.method = method
+    pass
 
 
 #######################################
 
 
-class SevereError(PyObsError):
+class SevereError(PyobsError):
     """Severe exception that is raised after multiple raised other exceptions."""
 
-    def __init__(self, exception: PyObsError, module: str | None = None):
-        PyObsError.__init__(self, "A severe error has occurred.")
+    def __init__(self, exception: PyobsError, module: str | None = None):
+        PyobsError.__init__(self, "A severe error has occurred.")
         self.module = module
         # never encapsulate a SevereError
         self.exception: Exception = exception.exception if isinstance(exception, SevereError) else exception
@@ -147,23 +144,23 @@ class SevereError(PyObsError):
 
 class LoggedException(NamedTuple):
     time: float
-    exception: PyObsError
+    exception: PyobsError
 
 
 class ExceptionHandler(NamedTuple):
-    exc_type: type[PyObsError]
+    exc_type: type[PyobsError]
     limit: int
     timespan: float | None = None
     module: str | None = None
-    callback: Callable[[PyObsError], Coroutine[Any, Any, None]] | None = None
+    callback: Callable[[PyobsError], Coroutine[Any, Any, None]] | None = None
     throw: bool = False
 
 
 #######################################
 
 
-_local_exceptions: dict[type[PyObsError], list[LoggedException]] = {}
-_remote_exceptions: dict[tuple[type[PyObsError], str], list[LoggedException]] = {}
+_local_exceptions: dict[type[PyobsError], list[LoggedException]] = {}
+_remote_exceptions: dict[tuple[type[PyobsError], str], list[LoggedException]] = {}
 _handlers: list[ExceptionHandler] = []
 
 
@@ -174,19 +171,20 @@ def clear() -> None:
 
 
 def register_exception(
-    exc_type: type[PyObsError],
+    exc_type: type[PyobsError],
     limit: int,
     timespan: float | None = None,
     module: str | None = None,
-    callback: Callable[[PyObsError], Coroutine[Any, Any, None]] | None = None,
+    callback: Callable[[PyobsError], Coroutine[Any, Any, None]] | None = None,
     throw: bool = False,
 ) -> None:
     _handlers.append(ExceptionHandler(exc_type, limit, timespan, module, callback, throw))
 
 
-def handle_exception(exception: PyObsError) -> PyObsError:
-    # get module and store exception
-    module = exception.module if isinstance(exception, InvocationError) else None
+def handle_exception(exception: PyobsError) -> PyobsError:
+    # get module and store exception -- "remote_module" is set by the RPC layer when reconstructing
+    # a fault from another module (see rpc.py's _on_jabber_rpc_method_fault), not by local raises
+    module = getattr(exception, "remote_module", None)
 
     # store exception itself
     _store_exception(exception, module)
@@ -199,9 +197,9 @@ def handle_exception(exception: PyObsError) -> PyObsError:
     triggered_handlers = _check_severity()
 
     # filter triggered handlers by those that actually handle the exception
-    handlers = list(filter(lambda h: isinstance(exception, h.exc_type), triggered_handlers))
+    handlers = list(filter(lambda h: _matches(exception, h.exc_type), triggered_handlers))
     if hasattr(exception, "exception"):
-        handlers += list(filter(lambda h: isinstance(exception.exception, h.exc_type), triggered_handlers))
+        handlers += list(filter(lambda h: _matches(exception.exception, h.exc_type), triggered_handlers))
 
     # check all handlers
     for h in handlers:
@@ -219,11 +217,30 @@ def handle_exception(exception: PyObsError) -> PyObsError:
     return exception
 
 
-def _store_exception(exception: PyObsError, module: str | None) -> None:
-    # get all classes from mro
-    for e in type(exception).__mro__:
+def _matches(exception: Exception, exc_type: type[PyobsError]) -> bool:
+    """Whether `exception` should count as an instance of `exc_type` for severity-handler matching:
+    true isinstance, or -- mirroring _store_exception's RemoteError special case below -- anything
+    tagged with remote_module counts as a RemoteError even though its own type no longer literally
+    subclasses it now that faults raise as their real type instead of wrapped."""
+    if isinstance(exception, exc_type):
+        return True
+    return exc_type is RemoteError and getattr(exception, "remote_module", None) is not None
+
+
+def _store_exception(exception: PyobsError, module: str | None) -> None:
+    # get all classes from mro -- plus RemoteError if this crossed an RPC boundary (module is not
+    # None, i.e. the exception carries a remote_module tag from rpc.py's fault reconstruction), even
+    # though a directly-reraised domain type (e.g. GrabImageError) no longer subclasses RemoteError
+    # itself now that faults raise as their real type instead of wrapped (see rpc.py, Assessment §A).
+    # Preserves register_exception(exc.RemoteError, ..., module=X)-style "this module keeps failing
+    # remotely, regardless of the specific type" handlers (e.g. AutoFocusSeries).
+    classes: list[type] = list(type(exception).__mro__)
+    if module is not None and RemoteError not in classes:
+        classes.append(RemoteError)
+
+    for e in classes:
         # only pyobs exceptions
-        if not issubclass(e, PyObsError):
+        if not issubclass(e, PyobsError):
             continue
 
         # is it handled by any handler?

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -90,6 +90,26 @@ class AcquisitionError(PyobsError):
     pass
 
 
+class DeviceBusyError(PyobsError):
+    """The device can't service this request right now because it's already busy with another
+    operation (e.g. an exposure/sequence already running, or another motion in progress) -- back
+    off and retry, as opposed to GrabImageError/MoveError/etc., which mean the operation was
+    actually attempted and failed. Deliberately one type across camera/telescope/roof/focuser
+    modules alike, not split by device or by which specific operation was busy -- no caller reacts
+    differently to those variants."""
+
+    pass
+
+
+class NotSupportedError(PyobsError):
+    """This module doesn't support the requested operation at all -- a capability the module only
+    optionally implements (e.g. an alt/az-only telescope asked to move_radec) isn't available,
+    as opposed to a specific attempt at that operation failing. Cross-cutting: any module with an
+    optional-capability mixin can raise this, not just telescopes."""
+
+    pass
+
+
 class UnclassifiedError(PyobsError):
     """Wraps an exception that isn't part of the deliberate PyobsError contract -- either it never
     was a PyobsError to begin with (a builtin, a vendor SDK exception) and escaped a module's own

--- a/pyobs/utils/threads/__init__.py
+++ b/pyobs/utils/threads/__init__.py
@@ -1,3 +1,3 @@
-from .lockwithabort import AcquireLockFailed, LockWithAbort
+from .lockwithabort import LockWithAbort
 
-__all__ = ["LockWithAbort", "AcquireLockFailed"]
+__all__ = ["LockWithAbort"]

--- a/pyobs/utils/threads/lockwithabort.py
+++ b/pyobs/utils/threads/lockwithabort.py
@@ -2,13 +2,10 @@ import asyncio
 import logging
 from typing import Any
 
+from pyobs.utils import exceptions as exc
 from pyobs.utils.parallel import acquire_lock
 
 log = logging.getLogger(__name__)
-
-
-class AcquireLockFailed(Exception):
-    pass
 
 
 class LockWithAbort:
@@ -33,8 +30,8 @@ class LockWithAbort:
 
             # still not successful?
             if not self.acquired:
-                # raise exception
-                raise AcquireLockFailed()
+                # the device is already busy handling another motion request -- back off and retry
+                raise exc.DeviceBusyError("Could not acquire lock.")
 
         # got lock, so unset abort and remember that we were successful
         self.event.clear()
@@ -46,4 +43,4 @@ class LockWithAbort:
             self.acquired = False
 
 
-__all__ = ["LockWithAbort", "AcquireLockFailed"]
+__all__ = ["LockWithAbort"]

--- a/tests/comm/test_rpc_serialization.py
+++ b/tests/comm/test_rpc_serialization.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 from slixmpp.xmlstream import ET
 
-from pyobs.comm.xmpp.rpc import _NS, _PYOBS_NS, params_to_xml, xml_to_params
+from pyobs.comm.xmpp.rpc import _NS, _PYOBS_NS, fault_to_xml, params_to_xml, xml_to_fault, xml_to_params
+from pyobs.utils import exceptions as exc
 
 
 class TestXmlToParams:
@@ -38,3 +39,26 @@ class TestXmlToParams:
         params.append(param)
         with pytest.raises(ValueError, match=_PYOBS_NS):
             xml_to_params(params, ["x"], {"x": int})
+
+
+class TestFaultXml:
+    """Test fault_to_xml/xml_to_fault, and that the round-tripped name resolves via the registry."""
+
+    def test_round_trip_uses_fully_qualified_name(self) -> None:
+        fault_elem = fault_to_xml(exc.FocusError("could not focus"))
+        exc_name, msg = xml_to_fault(fault_elem)
+        assert exc_name == "pyobs.utils.exceptions.FocusError"
+        assert msg == "<FocusError> could not focus"
+        assert exc.PyobsError.resolve(exc_name) is exc.FocusError
+
+    def test_missing_value_element_falls_back_to_remote_error(self) -> None:
+        fault = ET.Element(f"{{{_NS}}}fault")
+        exc_name, msg = xml_to_fault(fault)
+        assert exc_name == "pyobs.utils.exceptions.RemoteError"
+        assert msg == "Unknown error"
+        assert exc.PyobsError.resolve(exc_name) is exc.RemoteError
+
+    def test_unresolvable_name_has_no_registry_entry(self) -> None:
+        # a builtin, or a domain type whose defining module was never imported here
+        assert exc.PyobsError.resolve("builtins.ValueError") is None
+        assert exc.PyobsError.resolve("some.module.that.was.never.imported.WeatherDataError") is None

--- a/tests/comm/test_rpc_serialization.py
+++ b/tests/comm/test_rpc_serialization.py
@@ -48,8 +48,32 @@ class TestFaultXml:
         fault_elem = fault_to_xml(exc.FocusError("could not focus"))
         exc_name, msg = xml_to_fault(fault_elem)
         assert exc_name == "pyobs.utils.exceptions.FocusError"
-        assert msg == "<FocusError> could not focus"
+        assert msg == "could not focus"
         assert exc.PyobsError.resolve(exc_name) is exc.FocusError
+
+    def test_round_trip_message_is_raw_not_str_formatted(self) -> None:
+        # str(exception) is "<ClassName> message" -- serializing that instead of the raw message
+        # would double up once the caller's own __str__ formats the reconstructed instance again
+        fault_elem = fault_to_xml(exc.FocusError("could not focus"))
+        _, msg = xml_to_fault(fault_elem)
+        reconstructed = exc.FocusError(msg, remote_module="camera")
+        assert str(reconstructed) == "<FocusError> could not focus"
+
+    def test_unclassified_error_serializes_original_type_not_its_own_class_name(self) -> None:
+        # Module.execute() wraps a non-PyobsError as UnclassifiedError(original_type=...) before
+        # it ever reaches rpc.py -- the wire must carry the *original* type, not "UnclassifiedError"
+        # itself, or original_type is silently lost for the caller (it's not a wire-serialized
+        # attribute, only the class name and message are)
+        wrapped = exc.UnclassifiedError("Invalid destination", original_type="builtins.IndexError")
+        fault_elem = fault_to_xml(wrapped)
+        exc_name, msg = xml_to_fault(fault_elem)
+        assert exc_name == "builtins.IndexError"
+        assert msg == "Invalid destination"
+        assert exc.PyobsError.resolve(exc_name) is None  # builtins are never registered
+
+        # caller-side reconstruction (mirroring _on_jabber_rpc_method_fault's fallback branch)
+        reconstructed = exc.UnclassifiedError(msg, original_type=exc_name, remote_module="camera")
+        assert reconstructed.original_type == "builtins.IndexError"
 
     def test_missing_value_element_falls_back_to_remote_error(self) -> None:
         fault = ET.Element(f"{{{_NS}}}fault")

--- a/tests/integration/test_xmpp_rpc.py
+++ b/tests/integration/test_xmpp_rpc.py
@@ -143,7 +143,7 @@ async def test_rpc_exception_fault(make_xmpp_comm, make_camera_comm) -> None:
 
             async with observer_comm.proxy("camera", IExposure) as cam:
                 # abort_exposure when not exposing should raise
-                with pytest.raises((exc.RemoteError, exc.InvocationError, Exception)):
+                with pytest.raises((exc.RemoteError, exc.PyobsError, Exception)):
                     await cam.abort_exposure()
 
         finally:

--- a/tests/modules/camera/test_basecamera.py
+++ b/tests/modules/camera/test_basecamera.py
@@ -1,10 +1,31 @@
+import asyncio
+
 import pytest
 from astropy.io import fits
 
 from pyobs.events import BadWeatherEvent
 from pyobs.modules.camera import DummyCamera
+from pyobs.utils import exceptions as exc
 
 pytest_plugins = ("pytest_asyncio",)
+
+
+@pytest.mark.asyncio
+async def test_aborted_exposure_raises_aborted_error():
+    """DummyCamera's _expose() must raise AbortedError, not some guessed builtin, when cancelled
+    via abort_event -- see DESIGN_exception_handling.md's AbortedError contract."""
+    camera = DummyCamera()
+    await camera.open()
+    await camera.set_exposure_time(0.5)
+
+    task = asyncio.create_task(camera.grab_data())
+    await asyncio.sleep(0.1)
+    await camera.abort()
+
+    with pytest.raises(exc.AbortedError):
+        await task
+
+    await camera.close()
 
 
 @pytest.mark.asyncio

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -11,6 +11,7 @@ from pyobs.events import NewImageEvent
 from pyobs.interfaces import IImageType, IVideo
 from pyobs.modules import Module
 from pyobs.modules.camera.basevideo import BaseVideo, ImageRequest, LastImage, NextImage
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ImageType
 
 
@@ -469,7 +470,7 @@ async def test_grab_data_raises_when_never_gets_filename() -> None:
 
     asyncio.create_task(fulfill_with_no_filename())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.GrabImageError):
         await bv.grab_data()
 
 

--- a/tests/modules/camera/test_grab_sequence.py
+++ b/tests/modules/camera/test_grab_sequence.py
@@ -95,7 +95,7 @@ async def test_grab_sequence_pushes_progressing_state() -> None:
 @pytest.mark.asyncio
 async def test_grab_sequence_rejects_zero_count() -> None:
     camera = make_camera()
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.InvalidArgumentError):
         await camera.grab_sequence(0)
 
 
@@ -189,7 +189,7 @@ async def test_grab_sequence_skips_delay_after_last_grab() -> None:
 @pytest.mark.asyncio
 async def test_grab_sequence_rejects_negative_delay() -> None:
     camera = make_camera()
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.InvalidArgumentError):
         await camera.grab_sequence(2, delay=-1)
 
 

--- a/tests/modules/camera/test_grab_sequence.py
+++ b/tests/modules/camera/test_grab_sequence.py
@@ -14,7 +14,7 @@ import pytest
 
 from pyobs.interfaces import IDataSequence
 from pyobs.modules.camera import DummyCamera
-from pyobs.modules.camera.basecamera import CameraException
+from pyobs.utils import exceptions as exc
 
 
 def make_camera() -> DummyCamera:
@@ -111,7 +111,7 @@ async def test_grab_sequence_rejects_while_already_running() -> None:
     camera.grab_data = fake_grab_data
 
     await camera.grab_sequence(3)
-    with pytest.raises(CameraException):
+    with pytest.raises(exc.DeviceBusyError):
         await camera.grab_sequence(2)
 
     gate.set()

--- a/tests/modules/flatfield/test_flatfield.py
+++ b/tests/modules/flatfield/test_flatfield.py
@@ -20,6 +20,7 @@ from pyobs.interfaces.IBinning import Binning
 from pyobs.modules import Module
 from pyobs.modules.flatfield.flatfield import FlatField
 from pyobs.robotic.utils.skyflats import FlatFielder
+from pyobs.utils import exceptions as exc
 from tests.helpers import make_proxy_cm
 
 
@@ -248,7 +249,7 @@ async def test_flat_field_raises_when_already_running() -> None:
     task = asyncio.create_task(ff.flat_field())
     await asyncio.sleep(0.05)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.DeviceBusyError):
         await ff.flat_field()
 
     block.set()

--- a/tests/modules/flatfield/test_scheduler.py
+++ b/tests/modules/flatfield/test_scheduler.py
@@ -10,6 +10,7 @@ from pyobs.interfaces import IBinning, IFilters, IFlatField
 from pyobs.modules.flatfield.scheduler import FlatFieldScheduler
 from pyobs.robotic.utils.skyflats.priorities.base import SkyflatPriorities
 from pyobs.robotic.utils.skyflats.scheduler import Scheduler, SchedulerItem
+from pyobs.utils import exceptions as exc
 from tests.helpers import make_proxy_cm
 
 
@@ -68,7 +69,7 @@ async def test_run_raises_when_already_running() -> None:
     task = asyncio.create_task(module.run())
     await asyncio.sleep(0.05)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.DeviceBusyError):
         await module.run()
 
     block.set()

--- a/tests/modules/focus/test_focusmodel.py
+++ b/tests/modules/focus/test_focusmodel.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyobs.interfaces import IFocusModel, IWeather, OptimalFocusState, WeatherSensorReading
 from pyobs.modules import Module
-from pyobs.modules.focus.focusmodel import FocusModel
+from pyobs.modules.focus.focusmodel import FocusModel, WeatherDataError
 from pyobs.utils.enums import WeatherSensors
 
 
@@ -33,7 +33,7 @@ async def test_get_values_raises_on_none_value() -> None:
     weather = _weather_mock(None)
     fm = FocusModel(weather=weather, model="temp")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(WeatherDataError):
         await fm._get_values()
 
 

--- a/tests/modules/robotic/test_scriptrunner.py
+++ b/tests/modules/robotic/test_scriptrunner.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyobs.comm import Comm
+from pyobs.modules.robotic.scriptrunner import ScriptRunner
+from pyobs.robotic.scripts import Script, ScriptError
+from pyobs.utils import exceptions as exc
+
+
+class _RaisingScript(Script):
+    exc_to_raise: str = "runtime"
+
+    async def run(self, data) -> None:
+        if self.exc_to_raise == "domain":
+            raise exc.AbortedError("aborted")
+        raise RuntimeError("boom")
+
+
+def make_runner(exc_to_raise: str = "runtime") -> ScriptRunner:
+    comm = MagicMock(spec=Comm)
+    return ScriptRunner(
+        script={"class": f"{_RaisingScript.__module__}._RaisingScript", "exc_to_raise": exc_to_raise}, comm=comm
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_wraps_untyped_exception_as_script_error() -> None:
+    runner = make_runner("runtime")
+    with pytest.raises(ScriptError):
+        await runner.run()
+
+
+@pytest.mark.asyncio
+async def test_run_lets_domain_exception_through_unwrapped() -> None:
+    runner = make_runner("domain")
+    with pytest.raises(exc.AbortedError):
+        await runner.run()

--- a/tests/modules/telescope/test_basetelescope.py
+++ b/tests/modules/telescope/test_basetelescope.py
@@ -8,6 +8,7 @@ from astroplan import Observer
 from pyobs.interfaces import OrbitalElements
 from pyobs.modules.telescope import DummyRaDecTelescope
 from pyobs.modules.telescope.basetelescope import (
+    InvalidOrbitalElementsError,
     _orbital_plane_to_ecliptic_cartesian,
     _propagate_elements,
     _solve_barker_equation,
@@ -116,7 +117,7 @@ def test_propagate_elements_requires_mean_anomaly_or_perihelion_time():
         longitude_ascending_node=10.0,
         argument_of_periapsis=20.0,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidOrbitalElementsError):
         _propagate_elements(elements, Time("2024-01-01T00:00:00"))
 
 

--- a/tests/modules/telescope/test_dummyradectelescope.py
+++ b/tests/modules/telescope/test_dummyradectelescope.py
@@ -21,6 +21,7 @@ from pyobs.modules.telescope.basetelescope import (
     BodyResolutionError,
 )
 from pyobs.modules.telescope.dummyradectelescope import DummyRaDecTelescope
+from pyobs.utils import exceptions as exc
 
 
 def make_dummyradectelescope(**kwargs) -> DummyRaDecTelescope:
@@ -56,7 +57,7 @@ async def test_set_tracking_mode_valid_updates_state():
 @pytest.mark.asyncio
 async def test_set_tracking_mode_invalid_raises_and_does_not_change_state():
     tel = make_dummyradectelescope()
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.InvalidArgumentError):
         await tel.set_tracking_mode("bogus")  # type: ignore[arg-type]
     assert tel._tracking_mode == TrackingMode.OFF
 

--- a/tests/modules/telescope/test_dummyradectelescope.py
+++ b/tests/modules/telescope/test_dummyradectelescope.py
@@ -18,6 +18,7 @@ from pyobs.interfaces import (
 from pyobs.modules.telescope.basetelescope import (
     _DEFAULT_REFRESH_INTERVAL_SECONDS,
     _MOON_FALLBACK_REFRESH_INTERVAL_SECONDS,
+    BodyResolutionError,
 )
 from pyobs.modules.telescope.dummyradectelescope import DummyRaDecTelescope
 
@@ -160,7 +161,7 @@ async def test_track_body_moon_slews_and_uses_native_lunar_mode():
 
 
 @pytest.mark.asyncio
-async def test_track_body_unresolvable_raises_value_error():
+async def test_track_body_unresolvable_raises_body_resolution_error():
     tel = make_dummyradectelescope(speed=100000.0)
 
     def _raise(*args, **kwargs):
@@ -168,7 +169,7 @@ async def test_track_body_unresolvable_raises_value_error():
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("pyobs.modules.telescope.basetelescope.Horizons", MagicMock(side_effect=_raise))
-        with pytest.raises(ValueError):
+        with pytest.raises(BodyResolutionError):
             await tel.track_body("definitely-not-a-real-body-xyz")
 
 

--- a/tests/modules/test_exception_logging.py
+++ b/tests/modules/test_exception_logging.py
@@ -34,6 +34,32 @@ async def test_domain_exception_logs_as_info_without_traceback_by_default(caplog
 
 
 @pytest.mark.asyncio
+async def test_call_id_is_attached_to_the_exception_and_included_in_the_log_line(caplog):
+    module = _AbortableModule(exc.FocusError("could not focus"))
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.FocusError) as exc_info:
+            await module.execute("abort", sender="tester", call_id="42")
+
+    assert exc_info.value.call_id == "42"
+    record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
+    assert "call_id=42" in record.message
+
+
+@pytest.mark.asyncio
+async def test_call_id_omitted_from_log_line_when_not_given(caplog):
+    module = _AbortableModule(exc.FocusError("could not focus"))
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.FocusError) as exc_info:
+            await module.execute("abort", sender="tester")
+
+    assert exc_info.value.call_id is None
+    record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
+    assert "call_id" not in record.message
+
+
+@pytest.mark.asyncio
 async def test_module_error_always_logs_as_error_with_traceback(caplog):
     module = _AbortableModule(exc.ModuleError("broken"))
 

--- a/tests/modules/test_exception_logging.py
+++ b/tests/modules/test_exception_logging.py
@@ -1,0 +1,95 @@
+import logging
+from typing import Any
+
+import pytest
+
+from pyobs.interfaces import IAbortable
+from pyobs.modules import Module
+from pyobs.utils import exceptions as exc
+
+
+def setup_function() -> None:
+    # isolate from any severity-escalation handlers other test modules may have registered --
+    # register_exception's state is process-global (see DESIGN_exception_handling.md's Assessment §C)
+    exc.clear()
+
+
+class _AbortableModule(Module, IAbortable):
+    """Minimal test module whose abort() raises whatever exception it's given."""
+
+    def __init__(self, to_raise: Exception, **kwargs: Any):
+        Module.__init__(self, **kwargs)
+        self._to_raise = to_raise
+
+    async def abort(self, **kwargs: Any) -> None:
+        raise self._to_raise
+
+
+@pytest.mark.asyncio
+async def test_domain_exception_logs_as_info_without_traceback_by_default(caplog):
+    module = _AbortableModule(exc.FocusError("could not focus"))
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.FocusError):
+            await module.execute("abort", sender="tester")
+
+    record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
+    assert record.levelname == "INFO"
+    assert not record.exc_info
+
+
+@pytest.mark.asyncio
+async def test_module_error_always_logs_as_error_with_traceback(caplog):
+    module = _AbortableModule(exc.ModuleError("broken"))
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.ModuleError):
+            await module.execute("abort", sender="tester")
+
+    record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
+    assert record.levelname == "ERROR"
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_severe_error_always_logs_as_error_with_traceback(caplog):
+    module = _AbortableModule(exc.SevereError(exception=exc.FocusError("could not focus")))
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.SevereError):
+            await module.execute("abort", sender="tester")
+
+    record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
+    assert record.levelname == "ERROR"
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_disable_exception_logging_suppresses_the_local_line(caplog):
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    module._disable_exception_logging(exc.FocusError)
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(exc.FocusError):
+            await module.execute("abort", sender="tester")
+
+    assert not any("Exception was raised in call to abort" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_disable_exception_logging_covers_subclasses():
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    module._disable_exception_logging(exc.PyObsError)
+    assert isinstance(exc.FocusError("x"), module._disabled_exception_logging)
+
+
+def test_disable_exception_logging_rejects_module_error():
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    with pytest.raises(ValueError):
+        module._disable_exception_logging(exc.ModuleError)
+
+
+def test_disable_exception_logging_rejects_severe_error():
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    with pytest.raises(ValueError):
+        module._disable_exception_logging(exc.SevereError)

--- a/tests/modules/test_exception_logging.py
+++ b/tests/modules/test_exception_logging.py
@@ -79,7 +79,7 @@ async def test_disable_exception_logging_suppresses_the_local_line(caplog):
 @pytest.mark.asyncio
 async def test_disable_exception_logging_covers_subclasses():
     module = _AbortableModule(exc.FocusError("could not focus"))
-    module._disable_exception_logging(exc.PyObsError)
+    module._disable_exception_logging(exc.PyobsError)
     assert isinstance(exc.FocusError("x"), module._disabled_exception_logging)
 
 

--- a/tests/modules/test_exception_logging.py
+++ b/tests/modules/test_exception_logging.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -6,12 +7,6 @@ import pytest
 from pyobs.interfaces import IAbortable
 from pyobs.modules import Module
 from pyobs.utils import exceptions as exc
-
-
-def setup_function() -> None:
-    # isolate from any severity-escalation handlers other test modules may have registered --
-    # register_exception's state is process-global (see DESIGN_exception_handling.md's Assessment §C)
-    exc.clear()
 
 
 class _AbortableModule(Module, IAbortable):
@@ -52,13 +47,16 @@ async def test_module_error_always_logs_as_error_with_traceback(caplog):
 
 
 @pytest.mark.asyncio
-async def test_severe_error_always_logs_as_error_with_traceback(caplog):
-    module = _AbortableModule(exc.SevereError(exception=exc.FocusError("could not focus")))
+async def test_non_pyobs_error_is_wrapped_as_unclassified_and_logs_as_error_with_traceback(caplog):
+    # a raw builtin (or vendor SDK exception) wasn't part of the deliberate PyobsError contract --
+    # it always logs loud, and the caller receives UnclassifiedError, not the original type
+    module = _AbortableModule(ValueError("driver blew up"))
 
     with caplog.at_level(logging.INFO):
-        with pytest.raises(exc.SevereError):
+        with pytest.raises(exc.UnclassifiedError) as exc_info:
             await module.execute("abort", sender="tester")
 
+    assert exc_info.value.original_type == "builtins.ValueError"
     record = next(r for r in caplog.records if "Exception was raised in call to abort" in r.message)
     assert record.levelname == "ERROR"
     assert record.exc_info is not None
@@ -89,7 +87,128 @@ def test_disable_exception_logging_rejects_module_error():
         module._disable_exception_logging(exc.ModuleError)
 
 
-def test_disable_exception_logging_rejects_severe_error():
+def test_disable_exception_logging_rejects_unclassified_error():
     module = _AbortableModule(exc.FocusError("could not focus"))
     with pytest.raises(ValueError):
-        module._disable_exception_logging(exc.SevereError)
+        module._disable_exception_logging(exc.UnclassifiedError)
+
+
+@pytest.mark.asyncio
+async def test_execute_never_substitutes_the_raised_type() -> None:
+    # no more construction-time metaclass magic: raising FocusError always raises FocusError,
+    # however many times it recurs -- severity escalation only ever fires a callback now
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    module._register_exception(exc.FocusError, 2, callback=None)
+
+    for _ in range(5):
+        with pytest.raises(exc.FocusError):
+            await module.execute("abort", sender="tester")
+
+
+@pytest.mark.asyncio
+async def test_register_exception_fires_callback_after_limit_reached() -> None:
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    seen = []
+
+    async def callback(exception: exc.PyobsError) -> None:
+        seen.append(exception)
+
+    module._register_exception(exc.FocusError, 2, callback=callback)
+
+    with pytest.raises(exc.FocusError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert seen == []
+
+    with pytest.raises(exc.FocusError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert len(seen) == 1
+    assert isinstance(seen[0], exc.FocusError)
+
+
+@pytest.mark.asyncio
+async def test_register_exception_respects_timespan() -> None:
+    module = _AbortableModule(exc.FocusError("could not focus"))
+    seen = []
+
+    async def callback(exception: exc.PyobsError) -> None:
+        seen.append(exception)
+
+    module._register_exception(exc.FocusError, 2, timespan=0.05, callback=callback)
+
+    with pytest.raises(exc.FocusError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.1)  # first occurrence ages out of the timespan
+
+    with pytest.raises(exc.FocusError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert seen == []  # only one occurrence within the timespan, limit not reached
+
+
+@pytest.mark.asyncio
+async def test_register_exception_is_instance_scoped_not_shared_across_modules() -> None:
+    # two Module instances watching the same exception type must not share counters
+    module_a = _AbortableModule(exc.FocusError("could not focus"))
+    module_b = _AbortableModule(exc.FocusError("could not focus"))
+    seen_a: list[exc.PyobsError] = []
+    seen_b: list[exc.PyobsError] = []
+
+    async def callback_a(exception: exc.PyobsError) -> None:
+        seen_a.append(exception)
+
+    async def callback_b(exception: exc.PyobsError) -> None:
+        seen_b.append(exception)
+
+    module_a._register_exception(exc.FocusError, 2, callback=callback_a)
+    module_b._register_exception(exc.FocusError, 2, callback=callback_b)
+
+    with pytest.raises(exc.FocusError):
+        await module_a.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert seen_a == []
+    assert seen_b == []  # module_b's count is untouched by module_a's occurrence
+
+    with pytest.raises(exc.FocusError):
+        await module_a.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert len(seen_a) == 1
+    assert seen_b == []
+
+
+@pytest.mark.asyncio
+async def test_register_exception_remote_error_fires_regardless_of_specific_type() -> None:
+    # AutoFocusSeries-style usage: _register_exception(exc.RemoteError, ..., module=X) should still
+    # fire on a remote failure of any specific type, even though that type no longer literally
+    # subclasses RemoteError now that faults raise as their real type instead of wrapped
+    module = _AbortableModule(exc.GrabImageError("could not grab", remote_module="camera"))
+    seen = []
+
+    async def callback(exception: exc.PyobsError) -> None:
+        seen.append(exception)
+
+    module._register_exception(exc.RemoteError, 1, module="camera", callback=callback)
+
+    with pytest.raises(exc.GrabImageError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert len(seen) == 1
+    assert isinstance(seen[0], exc.GrabImageError)
+
+
+@pytest.mark.asyncio
+async def test_register_exception_remote_module_scoping() -> None:
+    module = _AbortableModule(exc.FocusError("could not focus", remote_module="wrong"))
+    seen = []
+
+    async def callback(exception: exc.PyobsError) -> None:
+        seen.append(exception)
+
+    module._register_exception(exc.FocusError, 1, module="test", callback=callback)
+
+    # wrong remote module -- shouldn't count
+    with pytest.raises(exc.FocusError):
+        await module.execute("abort", sender="tester")
+    await asyncio.sleep(0.01)
+    assert seen == []

--- a/tests/modules/utils/test_dummymode.py
+++ b/tests/modules/utils/test_dummymode.py
@@ -9,6 +9,7 @@ from pyobs.events import ModeChangedEvent
 from pyobs.interfaces import IMode, IMotion, IReady
 from pyobs.modules import Module
 from pyobs.modules.utils.dummymode import DummyMode
+from pyobs.utils import exceptions as exc
 
 
 def _state_for(mock: AsyncMock, interface: object) -> object:
@@ -112,7 +113,7 @@ async def test_set_mode_with_explicit_group(mocker) -> None:
 async def test_set_mode_raises_for_invalid_group() -> None:
     dm = make_dummymode()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.InvalidArgumentError):
         await dm.set_mode("Whatever", group="NoSuchGroup")
 
 

--- a/tests/modules/weather/test_mockweather.py
+++ b/tests/modules/weather/test_mockweather.py
@@ -6,6 +6,7 @@ from pyobs.events import BadWeatherEvent, GoodWeatherEvent
 from pyobs.interfaces import IRunning, IWeather, WeatherSensorReading
 from pyobs.modules import Module
 from pyobs.modules.weather import MockWeather
+from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import Unit, WeatherSensors
 
 
@@ -143,7 +144,7 @@ async def test_get_sensor_value() -> None:
 async def test_get_sensor_value_invalid() -> None:
     weather = MockWeather()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(exc.InvalidArgumentError):
         await weather.get_sensor_value("test", WeatherSensors.TIME)
 
 

--- a/tests/modules/weather/test_weather.py
+++ b/tests/modules/weather/test_weather.py
@@ -9,6 +9,7 @@ from pyobs.events import BadWeatherEvent, GoodWeatherEvent
 from pyobs.interfaces import IWeather, WeatherSensorReading
 from pyobs.modules import Module
 from pyobs.modules.weather import Weather
+from pyobs.modules.weather.weather import WeatherResponseError
 from pyobs.utils.enums import Unit, WeatherSensors
 from pyobs.utils.time import Time
 
@@ -74,7 +75,7 @@ async def test_get_sensor_value_invalid_response():
     weather = Weather("example.com/")
 
     weather._api.get_sensor_value = AsyncMock(return_value={})
-    with pytest.raises(ValueError):
+    with pytest.raises(WeatherResponseError):
         await weather.get_sensor_value("test", WeatherSensors.RAIN)
 
 

--- a/tests/robotic/scripts/test_autofocus.py
+++ b/tests/robotic/scripts/test_autofocus.py
@@ -53,14 +53,28 @@ async def test_can_run_true_when_ready() -> None:
     telescope = make_telescope(ready=True)
     script._comm.has_proxy = AsyncMock(return_value=True)
     script._comm.safe_proxy = MagicMock(return_value=make_proxy_cm(telescope))
-    assert await script.can_run(None) is True
+    target = SiderealTarget(name="Vega", ra=279.23, dec=38.78)
+    assert await script.can_run(make_task(target=target)) is True
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_when_no_data() -> None:
+    script = make_script()
+    assert await script.can_run(None) is False
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_when_no_target() -> None:
+    script = make_script()
+    assert await script.can_run(make_task(target=None)) is False
 
 
 @pytest.mark.asyncio
 async def test_can_run_false_when_autofocus_unavailable() -> None:
     script = make_script()
     script._comm.has_proxy = AsyncMock(return_value=False)
-    assert await script.can_run(None) is False
+    target = SiderealTarget(name="Vega", ra=279.23, dec=38.78)
+    assert await script.can_run(make_task(target=target)) is False
 
 
 @pytest.mark.asyncio
@@ -69,7 +83,8 @@ async def test_can_run_false_when_telescope_not_ready() -> None:
     telescope = make_telescope(ready=False)
     script._comm.has_proxy = AsyncMock(return_value=True)
     script._comm.safe_proxy = MagicMock(return_value=make_proxy_cm(telescope))
-    assert await script.can_run(None) is False
+    target = SiderealTarget(name="Vega", ra=279.23, dec=38.78)
+    assert await script.can_run(make_task(target=target)) is False
 
 
 # ── run ───────────────────────────────────────────────────────────────────────

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from pyobs.utils import exceptions as exc
-from pyobs.utils.exceptions import PyObsError
+from pyobs.utils.exceptions import PyobsError
 
 pytest_plugins = ("pytest_asyncio",)
 
@@ -19,7 +19,7 @@ def test_log() -> None:
 
 
 def test_register() -> None:
-    async def cb(exception: PyObsError) -> None:
+    async def cb(exception: PyobsError) -> None:
         pass
 
     exc.register_exception(exc.MotionError, 5, callback=cb)
@@ -35,7 +35,7 @@ def test_empty() -> None:
 async def test_callback() -> None:
     event = asyncio.Event()
 
-    async def cb(exception: PyObsError) -> None:
+    async def cb(exception: PyobsError) -> None:
         assert isinstance(exception, exc.MotionError)
         event.set()
 
@@ -62,7 +62,7 @@ async def test_callback() -> None:
 async def test_raise() -> None:
     event = asyncio.Event()
 
-    async def cb(exception: PyObsError) -> None:
+    async def cb(exception: PyobsError) -> None:
         assert isinstance(exception, exc.MotionError)
         event.set()
 
@@ -85,7 +85,7 @@ async def test_raise() -> None:
 async def test_timespan() -> None:
     event = asyncio.Event()
 
-    async def cb(exception: PyObsError) -> None:
+    async def cb(exception: PyobsError) -> None:
         assert isinstance(exception, exc.MotionError)
         event.set()
 
@@ -109,24 +109,41 @@ async def test_timespan() -> None:
 
 @pytest.mark.asyncio
 async def test_remote() -> None:
-    # get triggered after 3 MotionErrors
-    exc.register_exception(exc.MotionError, 3, throw=True)
+    # a domain exception reconstructed from a fault carries remote_module (set by rpc.py's
+    # _on_jabber_rpc_method_fault, see Assessment §A) instead of arriving wrapped in InvocationError
+    exc.register_exception(exc.MotionError, 3, module="test", throw=True)
 
     # raise two, shouldn't do anything
-    exc.MotionError()
-    exc.MotionError()
+    exc.MotionError(remote_module="test")
+    exc.MotionError(remote_module="test")
     await asyncio.sleep(0.01)
 
-    # one InvocationError should trigger MotionError
+    # third one from the same remote module triggers escalation
     with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.InvocationError(module="test", exception=exc.MotionError())
+        raise exc.MotionError(remote_module="test")
     assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.InvocationError)
-    assert isinstance(exc_info.value.exception.exception, exc.MotionError)
+    assert isinstance(exc_info.value.exception, exc.MotionError)
+
+
+def test_remote_broad_remote_error_handler_still_fires_regardless_of_specific_type() -> None:
+    # AutoFocusSeries-style usage: register_exception(exc.RemoteError, ..., module=X) should still
+    # fire on a remote failure of any specific type, even though that type no longer literally
+    # subclasses RemoteError now that faults raise as their real type instead of wrapped
+    exc.register_exception(exc.RemoteError, 1, module="camera", throw=True)
+
+    with pytest.raises(exc.SevereError) as exc_info:
+        raise exc.GrabImageError("could not grab", remote_module="camera")
+    assert isinstance(exc_info.value, exc.SevereError)
+    assert isinstance(exc_info.value.exception, exc.GrabImageError)
 
 
 def test_forbidden_error() -> None:
-    error = exc.ForbiddenError(sender="scheduler", method="reset_usb")
+    error = exc.ForbiddenError(
+        "Caller 'scheduler' is not permitted to invoke 'reset_usb'.",
+        sender="scheduler",
+        method="reset_usb",
+        module="scheduler",
+    )
     assert isinstance(error, exc.RemoteError)
     assert error.sender == "scheduler"
     assert error.method == "reset_usb"
@@ -134,20 +151,19 @@ def test_forbidden_error() -> None:
 
 
 def test_remote_module() -> None:
-    # get triggered after 3 MotionErrors
+    # get triggered after 1 MotionError specifically from module "test"
     exc.register_exception(exc.MotionError, 1, module="test", throw=True)
 
-    # raise, shouldn't do anything
+    # local (non-remote) MotionErrors shouldn't count
     exc.MotionError()
     exc.MotionError()
 
-    # same with other remote errors with other module
-    exc.InvocationError(module="wrong", exception=exc.MotionError())
-    exc.InvocationError(module="wrong", exception=exc.MotionError())
+    # MotionErrors from a different remote module shouldn't count either
+    exc.MotionError(remote_module="wrong")
+    exc.MotionError(remote_module="wrong")
 
-    # but with correct module, it should
+    # but one from the correct module should trigger
     with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.InvocationError(module="test", exception=exc.MotionError())
+        raise exc.MotionError(remote_module="test")
     assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.InvocationError)
-    assert isinstance(exc_info.value.exception.exception, exc.MotionError)
+    assert isinstance(exc_info.value.exception, exc.MotionError)

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -1,140 +1,31 @@
-import asyncio
-
-import pytest
+import logging
 
 from pyobs.utils import exceptions as exc
-from pyobs.utils.exceptions import PyobsError
-
-pytest_plugins = ("pytest_asyncio",)
 
 
-def setup_function() -> None:
-    exc.clear()
+def test_log_only_logs_once() -> None:
+    calls = []
+
+    class _FakeLogger:
+        def log(self, level, message, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            calls.append((level, message))
+
+    error = exc.FocusError("could not focus")
+    error.log(_FakeLogger(), "INFO", "first")
+    error.log(_FakeLogger(), "ERROR", "second")
+
+    assert len(calls) == 1
+    assert calls[0] == (logging.INFO, "first")
 
 
-def test_log() -> None:
-    exc.MotionError()
-    # should still be empty, since exception was not registered
-    assert len(exc._local_exceptions) == 0
+def test_resolve_finds_registered_subclass() -> None:
+    qualified_name = f"{exc.FocusError.__module__}.{exc.FocusError.__qualname__}"
+    assert exc.PyobsError.resolve(qualified_name) is exc.FocusError
 
 
-def test_register() -> None:
-    async def cb(exception: PyobsError) -> None:
-        pass
-
-    exc.register_exception(exc.MotionError, 5, callback=cb)
-    assert len(exc._handlers) == 1
-
-
-def test_empty() -> None:
-    assert len(exc._local_exceptions) == 0
-    assert len(exc._handlers) == 0
-
-
-@pytest.mark.asyncio
-async def test_callback() -> None:
-    event = asyncio.Event()
-
-    async def cb(exception: PyobsError) -> None:
-        assert isinstance(exception, exc.MotionError)
-        event.set()
-
-    # get triggered after 3 MotionErrors
-    exc.register_exception(exc.MotionError, 3, callback=cb)
-
-    # 1st is fine
-    exc.MotionError()
-    await asyncio.sleep(0.01)
-    assert event.is_set() is False
-
-    # 2nd is fine
-    exc.MotionError()
-    await asyncio.sleep(0.01)
-    assert event.is_set() is False
-
-    # 3rd triggers callback
-    exc.MotionError()
-    await asyncio.sleep(0.01)
-    assert event.is_set() is True
-
-
-@pytest.mark.asyncio
-async def test_raise() -> None:
-    event = asyncio.Event()
-
-    async def cb(exception: PyobsError) -> None:
-        assert isinstance(exception, exc.MotionError)
-        event.set()
-
-    # get triggered after 2 MotionErrors
-    exc.register_exception(exc.MotionError, 2, callback=cb, throw=True)
-
-    # 1st is fine
-    exc.MotionError()
-
-    # 2nd raises SevereError
-    with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.MotionError()
-
-    # nested exception is MotionError
-    assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.MotionError)
-
-
-@pytest.mark.asyncio
-async def test_timespan() -> None:
-    event = asyncio.Event()
-
-    async def cb(exception: PyobsError) -> None:
-        assert isinstance(exception, exc.MotionError)
-        event.set()
-
-    # get triggered after 3 MotionErrors
-    exc.register_exception(exc.MotionError, 3, callback=cb, timespan=0.1, throw=True)
-
-    # raise two and wait a little
-    exc.MotionError()
-    exc.MotionError()
-    await asyncio.sleep(0.11)
-    exc.MotionError()
-
-    # raise two more
-    exc.MotionError()
-    exc.MotionError()
-    await asyncio.sleep(0.01)
-    with pytest.raises(exc.SevereError):
-        raise exc.MotionError()
-    assert event.is_set()
-
-
-@pytest.mark.asyncio
-async def test_remote() -> None:
-    # a domain exception reconstructed from a fault carries remote_module (set by rpc.py's
-    # _on_jabber_rpc_method_fault, see Assessment §A) instead of arriving wrapped in InvocationError
-    exc.register_exception(exc.MotionError, 3, module="test", throw=True)
-
-    # raise two, shouldn't do anything
-    exc.MotionError(remote_module="test")
-    exc.MotionError(remote_module="test")
-    await asyncio.sleep(0.01)
-
-    # third one from the same remote module triggers escalation
-    with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.MotionError(remote_module="test")
-    assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.MotionError)
-
-
-def test_remote_broad_remote_error_handler_still_fires_regardless_of_specific_type() -> None:
-    # AutoFocusSeries-style usage: register_exception(exc.RemoteError, ..., module=X) should still
-    # fire on a remote failure of any specific type, even though that type no longer literally
-    # subclasses RemoteError now that faults raise as their real type instead of wrapped
-    exc.register_exception(exc.RemoteError, 1, module="camera", throw=True)
-
-    with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.GrabImageError("could not grab", remote_module="camera")
-    assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.GrabImageError)
+def test_resolve_returns_none_for_unregistered_name() -> None:
+    assert exc.PyobsError.resolve("builtins.ValueError") is None
+    assert exc.PyobsError.resolve("some.module.that.was.never.imported.WeatherDataError") is None
 
 
 def test_forbidden_error() -> None:
@@ -148,22 +39,3 @@ def test_forbidden_error() -> None:
     assert error.sender == "scheduler"
     assert error.method == "reset_usb"
     assert error.module == "scheduler"
-
-
-def test_remote_module() -> None:
-    # get triggered after 1 MotionError specifically from module "test"
-    exc.register_exception(exc.MotionError, 1, module="test", throw=True)
-
-    # local (non-remote) MotionErrors shouldn't count
-    exc.MotionError()
-    exc.MotionError()
-
-    # MotionErrors from a different remote module shouldn't count either
-    exc.MotionError(remote_module="wrong")
-    exc.MotionError(remote_module="wrong")
-
-    # but one from the correct module should trigger
-    with pytest.raises(exc.SevereError) as exc_info:
-        raise exc.MotionError(remote_module="test")
-    assert isinstance(exc_info.value, exc.SevereError)
-    assert isinstance(exc_info.value.exception, exc.MotionError)


### PR DESCRIPTION
## Summary

Full 8-step rollout from `DESIGN_exception_handling.md` (tracks #446), plus two bugs found and fixed while explaining the design along the way.

- **Step 1** — every RPC-exposed method raising a domain `PyobsError` now logs a quiet INFO line by default (previously only the two methods decorated with `@raises(...)`); `Module._disable_exception_logging()` lets a module opt a high-frequency type out entirely. `ModuleError`/`SevereError` (later just `ModuleError`/`UnclassifiedError`) stay unsuppressible.
- **Step 2** — a remote domain exception now arrives at the caller as its real type (`except exc.FocusError:` around a proxy call actually fires), not wrapped in the now-retired `InvocationError`. Exceptions resolve via a registry (`PyobsError._registry`/`resolve()`, populated by `__init_subclass__`) keyed by fully-qualified name, so a domain type can live anywhere and still survive the wire. `PyObsError` renamed to `PyobsError`; constructor standardized to `(message=None, **context)`.
- **Step 3** — retires the `SevereError` substitution and the `_Meta` metaclass entirely (nothing ever caught `SevereError` specifically, and production code never used the `throw=True` path). Severity tracking moves from module-level globals to `Module` instance state, fixing a real cross-instance leakage bug as a byproduct. `execute()` now also wraps any non-`PyobsError` into `UnclassifiedError` centrally, so `LocalComm`/`MultiModule` get the same safety net XMPP already had.
- **Step 4** — a correlation id (reusing XEP-0009's existing per-call `iq["id"]`) ties an origin-side log line to the exception the caller receives, for cross-process debugging.
- **Step 5** — sweeps concrete exception-typing gaps: `CameraException`/`AcquireLockFailed` retired in favor of one shared `DeviceBusyError`; new leaf types (`MissingObserverError`, `AltitudeLimitError`, `BodyResolutionError`, `InvalidOrbitalElementsError`, `WeatherDataError`, `FocusTimeoutError`, `MissingSensorError`, `ScriptError`, `NotSupportedError`) live next to the code that raises them, not bolted onto `exceptions.py`.
- **Steps 6-8** — documents the domain/transport split and the `AbortedError` contract on every `abort_event` hook (catching two more in-tree instances of driver authors guessing the wrong builtin type), and a docstring sweep across every interface the original audit flagged (16 of 27 documented interfaces had at least one mismatch).
- **Two bugs found and fixed post-rollout**: `UnclassifiedError.original_type` never actually survived the wire (the wrapper's own class name was serialized instead, which resolves successfully since it's a registered type, so the caller lost track of what the original type was); and every exception crossing the wire had its message doubled on display due to serializing `str(exception)` instead of the raw message.

## Known follow-ups (not in this PR)

- `pyobs-gui`, `pyobs-alpaca`, `pyobs-iagvt` need small companion updates (already flagged with in-repo TODOs, tracked in project memory).
- `pyobs-monet`/`pyobs-iagvt` scripts relying on the old `InvocationError` wrapping are explicitly deferred per their owners.
- `pyobs-sbig`/`pyobs-fli`'s `AbortedError` fix and `pyobs-brot`'s silent-success bug are companion fixes in those repos.
- Bad-argument-validation `ValueError`s are deliberately not promoted to typed exceptions (see `DESIGN_exception_handling.md`'s "Still open" section) — tracked, not forgotten.

## Test plan

- [x] `pyrefly check` clean throughout
- [x] Full test suite passes (1307 passed; the one pre-existing failure is an unrelated sandbox filesystem-permission issue, not caused by this branch)
- [x] Sphinx docs build clean of new warnings
- [x] New/updated tests for every behavioral change (severity tracking, correlation id, `AbortedError` contract, wire serialization round-trips, etc.)