### PR TITLE
Revert botched v2.0.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyobs-core"
-version = "2.0.1"
+version = "2.0.0.dev53"
 description = "robotic telescope software"
 authors = [{ name = "Tim-Oliver Husser", email = "thusser@uni-goettingen.de" }]
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3235,7 +3235,7 @@ wheels = [
 
 [[package]]
 name = "pyobs-core"
-version = "2.0.1"
+version = "2.0.0.dev53"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Reverts the version bump from the accidental v2.0.1 patch release (do-python-release was run
without -v dev, defaulting to a patch bump instead of continuing the 2.0.0 dev pre-release
track). PyPI publish for v2.0.1 failed on its own (check_changelog.sh caught the missing
changelog entry), so no PyPI cleanup is needed -- this just restores pyproject.toml/uv.lock to
2.0.0.dev53 on both branches. The v2.0.1 git tag and GitHub release are being deleted
separately.