### PR TITLE
Add per-step on_error control to image processing pipelines

### DIFF
--- a/pyobs/images/processor.py
+++ b/pyobs/images/processor.py
@@ -3,12 +3,32 @@ from typing import Any
 
 from pyobs.images import Image
 from pyobs.object import Object
+from pyobs.utils.exceptions import ImageError
 
 
 class ImageProcessor(Object, metaclass=ABCMeta):
-    def __init__(self, **kwargs: Any):
-        """Init new image processor."""
+    VALID_ERROR_MODES = frozenset(("raise", "error", "info", "ignore"))
+
+    def __init__(self, on_error: str = "raise", **kwargs: Any):
+        """Init new image processor.
+
+        Args:
+            on_error: How the pipeline should handle an ImageError raised by this step. One of:
+                - "raise" (default): re-raise the exception, aborting the pipeline.
+                - "error": call handle_error(), pass its return value downstream.
+                - "info": log at INFO level, pass the pre-step image downstream unmodified.
+                - "ignore": silently pass the pre-step image downstream unmodified.
+        """
         Object.__init__(self, **kwargs)
+
+        self._on_error = on_error
+        if self._on_error not in self.VALID_ERROR_MODES:
+            raise ValueError(f"on_error must be one of {sorted(self.VALID_ERROR_MODES)}, got {self._on_error!r}.")
+
+    @property
+    def on_error(self) -> str:
+        """The error handling mode for this step."""
+        return self._on_error
 
     @abstractmethod
     async def __call__(self, image: Image) -> Image:
@@ -20,6 +40,21 @@ class ImageProcessor(Object, metaclass=ABCMeta):
         Returns:
             Processed image.
         """
+
+    def handle_error(self, image: Image, error: ImageError) -> Image:
+        """Handle an ImageError raised by this step, when on_error == "error".
+
+        Override this to customize error handling (e.g. tag the image with a FITS header).
+        The default implementation re-raises the error.
+
+        Args:
+            image: The image that caused the error.
+            error: The ImageError that was raised.
+
+        Returns:
+            The image to pass to the next pipeline step.
+        """
+        raise error
 
     async def reset(self) -> None:
         """Resets state of image processor"""

--- a/pyobs/images/processors/astrometry/dotnet.py
+++ b/pyobs/images/processors/astrometry/dotnet.py
@@ -31,11 +31,15 @@ class AstrometryDotNet(Astrometry):
                          (commonly degrees for astrometry.net). Default: ``3.0``.
     :param int timeout: Timeout in seconds for the network call to the astrometry
                         web service. Default: ``10``.
-    :param bool exceptions: Whether to raise exceptions on failure. If ``True``,
-                            processing errors are raised (typically as
-                            :class:`pyobs.images.exceptions.ImageError`). If ``False``,
-                            errors are handled by marking the image header and returning
-                            the original image. Default: ``True``.
+    :param bool exceptions: Deprecated, use ``on_error`` instead. ``exceptions=False`` is
+                            equivalent to ``on_error="error"``; ``exceptions=True`` (the
+                            default) is equivalent to ``on_error="raise"``.
+    :param str on_error: How the pipeline should handle a failed solve: ``"raise"`` (default,
+                         abort the pipeline), ``"error"`` (mark ``WCSERR=1`` in the header, log
+                         a warning, and pass the image through -- see ``handle_error``),
+                         ``"info"``, or ``"ignore"``. Only takes effect when this processor
+                         runs as a step in a ``PipelineMixin`` pipeline; a direct call always
+                         raises on failure.
     :param kwargs: Additional keyword arguments forwarded to
                    :class:`pyobs.images.processors.astrometry.Astrometry`.
 
@@ -48,11 +52,9 @@ class AstrometryDotNet(Astrometry):
     - On success, receives solver output and writes the resulting WCS into a copy of
       the input image using :class:`pyobs.images.processors.astrometry._ResponseImageWriter`.
     - Logs the outcome, including WCS information, and returns the result image.
-    - On failure:
-
-        - If ``exceptions=True``, raises the underlying :class:`pyobs.images.exceptions.ImageError`.
-        - If ``exceptions=False``, sets ``WCSERR=1`` in the FITS header, logs a warning, and returns the original
-          image unchanged.
+    - On failure, raises the underlying :class:`pyobs.images.exceptions.ImageError`. When run as
+      a pipeline step with ``on_error="error"``, the pipeline calls ``handle_error``, which sets
+      ``WCSERR=1`` in the FITS header, logs a warning, and returns the original image unchanged.
 
     Input/Output
     ------------
@@ -69,20 +71,20 @@ class AstrometryDotNet(Astrometry):
        class: pyobs.images.processors.astrometry.AstrometryDotNet
        url: "http://localhost:8080/api"
 
-    Handle failures without raising exceptions:
+    Handle failures without aborting the pipeline:
 
     .. code-block:: yaml
 
        class: pyobs.images.processors.astrometry.AstrometryDotNet
        url: "http://localhost:8080/api"
-       exceptions: false
+       on_error: error
 
     Notes
     -----
     - The ``_DotNetRequestBuilder`` determines how sources are extracted and how the
       request is formed (including any unit conventions for ``radius``). Consult its
       documentation for details.
-    - ``WCSERR`` is used as a failure marker in the FITS header when ``exceptions=False``.
+    - ``WCSERR`` is used as a failure marker in the FITS header when ``handle_error`` runs.
     """
 
     __module__ = "pyobs.images.processors.astrometry"
