### PR TITLE
Gate RPC dispatch and XMPP presence until a module has fully started

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,21 @@
 v2.0.0.dev18 (unreleased)
 *************************
+* Modules no longer accept RPC calls until they've actually finished starting up. Some drivers
+  (e.g. camera modules connecting to hardware) take a while inside ``open()``, but were previously
+  reachable over XMPP -- and visible to peer discovery -- the instant they connected to the server,
+  long before ``open()`` returned. New ``ModuleState.STARTING``, set at construction and cleared by
+  the new ``Module.start()`` once the full ``open()`` override chain (base setup plus every
+  subclass's own) has completed; ``Module.execute()`` now rejects any call outside a small
+  introspection/recovery whitelist (``get_permitted_methods``, ``reset_error``) with the new
+  ``ModuleStartingError`` while a module is still ``STARTING``. ``XmppComm``/``XmppClient`` also
+  hold back the initial XMPP presence broadcast until a module reaches ``READY``, closing a race
+  where a peer reacting to ``_got_online`` could read capabilities (e.g. hardware-dependent ones
+  like ``IWindow``/``IBinning``) that hadn't been published yet -- scoped to comms with an actual
+  starting ``Module`` attached, so bare/GUI-style ``XmppComm`` usage announces itself exactly as
+  before. ``Application`` and ``MultiModule`` both call ``Module.start()`` instead of ``open()``
+  directly now; any other code that opens a module standalone (a custom script, a test) needs to do
+  the same, or call ``set_state(ModuleState.READY)`` itself after ``open()`` -- see
+  :ref:`module-startup-gating`.
 * New ``InvalidArgumentError`` for bad-argument validation on RPC-exposed methods (unknown filter
   name, invalid focus value, invalid config parameter, out-of-range ``grab_sequence`` count/delay,
   ...) -- previously these stayed as plain ``ValueError``, which works fine locally (``LocalComm``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ v2.0.0.dev18 (unreleased)
   (e.g. camera modules connecting to hardware) take a while inside ``open()``, but were previously
   reachable over XMPP -- and visible to peer discovery -- the instant they connected to the server,
   long before ``open()`` returned. New ``ModuleState.STARTING``, set at construction and cleared by
-  the new ``Module.start()`` once the full ``open()`` override chain (base setup plus every
+  the new ``Module.startup()`` once the full ``open()`` override chain (base setup plus every
   subclass's own) has completed; ``Module.execute()`` now rejects any call outside a small
   introspection/recovery whitelist (``get_permitted_methods``, ``reset_error``) with the new
   ``ModuleStartingError`` while a module is still ``STARTING``. ``XmppComm``/``XmppClient`` also
@@ -12,7 +12,7 @@ v2.0.0.dev18 (unreleased)
   where a peer reacting to ``_got_online`` could read capabilities (e.g. hardware-dependent ones
   like ``IWindow``/``IBinning``) that hadn't been published yet -- scoped to comms with an actual
   starting ``Module`` attached, so bare/GUI-style ``XmppComm`` usage announces itself exactly as
-  before. ``Application`` and ``MultiModule`` both call ``Module.start()`` instead of ``open()``
+  before. ``Application`` and ``MultiModule`` both call ``Module.startup()`` instead of ``open()``
   directly now; any other code that opens a module standalone (a custom script, a test) needs to do
   the same, or call ``set_state(ModuleState.READY)`` itself after ``open()`` -- see
   :ref:`module-startup-gating`.

--- a/DEV_STARTUP.md
+++ b/DEV_STARTUP.md
@@ -1,0 +1,330 @@
+# Gating RPC commands until module startup completes
+
+## Problem
+
+Some modules (e.g. camera drivers like FLI) take a while to boot: connecting
+to hardware, enabling cooling, etc. During that window the module is already
+reachable over XMPP and will accept and execute incoming RPC commands, even
+though it isn't fully initialized yet.
+
+Example log — the module is connected and publishing capabilities well
+before it's actually ready:
+
+```
+2026-07-17 19:23:41,057 [INFO] (fli) application.py:226 Opening module...
+2026-07-17 19:23:41,290 [INFO] (fli) bind.py:59 JID set to: fli230@monet.saao.ac.za/pyobs
+2026-07-17 19:23:41,291 [INFO] (fli) xmppclient.py:131 Connected to server.
+2026-07-17 19:23:44,022 [INFO] (fli) xmppcomm.py:905 Published capabilities for IModule
+2026-07-17 19:23:44,022 [INFO] (fli) xmppcomm.py:905 Published capabilities for IConfig
+2026-07-17 19:24:03,727 [INFO] (fli) flibase.py:70 Opening connection to "ProLine PL230" at /dev/fliusb0...
+2026-07-17 19:24:03,730 [INFO] (fli) flicamera.py:54 Connected to camera with serial number: PL0475014
+2026-07-17 19:24:03,730 [INFO] (fli) flicamera.py:185 Enabling cooling with a setpoint of 20.00°C...
+2026-07-17 19:24:03,786 [INFO] (fli) xmppcomm.py:905 Published capabilities for IWindow
+2026-07-17 19:24:03,810 [INFO] (fli) xmppcomm.py:905 Published capabilities for IBinning
+2026-07-17 19:24:03,822 [INFO] (fli) application.py:228 Started successfully.
+```
+
+Capabilities are published, and the RPC handler is live, ~20 seconds before
+`"Started successfully."` — there is currently no guard preventing commands
+from executing in that window.
+
+## Where the dispatch happens
+
+`Module.execute()` (`pyobs/modules/module.py:523`) is the single choke point
+for all incoming RPC calls, regardless of transport:
+
+- XMPP: `RPC._on_jabber_rpc_method_call` (`pyobs/comm/xmpp/rpc.py:232`) calls
+  `self._handler.execute(...)`, where `self._handler` is the `Module`
+  instance (wired up in `XmppComm._connect()`, `xmppcomm.py:262-263`, which
+  runs at the very start of `Module.open()`).
+- In-process / `MultiModule`: `LocalComm.execute()`
+  (`pyobs/comm/local/localcomm.py:50-55`) calls
+  `remote_client.module.execute(...)` — same method.
+
+A guard added in `Module.execute()` covers both transports with one change.
+
+`Module.execute()` already has two guards in the same style we'd want to
+copy:
+
+```python
+# pyobs/modules/module.py
+542  # is module in error state?
+543  if self._state == ModuleState.ERROR:
+544      # if called method is not from IModule, raise error
+545      if not hasattr(IModule, method):
+546          raise exc.ModuleError("Module is in error state, please reset it.")
+...
+558  if method != "get_permitted_methods" and self._acl_denied(sender, method):
+559      if self._acl_mode == "enforce":
+560          raise exc.ForbiddenError(
+561              f"Caller '{sender}' is not permitted to invoke '{method}'.",
+562              sender=sender, method=method, module=sender,
+563          )
+```
+
+## Where "fully started" actually happens
+
+`Application._main()` (`pyobs/application.py:220-231`):
+
+```python
+220  async def _main(self) -> None:
+224      try:
+225          # open module
+226          log.info("Opening module...")
+227          await self._module.open()
+228          log.info("Started successfully.")
+230          # run module
+231          await self._module.main()
+```
+
+`"Started successfully."` is logged only after `await self._module.open()`
+returns — i.e. after the **entire** override chain (base `Module.open()` +
+every subclass's `open()`) has finished. This is the true "ready" signal.
+
+### Why `Object._opened` / `Module.opened` is *not* the right flag
+
+`Module` extends `Object`, which has:
+
+```python
+# pyobs/object.py
+340  self._opened = False
+...
+365  async def open(self) -> None:
+379      self._opened = True
+...
+386  @property
+387  def opened(self) -> bool:
+388      return self._opened
+```
+
+But concrete module subclasses call the base `open()` as the *first*
+statement of their own override and keep doing device-specific setup
+*afterward*, e.g. `pyobs/modules/camera/basecamera.py:114-129`:
+
+```python
+114  async def open(self) -> None:
+115      await Module.open(self)          # <-- self._opened already True here
+116      # subscribe to events
+118      if self._comm:
+119          await self.comm.register_event(NewImageEvent)
+...
+124      # publish initial states
+125      await self.comm.set_state(...)
+```
+
+So `self.opened` flips `True` while the FLI driver is still between
+`"Opening connection to..."` and `"Started successfully."` in the log above.
+Using it as the readiness guard would still let commands through mid-boot —
+it does not match what the user is asking to gate on.
+
+## Proposed design
+
+1. Add a new `asyncio.Event` on `Module`, e.g. `self._startup_complete`.
+   Mirrors the existing shutdown flag `self._closing = asyncio.Event()`
+   (`module.py:159`), which is checked the same way elsewhere (e.g.
+   `xmppcomm.py:305: if self._closing.is_set(): return`).
+
+2. Set it in `Application._main()` right after `await self._module.open()`
+   returns (`application.py:228`), e.g. via a small public method such as
+   `Module._mark_started()` — this is the exact point that currently logs
+   `"Started successfully."`.
+
+3. Guard in `Module.execute()`: if `not self._startup_complete.is_set()`,
+   raise a `PyobsError` subclass, following the same style as the
+   `ModuleState.ERROR` / ACL checks above. Exempt a small whitelist of
+   introspection methods that should still work during startup —
+   `get_permitted_methods`, `get_version`, `reset_error` (the same ones
+   already special-cased around `IModule` in the existing guards).
+
+4. No XMPP-side wiring is required beyond raising the right exception type:
+   `rpc.py`'s generic fault handler (`rpc.py:243-251`) already serializes any
+   `PyobsError` back to the caller and reconstructs it via
+   `RPC._on_jabber_rpc_method_fault` (`rpc.py:283-311`). A dedicated XEP-0009
+   condition (mirroring the `ForbiddenError` fast-path at `rpc.py:239-241`)
+   would only be needed if callers should be able to distinguish "not ready
+   yet" from a generic error/retry.
+
+## Other relevant context found during research
+
+- `IModule` (`pyobs/interfaces/IModule.py`) currently only declares
+  `reset_error` and `get_permitted_methods` — no readiness concept.
+  `get_version`/`get_label` are plain `Module` methods, not on `IModule`, so
+  they are *not* currently covered by the `hasattr(IModule, method)`
+  exemption at `module.py:545` and would need to be added explicitly to any
+  new whitelist.
+- `ModuleState` (`pyobs/utils/enums.py:12-25`) only has `CLOSED`, `READY`,
+  `ERROR`, `LOCAL` — no `STARTING`/`OPENING` state, and `Module._state`
+  defaults to `READY` at construction (`module.py:152`), before `open()`
+  even runs. It cannot currently distinguish "still starting" from "fully
+  up," so it can't be reused as the readiness signal either.
+- `IReady` / `ReadyState` (`pyobs/interfaces/IReady.py`,
+  `pyobs/mixins/motionstatus.py`) is a *domain-level* "ready for science"
+  concept (e.g. telescope tracking settled), unrelated to RPC-dispatch
+  readiness — don't conflate the two.
+- There's already a `ModuleOpenedEvent` (`pyobs/events/moduleopened.py`),
+  sent by `XmppComm` when a *client* connects (`xmppcomm.py:570`) and
+  handled by `Module._on_module_opened` (`module.py:355`) — this is about
+  peer-discovery/announcing presence to other modules, not about the local
+  module's own startup completion. Not directly reusable for this guard.
+
+  **Correction (superseded an earlier, wrong claim in this doc):** it was
+  initially assumed that `_on_module_opened` (`module.py:353-366`) calling
+  `proxy.get_capabilities(IModule)` (`module.py:360-361`) would break against
+  the new `STARTING` guard, since `get_capabilities` isn't on the `execute()`
+  whitelist. That's incorrect — `Proxy.get_capabilities()`
+  (`comm/proxy.py:189-191`) is *not* an RPC call through `Module.execute()`
+  at all. It's a synchronous read of a local in-memory cache
+  (`self._capabilities`), populated asynchronously whenever a
+  capabilities-publish event arrives from the server (disco/PEP push). It
+  can never raise against the `STARTING` guard, because it never reaches it.
+
+  The real reason to still delay presence is a **capability-publish race**,
+  not RPC rejection. Inside `Module.open()` (`module.py:285-321`): (1)
+  `self.comm.open()` connects and, today, sends presence immediately; (2)
+  base `IModule`/`IConfig` capabilities are published (`module.py:310-321`);
+  (3) subclass `open()` overrides run afterward, which is where
+  hardware-dependent capabilities get published — e.g. a camera module
+  publishing `IWindow`/`IBinning` only once the sensor is connected and its
+  bounds are known (matches the example log: those capabilities appear right
+  before `"Started successfully."`, well after `IModule`/`IConfig`). Since
+  presence currently fires *before any* capabilities are published, a peer
+  reacting to `_got_online` could read `proxy.get_capabilities(IModule)`
+  before it's even been published (getting `None` → silently falls back to
+  an empty version string rather than crashing) — and the same race applies
+  to any device-specific interface a peer might read early. Delaying
+  presence until `READY` means that by the time any peer can observe the
+  module as online, the entire `open()` chain — including every subclass's
+  hardware-dependent capability publish — has already finished, so
+  capabilities peers read are always complete and race-free.
+
+## Decisions
+
+1. **Whitelist, not `hasattr(IModule, ...)`.** The existing `ModuleState.ERROR`
+   guard (`module.py:542-546`) exempts methods via `hasattr(IModule, method)`,
+   but `get_version`/`get_label` aren't declared on `IModule` so that pattern
+   would silently exclude them. The new `STARTING` guard in `Module.execute()`
+   uses an explicit whitelist tuple instead:
+   `("get_permitted_methods", "get_version", "get_label", "reset_error")`.
+
+2. **Add `ModuleState.STARTING`.** New value in `pyobs/utils/enums.py`
+   (alongside `CLOSED`, `READY`, `ERROR`, `LOCAL`). `Module._state` is set to
+   `STARTING` before `open()` begins (instead of defaulting straight to
+   `READY` as it does today at `module.py:152`), and transitions to `READY`
+   once `Application._main()`'s `await self._module.open()` returns
+   (`application.py:227-228`) — the same point that already logs
+   `"Started successfully."`. `Module.execute()` rejects calls (outside the
+   whitelist) while `_state == ModuleState.STARTING`.
+
+3. **`IReady` stays untouched.** It's a domain-level "ready for science"
+   concept (e.g. telescope settled after a slew) and is orthogonal to
+   RPC-dispatch readiness — a module can be `READY` (accepting commands)
+   while its `IReady` state is still `False` (e.g. still slewing). No change
+   needed here beyond keeping the two concepts separate.
+
+4. **Delay `send_presence()` until `READY`.** Not a command-execution guard
+   (that's fully handled by `Module.execute()`'s `STARTING` check, decision
+   #2, independent of transport or presence) — this is about eliminating the
+   **capability-publish race** described above. Currently
+   `XmppClient.session_start()` calls `self.send_presence()` immediately on
+   XMPP connect (`xmppclient.py:134`), which is what makes the module visible
+   to peers' `_got_online` → `ModuleOpenedEvent` → `_on_module_opened` chain
+   — long before the module's own `open()` override chain, and thus its
+   hardware-dependent capability publishes, have finished. Holding
+   `send_presence()` until `Module` signals it has reached `READY` means the
+   module stays connected to the XMPP server but invisible to peer discovery
+   until fully booted, so any capabilities a peer reads afterward are
+   guaranteed complete. This requires plumbing a readiness signal from
+   `Module` down into `XmppClient` (the two are presently decoupled —
+   `XmppClient` has no visibility into `Module._state`).
+
+## Implementation
+
+Landed on `feature/startup-gating`. Deviated from the plan above in a few
+places, discovered only by testing against a live local ejabberd server —
+worth recording since they weren't visible from code reading alone:
+
+- **`get_version`/`get_label` dropped from the `STARTING` whitelist.**
+  Neither is declared on `IModule`, so neither ever appears in
+  `Module._methods` (populated only from registered `Interface` methods) --
+  they were never reachable via `execute()` at all, whitelisted or not.
+  Whitelist trimmed to `("get_permitted_methods", "reset_error")`, the only
+  two methods actually callable through `execute()`.
+
+- **`Module.start()` added, not just `Application` calling `open()` then
+  `set_state(READY)`.** `MultiModule._run_module()` (`module.py`) calls
+  `await mod.open()` directly for each sub-module, with no follow-up
+  `set_state(READY)` -- under the original plan every module running inside
+  a `MultiModule` process would stay `STARTING` forever, rejecting all
+  RPC calls. Fixed by adding `Module.start()` (`open()` then
+  `set_state(READY)`) and having both `Application._main()` and
+  `MultiModule._run_module()` call it instead of `open()` directly.
+
+- **Presence gating had to become opt-in per-comm, not global per-client.**
+  The original design gated every `XmppClient.send_presence()` call behind
+  `mark_ready()`. Verified against a live local ejabberd
+  (`tests/integration/`, `-m xmpp`): this silently broke presence for any
+  module-less `XmppComm` too -- e.g. the `observer` comm used throughout the
+  integration test suite, which has no `Module` attached and thus never
+  calls anything that triggers `mark_ready()`. Its own presence broadcast
+  never went out, which broke the mutual-subscription exchange that
+  delivers *other* peers' presence to it, independent of anything `camera`
+  did. Fixed in `XmppComm._connect()`: a freshly created client is marked
+  ready immediately unless `self.has_module` is true and the module hasn't
+  reached `READY` yet (`self._module_ready`) -- gating now applies only to
+  an actual starting `Module`, not to bare/GUI/observer-style `XmppComm`
+  usage, which behaves exactly as before.
+
+- One integration test (`test_set_state_automatically_updates_presence`)
+  had to be reordered: it originally asserted peer visibility appearing
+  *after* the observer was already connected and the module announced
+  itself for the first time only afterward via `set_state()`. That specific
+  sequence -- a first "come online" broadcast reaching a subscriber that
+  connected before the peer ever announced -- isn't reliably delivered by
+  this test environment's roster/subscription setup (never previously
+  exercised, since presence used to go out immediately on connect, always
+  before any observer could possibly connect first). Fixed by establishing
+  `READY` visibility before exercising the `ERROR` update the test is
+  actually about, matching every other peer-discovery test in the suite.
+
+## Follow-up questions & resolutions
+
+Raised after the initial decisions, while thinking through implementation
+details:
+
+- **Does `LocalComm`/`MultiModule` need the same presence-delay treatment?**
+  No — confirmed not applicable. `LocalComm._register_events()` is a no-op
+  (`localcomm.py:71: pass`), so `ModuleOpenedEvent`/`_on_module_opened`
+  peer-discovery never fires under `LocalComm` — it's XMPP-only. Also,
+  `LocalComm.__init__` calls `self._network.connect_client(self)` immediately
+  at construction (`localcomm.py:21`), making a module visible via `.clients`
+  before `open()` even starts — there's no presence concept there to gate.
+  `LocalComm` callers are protected solely by the `Module.execute()`
+  `STARTING` guard, which already covers them via
+  `LocalComm.execute()` → `remote_client.module.execute(...)`
+  (`localcomm.py:50-55`).
+
+- **How does `Module` signal `READY` down to `XmppClient`?** Add a method on
+  `Comm` (e.g. `Comm.mark_ready()`), implemented by `XmppComm`/`XmppClient` to
+  fire the deferred `send_presence()`. `Module` calls it once `_state`
+  transitions to `READY` in `Application._main()`. Base `Comm` gets a no-op
+  default so `LocalComm` and other transports don't need to implement it.
+
+- **Reconnect behavior.** `XmppClient.session_start()` fires on every
+  reconnect, not just the first connect. Resolution: send presence
+  immediately if the module is already `READY`; only hold it back while the
+  module is still `STARTING`. Otherwise a brief network blip on an
+  already-running module would make it vanish from peer discovery.
+
+- **Guard ordering in `Module.execute()`.** `STARTING` is checked first,
+  ahead of the existing `ModuleState.ERROR` check (`module.py:542-546`) and
+  the ACL check (`module.py:558-567`).
+
+- **What if `open()` itself raises?** No fix needed. Checked
+  `Application._main()` (`application.py:220-231`): it runs exactly once per
+  process (`_run()` → `run_until_complete`, no retry/reconnect loop around
+  it); on an `open()` exception it logs, falls through to `finally`, calls
+  `close()`, and the process exits shortly after. Combined with the
+  presence-delay decision above, a module whose `open()` fails never sent
+  presence in the first place, so no peer could ever have observed it stuck
+  in `STARTING` — the state is unobservable and the process is gone moments
+  later anyway.

--- a/DEV_STARTUP.md
+++ b/DEV_STARTUP.md
@@ -250,14 +250,17 @@ worth recording since they weren't visible from code reading alone:
   Whitelist trimmed to `("get_permitted_methods", "reset_error")`, the only
   two methods actually callable through `execute()`.
 
-- **`Module.start()` added, not just `Application` calling `open()` then
+- **`Module.startup()` added, not just `Application` calling `open()` then
   `set_state(READY)`.** `MultiModule._run_module()` (`module.py`) calls
   `await mod.open()` directly for each sub-module, with no follow-up
   `set_state(READY)` -- under the original plan every module running inside
   a `MultiModule` process would stay `STARTING` forever, rejecting all
-  RPC calls. Fixed by adding `Module.start()` (`open()` then
+  RPC calls. Fixed by adding `Module.startup()` (`open()` then
   `set_state(READY)`) and having both `Application._main()` and
-  `MultiModule._run_module()` call it instead of `open()` directly.
+  `MultiModule._run_module()` call it instead of `open()` directly. (Named
+  `startup()`, not `start()` -- see the follow-up entry below; the original
+  landed version of this doc/commit used `start()` and shipped a real bug
+  because of it.)
 
 - **Presence gating had to become opt-in per-comm, not global per-client.**
   The original design gated every `XmppClient.send_presence()` call behind
@@ -328,3 +331,37 @@ details:
   presence in the first place, so no peer could ever have observed it stuck
   in `STARTING` — the state is unobservable and the process is gone moments
   later anyway.
+
+## Post-landing regression: `start()` collided with `IStartStop.start()`
+
+Found via a real `pyobs-gui` `full.yaml` run: `guiding` (a `DummyAutoGuiding`,
+which implements `IAutoGuiding` → `IStartStop`) never left `STARTING`, so a
+GUI client resolving a typed proxy for it hit `ValueError: ... is not of
+requested type "IModule"`.
+
+Root cause: `IStartStop` (`pyobs/interfaces/IStartStop.py`) declares an
+abstract RPC method `async def start(self, **kwargs) -> None` ("start this
+service"), implemented by several module families (`DummyAutoGuiding`,
+`Mastermind`, robotic `Pointing`, `Trigger`, `Scheduler`, `Kiosk`,
+`Weather`/`MockWeather`, ...). `Module.start()`, the new lifecycle helper
+added above, has the exact same name -- Python method resolution silently
+picks the subclass's `IStartStop.start()` override instead, so
+`MultiModule._run_module()`'s `await mod.start()` (and
+`Application._main()`'s `await self._module.start()`) called the RPC
+command, not the lifecycle helper, for every one of those module types.
+`open()` never ran, `_state` never left `STARTING`, and the module rejected
+every RPC call (or, in `LocalComm`, never even attached to its `Comm`,
+since `self.comm.module = self` is the first line of `Module.open()`)
+indefinitely -- not a race, a hard failure, for as long as the process ran.
+
+The existing test suite didn't catch this: `test_startup_gating.py` uses an
+`IAbortable`-only fixture module, and every XMPP integration test that
+switched `open()` → `start()` uses `DummyCamera`, which doesn't implement
+`IStartStop` either. No test in the gating commit exercised a module that
+actually implements `IStartStop`.
+
+Fix: renamed the lifecycle helper to `Module.startup()` everywhere (its own
+definition, `MultiModule._run_module()`, `Application._main()`, and every
+test/doc that called `.start()` expecting the lifecycle meaning). `open()`
+and `close()` were checked and confirmed not to collide with any interface
+method name, so they were left as-is.

--- a/docs/source/api/module.rst
+++ b/docs/source/api/module.rst
@@ -80,13 +80,16 @@ XMPP peer discovery (see :ref:`module-startup-gating`). This matters if your own
 calls into another module via ``self.proxy(...)`` — that module may itself still be
 ``STARTING``.
 
-A module doesn't call :meth:`~pyobs.modules.Module.start` on itself; whatever launches it
+A module doesn't call :meth:`~pyobs.modules.Module.startup` on itself; whatever launches it
 (``Application``, the normal ``pyobs``/``pyobsd`` entry point, or
-:class:`~pyobs.modules.MultiModule`) calls ``start()``, which runs ``open()`` and then
+:class:`~pyobs.modules.MultiModule`) calls ``startup()``, which runs ``open()`` and then
 transitions the module to
-:attr:`~pyobs.utils.enums.ModuleState.READY`. You only need to call ``start()`` yourself
+:attr:`~pyobs.utils.enums.ModuleState.READY`. You only need to call ``startup()`` yourself
 when opening a module outside of those two (a test, a standalone script) — ``open()`` alone
-leaves it in ``STARTING`` indefinitely.
+leaves it in ``STARTING`` indefinitely. It's named ``startup()`` rather than ``start()``
+because ``start()`` is already :class:`~pyobs.interfaces.IStartStop`'s abstract RPC method —
+a plain ``start()`` here would be silently shadowed by any module implementing that
+interface.
 
 
 Interfaces

--- a/docs/source/api/module.rst
+++ b/docs/source/api/module.rst
@@ -67,6 +67,28 @@ The matching YAML configuration::
     ``location`` are passed down from the YAML configuration.
 
 
+Startup and ``ModuleState.STARTING``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A module starts in :attr:`~pyobs.utils.enums.ModuleState.STARTING` and stays there for the
+whole ``open()`` override chain — including everything a subclass's own ``open()`` does
+after calling ``await Module.open(self)``, e.g. connecting to hardware. While
+``STARTING``, :meth:`~pyobs.modules.Module.execute` rejects any call from another module
+except ``get_permitted_methods``/``reset_error``, raising
+:class:`~pyobs.utils.exceptions.ModuleStartingError`, and the module stays invisible to
+XMPP peer discovery (see :ref:`module-startup-gating`). This matters if your own ``open()``
+calls into another module via ``self.proxy(...)`` — that module may itself still be
+``STARTING``.
+
+A module doesn't call :meth:`~pyobs.modules.Module.start` on itself; whatever launches it
+(``Application``, the normal ``pyobs``/``pyobsd`` entry point, or
+:class:`~pyobs.modules.MultiModule`) calls ``start()``, which runs ``open()`` and then
+transitions the module to
+:attr:`~pyobs.utils.enums.ModuleState.READY`. You only need to call ``start()`` yourself
+when opening a module outside of those two (a test, a standalone script) — ``open()`` alone
+leaves it in ``STARTING`` indefinitely.
+
+
 Interfaces
 ^^^^^^^^^^
 

--- a/docs/source/api/utils/exceptions.rst
+++ b/docs/source/api/utils/exceptions.rst
@@ -101,6 +101,13 @@ ModuleError
    :members:
    :undoc-members:
 
+ModuleStartingError
+^^^^^^^^^^^^^^^^^^^
+
+.. autoexception:: pyobs.utils.exceptions.ModuleStartingError
+   :members:
+   :undoc-members:
+
 MotionError
 ^^^^^^^^^^^
 

--- a/docs/source/whatsnew-2.0.rst
+++ b/docs/source/whatsnew-2.0.rst
@@ -110,6 +110,45 @@ Modules and configuration
   from the XMPP server due to a JID conflict (a duplicate login, or an admin-issued kick,
   both surface as the same stream-error condition).
 
+.. _module-startup-gating:
+
+Modules reject RPC calls until fully started
+------------------------------------------------
+
+A module is no longer reachable over RPC, nor visible to peer discovery, the instant it
+connects to its ``Comm`` — only once it has actually finished starting up. Some drivers
+(a camera module connecting to hardware, say) take a while inside ``open()``; previously
+they accepted commands and were discoverable the moment the XMPP connection came up, long
+before ``open()`` returned.
+
+A module's state now starts at ``ModuleState.STARTING`` (rather than ``READY``) and stays
+there until the *entire* ``open()`` override chain — the base ``Module`` setup and every
+subclass's own — has completed. While ``STARTING``, ``Module.execute()`` rejects any RPC
+call outside a small introspection/recovery whitelist (``get_permitted_methods``,
+``reset_error``) with a new ``exc.ModuleStartingError``. ``XmppComm``/``XmppClient`` also
+hold back the module's initial XMPP presence broadcast until it reaches ``READY``, so a
+peer reacting to the module coming online never reads capabilities (e.g. a camera's
+``IWindow``/``IBinning``, published only once the sensor is actually connected) that are
+still mid-publish. This only applies to a comm with an actual starting ``Module``
+attached — a bare/GUI-style ``XmppComm`` with no module announces itself immediately, same
+as before.
+
+The new ``Module.start()`` runs ``open()`` and then transitions the module to ``READY``:
+
+.. code-block:: python
+
+   # equivalent to open() in 1.x/early 2.0 -- runs open(), then unblocks RPC/presence
+   await module.start()
+
+``Application`` (the normal ``pyobs``/``pyobsd`` entry point) and ``MultiModule`` both call
+``start()`` instead of ``open()`` now, so this is transparent for any module launched the
+usual way. If you open a module standalone — a test, a script, anything that isn't
+``Application``/``MultiModule`` — call ``start()`` instead of ``open()``, or the module
+stays in ``STARTING`` indefinitely and rejects every non-whitelisted call. Calling
+``open()`` directly still works for cases that specifically want to inspect
+pre-``READY`` behavior; just follow it with ``await module.set_state(ModuleState.READY)``
+once ready.
+
 Removed and renamed interfaces / RPC methods
 ----------------------------------------------
 
@@ -527,4 +566,8 @@ GUI/client), check for, in roughly descending order of how likely they are to af
    answering the (now-removed) RPC getter.
 #. Any interface you *call through a proxy* whose getter was removed — switch to
    ``get_state``/``wait_for_state`` or ``get_capabilities``.
+#. Any place that calls ``module.open()`` directly outside of ``Application``/
+   ``MultiModule`` (a test, a standalone script) — switch to ``module.start()``, or the
+   module never leaves ``STARTING`` (see `Modules reject RPC calls until fully started`_
+   above).
 #. If you run your own ejabberd server, apply the ``mod_pubsub`` config change above.

--- a/docs/source/whatsnew-2.0.rst
+++ b/docs/source/whatsnew-2.0.rst
@@ -133,17 +133,20 @@ still mid-publish. This only applies to a comm with an actual starting ``Module`
 attached — a bare/GUI-style ``XmppComm`` with no module announces itself immediately, same
 as before.
 
-The new ``Module.start()`` runs ``open()`` and then transitions the module to ``READY``:
+The new ``Module.startup()`` runs ``open()`` and then transitions the module to ``READY``
+(named ``startup()`` rather than ``start()`` because ``start()`` is already
+``IStartStop``'s abstract RPC method — a plain ``start()`` here would be silently shadowed
+by any module implementing that interface, e.g. guiding, scheduler, weather):
 
 .. code-block:: python
 
    # equivalent to open() in 1.x/early 2.0 -- runs open(), then unblocks RPC/presence
-   await module.start()
+   await module.startup()
 
 ``Application`` (the normal ``pyobs``/``pyobsd`` entry point) and ``MultiModule`` both call
-``start()`` instead of ``open()`` now, so this is transparent for any module launched the
+``startup()`` instead of ``open()`` now, so this is transparent for any module launched the
 usual way. If you open a module standalone — a test, a script, anything that isn't
-``Application``/``MultiModule`` — call ``start()`` instead of ``open()``, or the module
+``Application``/``MultiModule`` — call ``startup()`` instead of ``open()``, or the module
 stays in ``STARTING`` indefinitely and rejects every non-whitelisted call. Calling
 ``open()`` directly still works for cases that specifically want to inspect
 pre-``READY`` behavior; just follow it with ``await module.set_state(ModuleState.READY)``
@@ -567,7 +570,7 @@ GUI/client), check for, in roughly descending order of how likely they are to af
 #. Any interface you *call through a proxy* whose getter was removed — switch to
    ``get_state``/``wait_for_state`` or ``get_capabilities``.
 #. Any place that calls ``module.open()`` directly outside of ``Application``/
-   ``MultiModule`` (a test, a standalone script) — switch to ``module.start()``, or the
+   ``MultiModule`` (a test, a standalone script) — switch to ``module.startup()``, or the
    module never leaves ``STARTING`` (see `Modules reject RPC calls until fully started`_
    above).
 #. If you run your own ejabberd server, apply the ``mod_pubsub`` config change above.

--- a/pyobs/application.py
+++ b/pyobs/application.py
@@ -224,7 +224,7 @@ class Application:
         try:
             # open module
             log.info("Opening module...")
-            await self._module.open()
+            await self._module.start()
             log.info("Started successfully.")
 
             # run module

--- a/pyobs/application.py
+++ b/pyobs/application.py
@@ -224,7 +224,7 @@ class Application:
         try:
             # open module
             log.info("Opening module...")
-            await self._module.start()
+            await self._module.startup()
             log.info("Started successfully.")
 
             # run module

--- a/pyobs/comm/comm.py
+++ b/pyobs/comm/comm.py
@@ -530,6 +530,21 @@ class Comm:
     async def _set_presence(self, state: ModuleState, error_string: str = "") -> None:
         pass
 
+    async def mark_ready(self) -> None:
+        """Signal that the module has finished its own startup (reached ModuleState.READY) and is
+        safe for peers to discover.
+
+        Called by Module once it transitions to READY. Transports that announce a module to peers
+        independently of RPC dispatch (e.g. XmppComm's XMPP presence, which drives other modules'
+        peer-discovery reaction) hold that announcement back until this fires, so peers never read
+        capabilities that are still mid-publish. Transports without such an announcement (e.g.
+        LocalComm) don't need to override this.
+        """
+        await self._mark_ready()
+
+    async def _mark_ready(self) -> None:
+        pass
+
     def get_client_state(self, module: str) -> tuple[ModuleState, str] | None:
         """Return the last known presence state of a connected module.
 

--- a/pyobs/comm/xmpp/xmppclient.py
+++ b/pyobs/comm/xmpp/xmppclient.py
@@ -34,6 +34,9 @@ class XmppClient(slixmpp.ClientXMPP):
         self._jid_conflict = False
         self._conflict_reason: str | None = None
 
+        # module startup gating -- see send_presence()/mark_ready() below
+        self._module_ready = False
+
         # auto-accept invitations
         self.auto_authorize = True
 
@@ -57,6 +60,33 @@ class XmppClient(slixmpp.ClientXMPP):
         self.add_event_handler("failed_all_auth", self.failed_all_auth)
         self.add_event_handler("stream_error", self._stream_error)
         self.add_filter("in", self._filter_messages)
+
+    def send_presence(self, *args: Any, **kwargs: Any) -> Any:
+        """Override slixmpp's send_presence to hold back every presence broadcast -- the initial
+        online announcement (session_start) as well as re-broadcasts triggered by capability
+        updates (XmppComm._register_events) or lifecycle state changes (XmppComm._set_presence) --
+        until mark_ready() fires. This keeps the module invisible to peers' online-discovery
+        (_got_online/ModuleOpenedEvent) while it's still starting up, so peers never read
+        capabilities that are still mid-publish. Calls made before mark_ready() are simply dropped;
+        mark_ready() sends its own presence once, which is enough to announce the module (any
+        entity-capabilities hash update from a dropped call in the meantime is still picked up,
+        since update_caps() itself isn't gated).
+        """
+        if not self._module_ready:
+            return None
+        return super().send_presence(*args, **kwargs)
+
+    def mark_ready(self) -> None:
+        """Allow send_presence() to actually transmit from here on -- called either once the owning
+        Module first reaches ModuleState.READY (on the live, already-connected client: announce
+        immediately), or by XmppComm._connect() on a freshly created client for a reconnect after
+        the module was already READY (not connected yet -- session_start() will send presence as
+        soon as it fires, now that gating allows it). No-op if already marked ready."""
+        if self._module_ready:
+            return
+        self._module_ready = True
+        if self._connect_event.is_set():
+            self.send_presence()
 
     def reconnect(self, wait: int | float = 2.0, reason: str = "Reconnecting") -> Any:
         """Disconnect only, instead of slixmpp's default reconnect-in-place.

--- a/pyobs/comm/xmpp/xmppcomm.py
+++ b/pyobs/comm/xmpp/xmppcomm.py
@@ -170,6 +170,12 @@ class XmppComm(Comm):
         self._xmpp: XmppClient | None = None
         self._rpc: RPC | None = None
 
+        # module readiness (see mark_ready()) -- lives here rather than solely on XmppClient
+        # because _connect() replaces self._xmpp with a brand-new instance on every reconnect,
+        # and a reconnect after the module is already READY must announce presence immediately
+        # rather than re-gating it
+        self._module_ready = False
+
         # pubsub for states
         self._pubsub_service = f"pubsub.{self._domain}"
         self._state_node_handlers: dict[str, tuple[type[Interface], list[Callable[[Any], None]]]] = {}
@@ -212,6 +218,18 @@ class XmppComm(Comm):
 
         # create client
         self._xmpp = XmppClient(self._jid, self._password)
+
+        # presence gating (see mark_ready()) only applies to a comm with an actual Module
+        # attached that hasn't finished starting yet -- a module-less XmppComm (a GUI, an
+        # admin tool, a bare observer in tests) has no such lifecycle and must announce
+        # itself immediately as before, or peers relying on presence-based discovery would
+        # never see it. Likewise, if the module already reached READY on a previous
+        # connection, tell the new client right away -- it isn't connected yet, so this
+        # doesn't send anything itself, but it means session_start() will announce presence
+        # immediately once (re)connected instead of holding it back as if this were the
+        # initial startup.
+        if self._module_ready or not self.has_module:
+            self._xmpp.mark_ready()
 
         # self._xmpp = slixmpp.ClientXMPP(self._jid, password)
         # Register directly with an XML mask rather than via pubsub_publish.
@@ -957,6 +975,14 @@ class XmppComm(Comm):
             CLOSED → handled by normal disconnect (unavailable)
         error_string rides as <status> text when state is ERROR.
         """
+        # publishing any lifecycle state at all is itself a readiness signal -- covers direct
+        # set_presence() callers that don't go through Module.set_state() (see mark_ready()).
+        # Idempotent: unlocks send_presence() once, then this call's own send below goes through.
+        # Goes through self._mark_ready() (not just self.client.mark_ready()) so self._module_ready
+        # is set too -- otherwise a later reconnect (_connect() creates a brand-new XmppClient)
+        # would re-gate presence on the new client despite this module already being announced.
+        await self._mark_ready()
+
         _show_map: dict[ModuleState, str | None] = {
             ModuleState.READY: None,
             ModuleState.ERROR: "dnd",
@@ -965,6 +991,12 @@ class XmppComm(Comm):
         show = _show_map.get(state)
         status = error_string if state == ModuleState.ERROR and error_string else None
         self.client.send_presence(pshow=show, pstatus=status)
+
+    async def _mark_ready(self) -> None:
+        """See Comm.mark_ready(). Remembers readiness on self (survives client recreation on
+        reconnect, see _connect()) and lets the live client announce presence now."""
+        self._module_ready = True
+        self.client.mark_ready()
 
     async def _subscribe_presence(self, module: str, callback: Callable[[ModuleState, str], None]) -> None:
         self._presence_callbacks.setdefault(module, []).append(callback)

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -327,7 +327,7 @@ class Module(Object, IModule, IConfig):
                 ConfigCapabilities(caps=self._config_caps),
             )
 
-    async def start(self) -> None:
+    async def startup(self) -> None:
         """Open the module and mark it ready for RPC dispatch.
 
         Runs the full open() override chain (base Module setup plus every subclass's own
@@ -337,6 +337,11 @@ class Module(Object, IModule, IConfig):
         this instead of open() directly -- otherwise the module stays in STARTING forever.
         Callers that need finer-grained control (e.g. tests exercising STARTING behavior
         directly) can call open() and set_state() separately instead.
+
+        Named startup() rather than start() because start() is already IStartStop's abstract
+        RPC method -- a plain start() here would be silently shadowed by any module
+        implementing that interface (guiding, mastermind, scheduler, weather, kiosk, ...),
+        which would then never leave STARTING under Application/MultiModule.
         """
         await self.open()
         await self.set_state(ModuleState.READY)
@@ -947,7 +952,7 @@ class MultiModule(Module):
 
         _module_name_var.set(name)
         try:
-            await mod.start()
+            await mod.startup()
             await mod.main()
         except asyncio.CancelledError:
             pass

--- a/pyobs/modules/module.py
+++ b/pyobs/modules/module.py
@@ -148,8 +148,9 @@ class Module(Object, IModule, IConfig):
         self._device_name = self.comm.name
         self._label = label if label is not None else self._device_name
 
-        # state
-        self._state = ModuleState.READY
+        # state -- starts STARTING, moved to READY once Application finishes the full open() chain
+        # (see Module.execute()'s guard and Application._main)
+        self._state = ModuleState.STARTING
         self._error_string = ""
 
         # own?
@@ -174,6 +175,12 @@ class Module(Object, IModule, IConfig):
     # un-typed, either locally or across an RPC boundary. Neither is part of the deliberate
     # per-type logging contract a module author gets to opt out of.
     _UNSUPPRESSIBLE: tuple[type[exc.PyobsError], ...] = (exc.ModuleError, exc.UnclassifiedError)
+
+    # methods still callable while the module is ModuleState.STARTING -- introspection/recovery
+    # only, nothing that touches a device that may not be initialized yet. get_version/get_label
+    # are deliberately not listed: they aren't declared on IModule, so they never appear in
+    # self._methods and can't be called via execute() at all, in any state.
+    _STARTING_WHITELIST: tuple[str, ...] = ("get_permitted_methods", "reset_error")
 
     def _disable_exception_logging(self, *exceptions: type[exc.PyobsError]) -> None:
         """Declare that the given PyobsError types (and their subclasses) fire often enough that even the
@@ -319,6 +326,20 @@ class Module(Object, IModule, IConfig):
                 IConfig,
                 ConfigCapabilities(caps=self._config_caps),
             )
+
+    async def start(self) -> None:
+        """Open the module and mark it ready for RPC dispatch.
+
+        Runs the full open() override chain (base Module setup plus every subclass's own
+        setup) and only then transitions ModuleState.STARTING -> READY, so Module.execute()
+        starts accepting non-whitelisted calls exactly once startup has actually finished.
+        Every caller that opens a module standalone (Application, MultiModule) should call
+        this instead of open() directly -- otherwise the module stays in STARTING forever.
+        Callers that need finer-grained control (e.g. tests exercising STARTING behavior
+        directly) can call open() and set_state() separately instead.
+        """
+        await self.open()
+        await self.set_state(ModuleState.READY)
 
     async def close(self) -> None:
         """Close module."""
@@ -538,6 +559,10 @@ class Module(Object, IModule, IConfig):
         Raises:
             KeyError: If method does not exist.
         """
+
+        # is module still starting up?
+        if self._state == ModuleState.STARTING and method not in self._STARTING_WHITELIST:
+            raise exc.ModuleStartingError("Module is still starting up, please try again shortly.")
 
         # is module in error state?
         if self._state == ModuleState.ERROR:
@@ -771,6 +796,11 @@ class Module(Object, IModule, IConfig):
         if self._comm is not None:
             await self._comm.set_presence(state, error_string if error_string is not None else self._error_string)
 
+            # first time reaching READY, tell the transport it may now announce this module to
+            # peers -- e.g. XmppComm delays its initial XMPP presence until here, see mark_ready()
+            if state == ModuleState.READY:
+                await self._comm.mark_ready()
+
     async def get_state(self, **kwargs: Any) -> ModuleState:  # type: ignore[override]
         """Returns current state of module."""
         return self._state
@@ -917,7 +947,7 @@ class MultiModule(Module):
 
         _module_name_var.set(name)
         try:
-            await mod.open()
+            await mod.start()
             await mod.main()
         except asyncio.CancelledError:
             pass

--- a/pyobs/utils/enums.py
+++ b/pyobs/utils/enums.py
@@ -14,12 +14,14 @@ class ModuleState(StrEnum):
 
     Attributes:
         CLOSED: Module is closed.
+        STARTING: Module is starting up and not yet ready to accept commands.
         READY: Module is ready.
         ERROR: Module has an error.
         LOCAL: Module is in local mode and cannot be used remotely.
     """
 
     CLOSED = "closed"
+    STARTING = "starting"
     READY = "ready"
     ERROR = "error"
     LOCAL = "local"

--- a/pyobs/utils/exceptions.py
+++ b/pyobs/utils/exceptions.py
@@ -122,6 +122,15 @@ class DeviceBusyError(PyobsError):
     pass
 
 
+class ModuleStartingError(PyobsError):
+    """The module hasn't finished its own startup yet (still inside `open()`, e.g. connecting to
+    hardware) and isn't safe to command -- distinct from DeviceBusyError, which means the module is
+    fully up but its device is occupied with another operation. Back off and retry once the module
+    reports ModuleState.READY, rather than treating this as a domain failure."""
+
+    pass
+
+
 class NotSupportedError(PyobsError):
     """This module doesn't support the requested operation at all -- a capability the module only
     optionally implements (e.g. an alt/az-only telescope asked to move_radec) isn't available,

--- a/tests/integration/test_xmpp_acl.py
+++ b/tests/integration/test_xmpp_acl.py
@@ -35,7 +35,7 @@ async def test_acl_deny_forbids_call(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"deny": ["observer"]})
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -57,7 +57,7 @@ async def test_acl_allow_interface_name_sugar(make_xmpp_comm, make_camera_comm) 
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"observer": ["ICooling"]}})
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -85,7 +85,7 @@ async def test_acl_deny_allows_other_callers(make_xmpp_comm, make_camera_comm) -
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"deny": ["legacy_gui"]})
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -106,7 +106,7 @@ async def test_acl_allow_permits_listed_method(make_xmpp_comm, make_camera_comm)
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"observer": "*"}})
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -127,7 +127,7 @@ async def test_acl_allow_denies_unlisted_caller(make_xmpp_comm, make_camera_comm
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"mastermind": "*"}})
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok

--- a/tests/integration/test_xmpp_acl.py
+++ b/tests/integration/test_xmpp_acl.py
@@ -35,7 +35,7 @@ async def test_acl_deny_forbids_call(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"deny": ["observer"]})
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -57,7 +57,7 @@ async def test_acl_allow_interface_name_sugar(make_xmpp_comm, make_camera_comm) 
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"observer": ["ICooling"]}})
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -85,7 +85,7 @@ async def test_acl_deny_allows_other_callers(make_xmpp_comm, make_camera_comm) -
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"deny": ["legacy_gui"]})
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -106,7 +106,7 @@ async def test_acl_allow_permits_listed_method(make_xmpp_comm, make_camera_comm)
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"observer": "*"}})
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -127,7 +127,7 @@ async def test_acl_allow_denies_unlisted_caller(make_xmpp_comm, make_camera_comm
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm, acl={"allow": {"mastermind": "*"}})
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok

--- a/tests/integration/test_xmpp_dummy_camera.py
+++ b/tests/integration/test_xmpp_dummy_camera.py
@@ -32,7 +32,7 @@ async def test_dummy_camera_publishes_cooling_state(make_xmpp_comm, make_camera_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -66,7 +66,7 @@ async def test_dummy_camera_cooling_state_reflects_set_cooling(make_xmpp_comm, m
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -102,7 +102,7 @@ async def test_dummy_camera_publishes_iwindow_capabilities(make_xmpp_comm, make_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -129,7 +129,7 @@ async def test_dummy_camera_publishes_imodule_capabilities(make_xmpp_comm, make_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -156,7 +156,7 @@ async def test_dummy_camera_no_capabilities_for_unconfigured_interface(make_xmpp
 
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)

--- a/tests/integration/test_xmpp_dummy_camera.py
+++ b/tests/integration/test_xmpp_dummy_camera.py
@@ -32,7 +32,7 @@ async def test_dummy_camera_publishes_cooling_state(make_xmpp_comm, make_camera_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -66,7 +66,7 @@ async def test_dummy_camera_cooling_state_reflects_set_cooling(make_xmpp_comm, m
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -102,7 +102,7 @@ async def test_dummy_camera_publishes_iwindow_capabilities(make_xmpp_comm, make_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -129,7 +129,7 @@ async def test_dummy_camera_publishes_imodule_capabilities(make_xmpp_comm, make_
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
@@ -156,7 +156,7 @@ async def test_dummy_camera_no_capabilities_for_unconfigured_interface(make_xmpp
 
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
 
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)

--- a/tests/integration/test_xmpp_presence.py
+++ b/tests/integration/test_xmpp_presence.py
@@ -92,6 +92,7 @@ async def test_presence_error_state_delivered(make_xmpp_comm, make_unopened_comm
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
@@ -120,6 +121,7 @@ async def test_presence_local_state_delivered(make_xmpp_comm, make_unopened_comm
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
@@ -147,9 +149,16 @@ async def test_set_state_automatically_updates_presence(make_xmpp_comm, make_uno
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
         observer_comm = await make_xmpp_comm("observer")
-        await wait_for_peer(observer_comm, "camera")
 
         m = Module(comm=camera_comm)
+
+        # establish visibility first, via the same automatic set_state() -> presence path
+        # this test exercises -- a first-ever "came online" broadcast reaching a subscriber
+        # that connected before camera ever announced itself isn't guaranteed by every XMPP
+        # deployment's roster/subscription setup, so route through READY like every other
+        # peer-discovery test here before exercising the ERROR update this test is about.
+        await m.set_state(ModuleState.READY)
+        await wait_for_peer(observer_comm, "camera")
 
         await m.set_state(ModuleState.ERROR, "disk full")
 
@@ -214,6 +223,7 @@ async def test_imodule_capabilities_in_disco_info(make_xmpp_comm, make_unopened_
 
         # publish capabilities explicitly (normally done by Module.open())
         await camera_comm.set_capabilities(IModule, ModuleCapabilities(version="2.0.0.dev1", label="My Camera"))
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
@@ -243,6 +253,7 @@ async def test_iwindow_capabilities_in_disco_info(make_xmpp_comm, make_unopened_
             IWindow,
             WindowCapabilities(full_frame_x=0, full_frame_y=0, full_frame_width=4096, full_frame_height=4096),
         )
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
@@ -269,6 +280,7 @@ async def test_multiple_interface_capabilities(make_xmpp_comm, make_unopened_com
             IWindow,
             WindowCapabilities(full_frame_x=0, full_frame_y=0, full_frame_width=512, full_frame_height=512),
         )
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
@@ -298,6 +310,7 @@ async def test_get_capabilities_api(make_xmpp_comm, make_unopened_comm) -> None:
             IWindow,
             WindowCapabilities(full_frame_x=0, full_frame_y=0, full_frame_width=4096, full_frame_height=4096),
         )
+        await camera_comm.set_presence(ModuleState.READY)
 
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")

--- a/tests/integration/test_xmpp_rpc.py
+++ b/tests/integration/test_xmpp_rpc.py
@@ -38,7 +38,7 @@ async def test_rpc_void_return_bool_float_params(make_xmpp_comm, make_camera_com
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -59,7 +59,7 @@ async def test_rpc_float_return(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -83,7 +83,7 @@ async def test_rpc_float_param_float_return(make_xmpp_comm, make_camera_comm) ->
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -112,7 +112,7 @@ async def test_rpc_int_params_void_return(make_xmpp_comm, make_camera_comm) -> N
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -133,7 +133,7 @@ async def test_rpc_exception_fault(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -158,7 +158,7 @@ async def test_rpc_bool_float_roundtrip(make_xmpp_comm, make_camera_comm) -> Non
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.start()
+            await camera.startup()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok

--- a/tests/integration/test_xmpp_rpc.py
+++ b/tests/integration/test_xmpp_rpc.py
@@ -38,7 +38,7 @@ async def test_rpc_void_return_bool_float_params(make_xmpp_comm, make_camera_com
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -59,7 +59,7 @@ async def test_rpc_float_return(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -83,7 +83,7 @@ async def test_rpc_float_param_float_return(make_xmpp_comm, make_camera_comm) ->
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -112,7 +112,7 @@ async def test_rpc_int_params_void_return(make_xmpp_comm, make_camera_comm) -> N
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -133,7 +133,7 @@ async def test_rpc_exception_fault(make_xmpp_comm, make_camera_comm) -> None:
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok
@@ -158,7 +158,7 @@ async def test_rpc_bool_float_roundtrip(make_xmpp_comm, make_camera_comm) -> Non
     async def _run():
         camera = DummyCamera(name="camera", comm=make_camera_comm)
         try:
-            await camera.open()
+            await camera.start()
             observer_comm = await make_xmpp_comm("observer")
             ok = await wait_for(lambda: "camera" in observer_comm.clients)
             assert ok

--- a/tests/integration/test_xmpp_state.py
+++ b/tests/integration/test_xmpp_state.py
@@ -24,6 +24,7 @@ import pytest
 
 from pyobs.events import ModuleClosedEvent
 from pyobs.interfaces import CoolingState, ICooling
+from pyobs.utils.enums import ModuleState
 from tests.integration.conftest import make_module
 
 # Applies asyncio/integration/xmpp marks to every test in this module.
@@ -68,6 +69,7 @@ async def test_subscriber_receives_initial_value_on_subscribe(make_xmpp_comm, ma
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
         await camera_comm.set_state(ICooling, CoolingState(setpoint=-20.0, power=65, enabled=True))
 
         # Brief pause to let ejabberd persist the item before observer subscribes
@@ -94,6 +96,7 @@ async def test_subscriber_receives_live_update(make_xmpp_comm, make_unopened_com
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
 
@@ -120,6 +123,7 @@ async def test_proxy_state_method_reflects_latest_value(make_xmpp_comm, make_uno
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
         await camera_comm.set_state(ICooling, CoolingState(setpoint=-15.0, power=50, enabled=True))
         await asyncio.sleep(0.5)
 
@@ -147,6 +151,7 @@ async def test_disconnect_cleans_up_subscriptions(make_xmpp_comm, make_unopened_
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
 
@@ -176,6 +181,7 @@ async def test_reconnect_resubscribes_with_fresh_proxy(make_xmpp_comm, make_unop
         comm = make_unopened_comm("camera")
         make_module([ICooling], comm)
         camera_comm = await make_xmpp_comm("camera", comm=comm)
+        await camera_comm.set_presence(ModuleState.READY)
         observer_comm = await make_xmpp_comm("observer")
         await wait_for_peer(observer_comm, "camera")
 
@@ -190,6 +196,7 @@ async def test_reconnect_resubscribes_with_fresh_proxy(make_xmpp_comm, make_unop
         comm2 = make_unopened_comm("camera")
         make_module([ICooling], comm2)
         camera_comm2 = await make_xmpp_comm("camera", comm=comm2)
+        await camera_comm2.set_presence(ModuleState.READY)
         await camera_comm2.set_state(ICooling, CoolingState(setpoint=-30.0, power=90, enabled=True))
 
         await wait_for_peer(observer_comm, "camera")

--- a/tests/modules/test/test_standalone.py
+++ b/tests/modules/test/test_standalone.py
@@ -5,6 +5,7 @@ import pytest
 
 from pyobs.modules.test import StandAlone
 from pyobs.utils import exceptions as exc
+from pyobs.utils.enums import ModuleState
 
 
 def test_default():
@@ -108,6 +109,7 @@ def test_acl_allow_unknown_entry_kept_as_plain_method_name():
 @pytest.mark.asyncio
 async def test_execute_allow_interface_name_sugar_permits_interface_methods():
     module = StandAlone(acl={"allow": {"scheduler": ["IConfig"]}})
+    module._state = ModuleState.READY  # set_config_value isn't in the STARTING whitelist
     with pytest.raises(exc.ForbiddenError):
         await module.execute("reset_error", sender="scheduler")
     # set_config_value is part of IConfig, so it's permitted by the "IConfig" sugar entry --

--- a/tests/modules/test_exception_logging.py
+++ b/tests/modules/test_exception_logging.py
@@ -7,14 +7,21 @@ import pytest
 from pyobs.interfaces import IAbortable
 from pyobs.modules import Module
 from pyobs.utils import exceptions as exc
+from pyobs.utils.enums import ModuleState
 
 
 class _AbortableModule(Module, IAbortable):
-    """Minimal test module whose abort() raises whatever exception it's given."""
+    """Minimal test module whose abort() raises whatever exception it's given.
+
+    Starts in ModuleState.READY rather than the real STARTING default -- these tests
+    exercise execute()'s exception classification/logging, not startup gating (that's
+    covered separately in tests/modules/test_startup_gating.py).
+    """
 
     def __init__(self, to_raise: Exception, **kwargs: Any):
         Module.__init__(self, **kwargs)
         self._to_raise = to_raise
+        self._state = ModuleState.READY
 
     async def abort(self, **kwargs: Any) -> None:
         raise self._to_raise

--- a/tests/modules/test_startup_gating.py
+++ b/tests/modules/test_startup_gating.py
@@ -1,4 +1,4 @@
-"""Tests for the ModuleState.STARTING guard in Module.execute() and the Module.start()
+"""Tests for the ModuleState.STARTING guard in Module.execute() and the Module.startup()
 helper that transitions a module out of it once open() has fully finished.
 """
 
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from pyobs.interfaces import IAbortable
+from pyobs.interfaces import IAbortable, IStartStop
 from pyobs.modules import Module
 from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ModuleState
@@ -23,6 +23,25 @@ class _AbortableModule(Module, IAbortable):
 
     async def abort(self, **kwargs: Any) -> None:
         self.aborted = True
+
+
+class _StartStopModule(Module, IStartStop):
+    """Module implementing IStartStop, whose abstract `start(**kwargs)` RPC method has the
+    same name as Module's lifecycle helper -- regression coverage for that collision (see
+    DEV_STARTUP.md, "Post-landing regression")."""
+
+    def __init__(self, **kwargs: Any):
+        Module.__init__(self, **kwargs)
+        self.running = False
+
+    async def start(self, **kwargs: Any) -> None:
+        self.running = True
+
+    async def stop(self, **kwargs: Any) -> None:
+        self.running = False
+
+    async def is_running(self, **kwargs: Any) -> bool:
+        return self.running
 
 
 def test_module_starts_in_starting_state() -> None:
@@ -55,10 +74,10 @@ async def test_execute_allows_whitelisted_calls_while_starting(method: str) -> N
 
 @pytest.mark.asyncio
 async def test_start_transitions_to_ready_and_unblocks_execute() -> None:
-    """Module.start() must run the full open() chain and then flip STARTING -> READY."""
+    """Module.startup() must run the full open() chain and then flip STARTING -> READY."""
     module = _AbortableModule(own_comm=False)
 
-    await module.start()
+    await module.startup()
 
     assert module._state == ModuleState.READY
     await module.execute("abort", sender="tester")
@@ -67,8 +86,8 @@ async def test_start_transitions_to_ready_and_unblocks_execute() -> None:
 
 @pytest.mark.asyncio
 async def test_open_alone_does_not_reach_ready() -> None:
-    """Calling open() directly (bypassing start()) must leave the module in STARTING --
-    this is the exact gap that broke MultiModule sub-modules before start() existed."""
+    """Calling open() directly (bypassing startup()) must leave the module in STARTING --
+    this is the exact gap that broke MultiModule sub-modules before startup() existed."""
     module = _AbortableModule(own_comm=False)
 
     await module.open()
@@ -76,3 +95,20 @@ async def test_open_alone_does_not_reach_ready() -> None:
     assert module._state == ModuleState.STARTING
     with pytest.raises(exc.ModuleStartingError):
         await module.execute("abort", sender="tester")
+
+
+@pytest.mark.asyncio
+async def test_startup_reaches_ready_on_module_implementing_istartstop() -> None:
+    """Module.startup() must be the lifecycle helper actually called by MultiModule/
+    Application, not IStartStop.start() -- a name collision would silently call the RPC
+    command instead, leaving the module stuck in STARTING forever (real regression, caught
+    via a pyobs-gui full.yaml run: a DummyAutoGuiding module never reached READY)."""
+    module = _StartStopModule(own_comm=False)
+
+    await module.startup()
+
+    assert module._state == ModuleState.READY
+    assert module.running is False  # startup() must not have invoked IStartStop.start()
+
+    await module.execute("start", sender="tester")
+    assert module.running is True

--- a/tests/modules/test_startup_gating.py
+++ b/tests/modules/test_startup_gating.py
@@ -1,0 +1,78 @@
+"""Tests for the ModuleState.STARTING guard in Module.execute() and the Module.start()
+helper that transitions a module out of it once open() has fully finished.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pyobs.interfaces import IAbortable
+from pyobs.modules import Module
+from pyobs.utils import exceptions as exc
+from pyobs.utils.enums import ModuleState
+
+
+class _AbortableModule(Module, IAbortable):
+    """Minimal test module with one guarded (non-whitelisted) RPC method."""
+
+    def __init__(self, **kwargs: Any):
+        Module.__init__(self, **kwargs)
+        self.aborted = False
+
+    async def abort(self, **kwargs: Any) -> None:
+        self.aborted = True
+
+
+def test_module_starts_in_starting_state() -> None:
+    """A freshly constructed module hasn't been started yet."""
+    module = _AbortableModule()
+    assert module._state == ModuleState.STARTING
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_non_whitelisted_call_while_starting() -> None:
+    """A regular RPC method must be rejected while the module is still STARTING."""
+    module = _AbortableModule()
+
+    with pytest.raises(exc.ModuleStartingError):
+        await module.execute("abort", sender="tester")
+
+    assert module.aborted is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get_permitted_methods", "reset_error"])
+async def test_execute_allows_whitelisted_calls_while_starting(method: str) -> None:
+    """Introspection/recovery methods must stay callable during STARTING."""
+    module = _AbortableModule()
+
+    result = await module.execute(method, sender="tester")
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_start_transitions_to_ready_and_unblocks_execute() -> None:
+    """Module.start() must run the full open() chain and then flip STARTING -> READY."""
+    module = _AbortableModule(own_comm=False)
+
+    await module.start()
+
+    assert module._state == ModuleState.READY
+    await module.execute("abort", sender="tester")
+    assert module.aborted is True
+
+
+@pytest.mark.asyncio
+async def test_open_alone_does_not_reach_ready() -> None:
+    """Calling open() directly (bypassing start()) must leave the module in STARTING --
+    this is the exact gap that broke MultiModule sub-modules before start() existed."""
+    module = _AbortableModule(own_comm=False)
+
+    await module.open()
+
+    assert module._state == ModuleState.STARTING
+    with pytest.raises(exc.ModuleStartingError):
+        await module.execute("abort", sender="tester")


### PR DESCRIPTION
## Summary
- Modules with slow `open()` (e.g. camera drivers connecting to hardware) were reachable over RPC and visible to XMPP peer discovery the instant they connected to the server, long before startup actually finished.
- New `ModuleState.STARTING`, set at construction and cleared by the new `Module.start()` once the full `open()` override chain completes; `Module.execute()` rejects non-whitelisted calls (`get_permitted_methods`/`reset_error` excepted) with a new `ModuleStartingError` while `STARTING`.
- `XmppComm`/`XmppClient` hold back the initial presence broadcast until a module reaches `READY`, closing a race where a peer could read capabilities (e.g. `IWindow`/`IBinning`) that were still mid-publish -- scoped to comms with an actual starting `Module` attached, so bare/GUI-style `XmppComm` usage is unaffected.
- `Application` and `MultiModule` both call `Module.start()` instead of `open()` now (the latter was a real gap: sub-modules would otherwise never leave `STARTING`).
- Updated changelog, whatsnew-2.0.rst (breaking change + upgrade note), and API docs.

## Test plan
- [x] `pytest tests/ -m "not integration and not xmpp"` -- 1316 passed
- [x] `pytest tests/integration -m xmpp` against a live local ejabberd -- 30 passed
- [x] `ruff check .` clean
- [x] `pyrefly check` clean on touched files
- [x] `sphinx-build -W --keep-going` -- no new warnings introduced