@@ -93,7 +95,8 @@ class AstrometryDotNet(Astrometry):
         source_count: int = 50,
         radius: float = 3.0,
         timeout: int = 10,
-        exceptions: bool = True,
+        exceptions: bool | None = None,
+        on_error: str = "raise",
         **kwargs: Any,
     ):
         """Init new astronomy.net processor.
@@ -103,16 +106,27 @@ class AstrometryDotNet(Astrometry):
             source_count: Number of sources to send.
             radius: Radius to search in.
             timeout: Timeout in seconds for call to astrometry web service.
-            exceptions: Whether to raise Exceptions.
+            exceptions: Deprecated, use on_error instead. Whether to raise Exceptions.
+            on_error: How to handle a failed solve. One of "raise", "error", "info", "ignore".
+                On "error", handle_error() marks the image with WCSERR=1 and logs a warning.
         """
-        Astrometry.__init__(self, **kwargs)
+        Astrometry.__init__(self, on_error=on_error, **kwargs)
 
         self.url = url
 
         self.timeout = timeout
-        self.exceptions = exceptions
+
+        # backwards compat: if 'exceptions' is set but 'on_error' is left at its default,
+        # derive on_error from it.
+        if exceptions is not None and on_error == "raise":
+            self._on_error = "raise" if exceptions else "error"
 
         self._request_builder = _DotNetRequestBuilder(source_count, radius)
+
+    @property
+    def exceptions(self) -> bool:
+        """Deprecated, use on_error instead."""
+        return self.on_error != "error"
 
     async def _process(self, image: Image) -> Image:
         # build the request
@@ -132,10 +146,7 @@ class AstrometryDotNet(Astrometry):
 
         return result_image
 
-    def _handle_error(self, image: Image, error: exc.ImageError) -> Image:
-        if self.exceptions:
-            raise error
-
+    def handle_error(self, image: Image, error: exc.ImageError) -> Image:
         image.header["WCSERR"] = 1
 
         log.warning(error.message)
@@ -145,16 +156,13 @@ class AstrometryDotNet(Astrometry):
     async def __call__(self, image: Image) -> Image:
         """Find astrometric solution on given image.
 
-        Writes WCSERR=1 into FITS header on failure.
+        Writes WCSERR=1 into FITS header on failure (see handle_error).
 
         Args:
             image: Image to analyse.
         """
 
-        try:
-            return await self._process(image)
-        except exc.ImageError as e:
-            return self._handle_error(image, e)
+        return await self._process(image)
 
 
 __all__ = ["AstrometryDotNet"]

--- a/pyobs/mixins/pipeline.py
+++ b/pyobs/mixins/pipeline.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pyobs.images import Image, ImageProcessor
 from pyobs.object import Object
+from pyobs.utils.exceptions import ImageError
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +38,10 @@ class PipelineMixin:
     async def run_pipeline(self, image: Image) -> Image:
         """Run the pipeline on the given image.
 
+        Each step is run, and an ImageError it raises is handled according to the step's
+        on_error setting (default "raise"): re-raised, dispatched to the step's handle_error(),
+        logged, or ignored. Non-ImageError exceptions always propagate.
+
         Args:
             image: Image to run pipeline on.
 
@@ -44,9 +49,18 @@ class PipelineMixin:
             Image after pipeline run.
         """
 
-        # loop steps, just let any exception pass
         for step in self.__pipeline_steps:
-            image = await step(image)
+            try:
+                image = await step(image)
+            except ImageError as e:
+                if step.on_error == "raise":
+                    raise
+                elif step.on_error == "error":
+                    image = step.handle_error(image, e)
+                elif step.on_error == "info":
+                    log.info("Step %s: %s", type(step).__name__, e)
+                elif step.on_error == "ignore":
+                    pass
 
         # finished
         return image

--- a/specs/plans/pipeline-step-error-control.md
+++ b/specs/plans/pipeline-step-error-control.md
@@ -1,6 +1,6 @@
 # Plan: Per-step error control in image processing pipelines
 
-Status: draft
+Status: implemented
 Issues: #693, #328 (previous attempt — nested `ExceptionHandler` wrapper, not merged)
 
 ## Problem
@@ -124,22 +124,15 @@ class ImageProcessor(Object, metaclass=ABCMeta):
         """Resets state of image processor."""
 ```
 
-Note: `__call__` becomes a *concrete* method (not abstract) that calls an *abstract*
-`_process()` template, but the existing behavior is that every subclass overrides `__call__`
-directly. To minimize disruption, keep `__call__` abstract and add the `handle_error` method
-as a new concrete hook. Subclasses that currently handle errors in their `__call__` method
-(like `AstrometryDotNet`) will be migrated in a follow-up step.
-
-Actually — looking at the current code, every processor that handles its own errors does so
-inside `__call__` (via try/except in `AstrometryDotNet`, via early-return in
-`SepSourceDetection.__call__`). The cleanest migration path:
+`__call__` stays abstract, as today — the base class only adds the error-*handling* hook
+(`handle_error`), not an error-*catching* wrapper; the catching happens in the pipeline
+(next section). Migration path for processors that currently catch their own errors inside
+`__call__` (e.g. `AstrometryDotNet`'s try/except, `SepSourceDetection`'s early-return):
 
 1. Add `handle_error` and `on_error` to the base class (as above).
-2. Have `AstrometryDotNet.__call__` call `handle_error` instead of its internal `_handle_error`.
-3. The pipeline-level try/except (next step) handles the remaining paths where exceptions escape.
-
-So `__call__` stays abstract — the base class only adds the error-*handling* hook, not an
-error-*catching* wrapper (that lives in the pipeline).
+2. Move each processor's internal error-handling logic into its own `handle_error` override.
+3. Remove the internal try/except — let the pipeline's per-step try/except (below) catch and
+   dispatch instead.
 
 ### 2. `PipelineMixin.run_pipeline()` — wrap each step
 

--- a/tests/images/processors/astrometry/test_dotnet.py
+++ b/tests/images/processors/astrometry/test_dotnet.py
@@ -18,6 +18,7 @@ def test_init_default():
     assert astrometry._request_builder._source_count == 50
     assert astrometry._request_builder._radius == 3.0
     assert astrometry.timeout == 10
+    assert astrometry.on_error == "raise"
     assert astrometry.exceptions is True
 
 
@@ -33,46 +34,23 @@ def test_init_w_values():
     assert astrometry._request_builder._source_count == source_count
     assert astrometry._request_builder._radius == radius
     assert astrometry.timeout == timeout
+    assert astrometry.on_error == "error"
     assert astrometry.exceptions == exceptions
 
 
-def check_astrometry_header_exist(image, inverse=False) -> bool:
-    keywords = [
-        "CTYPE1",
-        "CTYPE2",
-        "CRPIX1",
-        "CRPIX2",
-        "CRVAL1",
-        "CRVAL2",
-        "CD1_1",
-        "CD1_2",
-        "CD2_1",
-        "CD2_2",
-    ]
+def test_init_on_error_takes_precedence_over_exceptions():
+    url = "https://nova.astrometry.net"
 
-    keyword_in_hdr = [x in image.header for x in keywords]
+    astrometry = AstrometryDotNet(url, exceptions=False, on_error="info")
 
-    if inverse:
-        return not any(keyword_in_hdr)
-    else:
-        return all(keyword_in_hdr)
+    assert astrometry.on_error == "info"
 
 
 @pytest.mark.asyncio
-async def test_call_n_catalog_n_exception():
+async def test_call_n_catalog_always_raises():
     image = Image()
     url = "https://nova.astrometry.net"
     astrometry = AstrometryDotNet(url, exceptions=False)
-
-    result_img = await astrometry(image)
-    assert check_astrometry_header_exist(result_img, True)
-
-
-@pytest.mark.asyncio
-async def test_call_n_catalog_w_exception():
-    image = Image()
-    url = "https://nova.astrometry.net"
-    astrometry = AstrometryDotNet(url, exceptions=True)
 
     with pytest.raises(exc.ImageError):
         await astrometry(image)
@@ -90,46 +68,22 @@ def mock_catalog(size: int):
 
 
 @pytest.mark.asyncio
-async def test_call_small_catalog_n_exception():
+async def test_call_small_catalog_always_raises():
     image = Image()
     image.catalog = mock_catalog(2)
     url = "https://nova.astrometry.net"
     astrometry = AstrometryDotNet(url, exceptions=False)
-
-    result_img = await astrometry(image)
-    assert check_astrometry_header_exist(result_img, True)
-    assert result_img.header["WCSERR"] == 1
-
-
-@pytest.mark.asyncio
-async def test_call_small_catalog_w_exception():
-    image = Image()
-    image.catalog = mock_catalog(2)
-    url = "https://nova.astrometry.net"
-    astrometry = AstrometryDotNet(url, exceptions=True)
 
     with pytest.raises(exc.ImageError):
         await astrometry(image)
 
 
 @pytest.mark.asyncio
-async def test_call_cdelt_n_exception():
+async def test_call_cdelt_always_raises():
     image = Image()
     image.catalog = mock_catalog(5)
     url = "https://nova.astrometry.net"
     astrometry = AstrometryDotNet(url, exceptions=False)
-
-    result_img = await astrometry(image)
-    assert check_astrometry_header_exist(result_img, True)
-    assert result_img.header["WCSERR"] == 1
-
-
-@pytest.mark.asyncio
-async def test_call_cdelt_w_exception():
-    image = Image()
-    image.catalog = mock_catalog(5)
-    url = "https://nova.astrometry.net"
-    astrometry = AstrometryDotNet(url, exceptions=True)
 
     with pytest.raises(exc.ImageError):
         await astrometry(image)
@@ -156,7 +110,7 @@ class MockResponse:
 
 
 @pytest.mark.asyncio
-async def test_call_post_error_n_exception(mocker, mock_header):
+async def test_call_post_error_always_raises(mocker, mock_header):
     image = Image()
     image.header = mock_header
     image.catalog = mock_catalog(5)
@@ -164,44 +118,22 @@ async def test_call_post_error_n_exception(mocker, mock_header):
     astrometry = AstrometryDotNet(url, exceptions=False)
 
     resp = MockResponse(json.dumps({}), 404)
-    mock = mocker.patch("aiohttp.ClientSession.post", return_value=resp)
-
-    result_image = await astrometry(image)
-    assert result_image.header["WCSERR"] == 1
-
-    assert mock.call_args_list[0].args[0] == url
-
-    data = mock.call_args_list[0].kwargs["json"]
-
-    assert data == {
-        "crpix-x": image.header["CRPIX1"],
-        "crpix-y": image.header["CRPIX2"],
-        "ra": image.header["TEL-RA"],
-        "dec": image.header["TEL-DEC"],
-        "scale_low": 3600 * 0.9,
-        "scale_high": 3600 * 1.1,
-        "radius": 3.0,
-        "nx": image.header["NAXIS1"],
-        "ny": image.header["NAXIS2"],
-        "x": [0.0, 0.0, 0.0, 0.0, 0.0],
-        "y": [0.0, 0.0, 0.0, 0.0, 0.0],
-        "flux": [1.0, 1.0, 1.0, 1.0, 1.0],
-    }
-
-
-@pytest.mark.asyncio
-async def test_call_post_error_w_exception(mocker, mock_header):
-    image = Image()
-    image.header = mock_header
-    image.catalog = mock_catalog(5)
-    url = "https://nova.astrometry.net"
-    astrometry = AstrometryDotNet(url, exceptions=True)
-
-    resp = MockResponse(json.dumps({}), 404)
     mocker.patch("aiohttp.ClientSession.post", return_value=resp)
 
     with pytest.raises(exc.ImageError):
         await astrometry(image)
+
+
+def test_handle_error_marks_wcserr(mock_header):
+    image = Image()
+    image.header = mock_header
+    url = "https://nova.astrometry.net"
+    astrometry = AstrometryDotNet(url)
+
+    error = exc.ImageError("No WCS found.")
+    result_image = astrometry.handle_error(image, error)
+
+    assert result_image.header["WCSERR"] == 1
 
 
 @pytest.fixture()

--- a/tests/mixins/test_pipeline_on_error.py
+++ b/tests/mixins/test_pipeline_on_error.py
@@ -1,0 +1,122 @@
+from typing import Any
+
+import pytest
+
+import pyobs.utils.exceptions as exc
+from pyobs.images import Image, ImageProcessor
+from pyobs.mixins.pipeline import PipelineMixin
+from pyobs.object import Object
+
+
+class _TestPipeline(Object, PipelineMixin):
+    def __init__(self, steps: list[dict[str, Any] | ImageProcessor], **kwargs: Any):
+        Object.__init__(self, **kwargs)
+        PipelineMixin.__init__(self, steps)
+
+
+class _TagStep(ImageProcessor):
+    """Marks the image with a header entry, so tests can tell whether a step ran."""
+
+    def __init__(self, tag: str, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.tag = tag
+
+    async def __call__(self, image: Image) -> Image:
+        image.header[self.tag] = True
+        return image
+
+
+class _RaisingStep(ImageProcessor):
+    def __init__(self, message: str = "boom", **kwargs: Any):
+        super().__init__(**kwargs)
+        self.message = message
+
+    async def __call__(self, image: Image) -> Image:
+        raise exc.ImageError(self.message)
+
+    def handle_error(self, image: Image, error: exc.ImageError) -> Image:
+        image.header["HANDLED"] = error.message
+        return image
+
+
+class _NonImageErrorStep(ImageProcessor):
+    async def __call__(self, image: Image) -> Image:
+        raise ValueError("not an ImageError")
+
+
+@pytest.mark.asyncio
+async def test_on_error_raise_aborts_pipeline():
+    pipeline = _TestPipeline([_RaisingStep(on_error="raise"), _TagStep("AFTER")])
+
+    with pytest.raises(exc.ImageError):
+        await pipeline.run_pipeline(Image())
+
+
+@pytest.mark.asyncio
+async def test_on_error_error_dispatches_to_handle_error():
+    pipeline = _TestPipeline([_RaisingStep(on_error="error"), _TagStep("AFTER")])
+
+    result = await pipeline.run_pipeline(Image())
+
+    assert result.header["HANDLED"] == "boom"
+    assert result.header["AFTER"] is True
+
+
+@pytest.mark.asyncio
+async def test_on_error_info_passes_image_through(caplog):
+    caplog.set_level("INFO")
+    pipeline = _TestPipeline([_RaisingStep(on_error="info"), _TagStep("AFTER")])
+
+    result = await pipeline.run_pipeline(Image())
+
+    assert "HANDLED" not in result.header
+    assert result.header["AFTER"] is True
+    assert any("boom" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_error_ignore_passes_image_through_silently(caplog):
+    pipeline = _TestPipeline([_RaisingStep(on_error="ignore"), _TagStep("AFTER")])
+
+    result = await pipeline.run_pipeline(Image())
+
+    assert "HANDLED" not in result.header
+    assert result.header["AFTER"] is True
+    assert not any("boom" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_non_image_error_always_propagates():
+    pipeline = _TestPipeline([_NonImageErrorStep(on_error="ignore"), _TagStep("AFTER")])
+
+    with pytest.raises(ValueError):
+        await pipeline.run_pipeline(Image())
+
+
+@pytest.mark.asyncio
+async def test_handle_error_raising_repropagates():
+    class _ReraisingStep(_RaisingStep):
+        def handle_error(self, image: Image, error: exc.ImageError) -> Image:
+            raise error
+
+    pipeline = _TestPipeline([_ReraisingStep(on_error="error")])
+
+    with pytest.raises(exc.ImageError):
+        await pipeline.run_pipeline(Image())
+
+
+def test_on_error_validation():
+    with pytest.raises(ValueError):
+        _TagStep("X", on_error="not-a-mode")
+
+
+@pytest.mark.asyncio
+async def test_astrometry_dotnet_exceptions_false_dispatches_to_handle_error():
+    from pyobs.images.processors.astrometry import AstrometryDotNet
+
+    astrometry = AstrometryDotNet("https://nova.astrometry.net", exceptions=False)
+    pipeline = _TestPipeline([astrometry])
+
+    result = await pipeline.run_pipeline(Image())
+
+    assert result.header["WCSERR"] == 1


### PR DESCRIPTION
## Summary
- `PipelineMixin.run_pipeline()` was all-or-nothing: any step's exception aborted the whole chain, with no way for one step's failure to be non-fatal while another stays fatal.
- Adds `on_error: "raise" | "error" | "info" | "ignore"` (default `"raise"`, unchanged behavior) to `ImageProcessor.__init__`, plus a `handle_error(image, error)` override point used when `on_error == "error"`.
- `run_pipeline()` now catches `ImageError` per step and dispatches based on `step.on_error`. Non-`ImageError` exceptions always propagate.
- Migrates `AstrometryDotNet`'s `exceptions: bool` onto this: kept as a deprecated back-compat kwarg (`exceptions=False` → `on_error="error"`), with `on_error` taking precedence if both are set. Its own try/except is removed — error dispatch now happens in the pipeline, so a *direct* call to `AstrometryDotNet(...)()` (outside a pipeline) always raises on failure regardless of `exceptions`/`on_error`.
- `error_header` (an option from the earlier, rejected #328 approach) is intentionally dropped — not carried into this design.

Implements the plan in `specs/plans/pipeline-step-error-control.md` (now marked `implemented`).

Fixes #693

## Test plan
- [x] `pytest tests/mixins/test_pipeline_on_error.py` — all 4 `on_error` modes, non-`ImageError` propagation, `handle_error` re-raising, `on_error` validation, `AstrometryDotNet` back-compat dispatch through the pipeline.
- [x] `pytest tests/images/processors/astrometry/test_dotnet.py` — updated for the new contract (direct calls always raise; `handle_error` unit-tested directly).
- [x] `pytest -m "not integration and not xmpp"` — full suite passes (one pre-existing, unrelated failure confirmed present on `develop` too: a permission error writing to `/opt/pyobs/storage` in `test_fitsheader.py`).
- [x] `pyrefly check` on all changed files — 0 errors.
- [x] `black`/`ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)