### PR TITLE
Rename Night to Reduction, unify output routing, harden calibration I/O

### DIFF
--- a/docs/source/api/utils/pipeline.rst
+++ b/docs/source/api/utils/pipeline.rst
@@ -7,6 +7,6 @@ Image pipeline (pyobs.utils.pipeline)
    :members:
    :show-inheritance:
 
-.. autoclass:: pyobs.utils.pipeline.Night
+.. autoclass:: pyobs.utils.pipeline.Reduction
    :members:
    :show-inheritance:

--- a/pyobs/robotic/utils/archive/local_archive.py
+++ b/pyobs/robotic/utils/archive/local_archive.py
@@ -166,7 +166,13 @@ class LocalArchive(Archive):
         return headers
 
     async def upload_frames(self, images: list[Image]) -> None:
-        pass
+        self._root_path.mkdir(parents=True, exist_ok=True)
+        for image in images:
+            filename = image.header.get("FNAME")
+            if not filename:
+                raise ValueError("Image has no FNAME header set, cannot determine output filename.")
+            image.writeto(str(self._root_path / filename), overwrite=True)
+        self._update_root()  # refresh the in-memory index so newly-written frames are queryable
 
 
 __all__ = ["LocalArchive"]

--- a/pyobs/utils/pipeline/__init__.py
+++ b/pyobs/utils/pipeline/__init__.py
@@ -1,4 +1,4 @@
-from .night import Night
 from .pipeline import Pipeline
+from .reduction import Reduction
 
-__all__ = ["Night", "Pipeline"]
+__all__ = ["Reduction", "Pipeline"]

--- a/pyobs/utils/pipeline/reduction.py
+++ b/pyobs/utils/pipeline/reduction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import os.path
 from typing import Any
 
@@ -19,28 +20,27 @@ log = logging.getLogger(__name__)
 FILENAME = "{SITEID}{TELID}-{INSTRUME}-{DAY-OBS|date:}-{IMAGETYP}-{XBINNING}x{YBINNING}{FILTER|filter}.fits"
 
 
-class Night:
+class Reduction:
     def __init__(
         self,
         archive: dict[str, Any] | Archive,
         pipeline: dict[str, Any] | Pipeline,
-        worker_procs: int = 4,
         filenames_calib: str = FILENAME,
         min_flats: int = 10,
-        store_local: str | None = None,
+        output: str | dict[str, Any] | Archive | None = None,
         create_calibs: bool = True,
         calib_science: bool = True,
-        **kwargs: Any,
     ):
-        """Creates a Night object for reducing a given night.
+        """Creates a Reduction object for reducing a given observation period.
 
         Args:
-            archive: Archive to fetch images from and write results to.
+            archive: Archive to fetch raw and calibration frames from. Also the output
+                destination, unless output is set.
             pipeline: Science pipeline.
-            worker_procs: Number of worker processes.
             filenames_calib: Filename pattern for master calibration files.
             min_flats: Minimum number of raw frames to create flat field.
-            store_local: If True, files are stored in given local directory instead of uploaded to archive.
+            output: Where to write results. A string is a local directory path; a dict or
+                Archive is an output archive. If not set, results are written back to archive.
             create_calibs: If False, no calibration files are created for night.
             calib_science: If False, no science frames are calibrated.
         """
@@ -50,11 +50,17 @@ class Night:
         self._pipeline = get_object(pipeline, Pipeline, archive=archive)
 
         # stuff
-        self._worker_processes = worker_procs
         self._min_flats = min_flats
-        self._store_local = store_local
+        self._store_local: str | None = output if isinstance(output, str) else None
+        self._output_archive = (
+            self._archive if output is None or isinstance(output, str) else get_object(output, Archive)
+        )
         self._create_calibs = create_calibs
         self._calib_science = calib_science
+
+        # make sure the local output directory exists
+        if self._store_local:
+            os.makedirs(self._store_local, exist_ok=True)
 
         # cache for master calibration frames
         self._master_frames: dict[tuple[ImageType, str, str, str | None], Image] = {}
@@ -128,6 +134,7 @@ class Night:
         images = await self._archive.download_frames(infos)
         if len(images) < 3:
             log.warning("Too few (%d) frames found, skipping...", len(infos))
+            return None
 
         # create master
         calib: Image | None = None
@@ -191,7 +198,7 @@ class Night:
             calib.writeto(path, overwrite=True)
         else:
             log.info("Uploading master calibration frame as %s...", calib.header["FNAME"])
-            await self._archive.upload_frames([calib])
+            await self._output_archive.upload_frames([calib])
 
         # finished
         return calib
@@ -230,7 +237,7 @@ class Night:
                     calibrated.writeto(path, overwrite=True)
                 else:
                     log.info("(%d/%d) Uploading calibrated images as %s...", i, total, calibrated.header["FNAME"])
-                    await self._archive.upload_frames([calibrated])
+                    await self._output_archive.upload_frames([calibrated])
 
             except Exception:
                 log.exception("(%d/%d) Error processing image %s.", i, total, info.filename)
@@ -256,18 +263,32 @@ class Night:
             for binning in options["binnings"]:
                 # create bias and dark
                 if self._create_calibs:
-                    await self._create_master_calib(night, instrument, ImageType.BIAS, binning)
-                    await self._create_master_calib(night, instrument, ImageType.DARK, binning)
+                    try:
+                        await self._create_master_calib(night, instrument, ImageType.BIAS, binning)
+                    except Exception:
+                        log.exception("Error creating master bias for instrument %s, binning %s.", instrument, binning)
+                    try:
+                        await self._create_master_calib(night, instrument, ImageType.DARK, binning)
+                    except Exception:
+                        log.exception("Error creating master dark for instrument %s, binning %s.", instrument, binning)
 
                 # loop filters
                 for filter_name in options["filters"]:
                     # create flat
                     if self._create_calibs:
-                        await self._create_master_calib(night, instrument, ImageType.SKYFLAT, binning, filter_name)
+                        try:
+                            await self._create_master_calib(night, instrument, ImageType.SKYFLAT, binning, filter_name)
+                        except Exception:
+                            log.exception(
+                                "Error creating master flat for instrument %s, binning %s, filter %s.",
+                                instrument,
+                                binning,
+                                filter_name,
+                            )
 
                     # calibrate science data
                     if self._calib_science:
                         await self._calib_data(night, instrument, binning, filter_name)
 
 
-__all__ = ["Night"]
+__all__ = ["Reduction"]

--- a/tests/robotic/utils/archive/test_local_archive.py
+++ b/tests/robotic/utils/archive/test_local_archive.py
@@ -235,7 +235,55 @@ async def test_download_headers_returns_header_dicts(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_frames_is_noop(tmp_path: Path) -> None:
+async def test_upload_frames_writes_file_to_root(tmp_path: Path) -> None:
     archive = LocalArchive(root=str(tmp_path))
-    # should not raise
-    await archive.upload_frames([])
+    image = Image(data=np.zeros((2, 2)))
+    for key, value in make_frame_headers().items():
+        image.header[key] = value
+    image.header["FNAME"] = "uploaded.fits"
+
+    await archive.upload_frames([image])
+
+    assert (tmp_path / "uploaded.fits").exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_frames_creates_missing_root(tmp_path: Path) -> None:
+    root = tmp_path / "does" / "not" / "exist"
+    archive = LocalArchive(root=str(root))
+    image = Image(data=np.zeros((2, 2)))
+    for key, value in make_frame_headers().items():
+        image.header[key] = value
+    image.header["FNAME"] = "uploaded.fits"
+
+    await archive.upload_frames([image])
+
+    assert (root / "uploaded.fits").exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_frames_raises_without_fname_header(tmp_path: Path) -> None:
+    archive = LocalArchive(root=str(tmp_path))
+    image = Image(data=np.zeros((2, 2)))
+    for key, value in make_frame_headers().items():
+        image.header[key] = value
+
+    with pytest.raises(ValueError):
+        await archive.upload_frames([image])
+
+
+@pytest.mark.asyncio
+async def test_upload_frames_refreshes_index_for_list_frames(tmp_path: Path) -> None:
+    archive = LocalArchive(root=str(tmp_path))
+    assert await archive.list_frames() == []
+
+    image = Image(data=np.zeros((2, 2)))
+    for key, value in make_frame_headers(filter_name="red").items():
+        image.header[key] = value
+    image.header["FNAME"] = "uploaded.fits"
+    await archive.upload_frames([image])
+
+    frames = await archive.list_frames()
+    assert len(frames) == 1
+    assert frames[0].filename == str(tmp_path / "uploaded.fits")
+    assert frames[0].filter_name == "red"

--- a/tests/utils/pipeline/test_reduction.py
+++ b/tests/utils/pipeline/test_reduction.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pyobs.images import Image
+from pyobs.robotic.utils.archive import Archive, FrameInfo
+from pyobs.robotic.utils.archive.local_archive import LocalArchive
+from pyobs.utils.enums import ImageType
+from pyobs.utils.pipeline import Pipeline, Reduction
+from pyobs.utils.time import Time
+
+
+def write_fits(path: Path, **header: object) -> None:
+    image = Image(data=np.zeros((2, 2)))
+    for key, value in header.items():
+        image.header[key] = value
+    image.writeto(str(path))
+
+
+def make_frame_headers(
+    date_obs: str = "2024-01-01T03:00:00.000",
+    day_obs: str = "2024-01-01",
+    binning: tuple[int, int] = (1, 1),
+    filter_name: str = "clear",
+    image_type: str = "object",
+    instrument: str = "cam1",
+    site: str = "siteA",
+    telescope: str = "tel1",
+    rlevel: int = 0,
+    fname: str = "raw.fits",
+) -> dict[str, object]:
+    return {
+        "DATE-OBS": date_obs,
+        "DAY-OBS": day_obs,
+        "XBINNING": binning[0],
+        "YBINNING": binning[1],
+        "FILTER": filter_name,
+        "IMAGETYP": image_type,
+        "INSTRUME": instrument,
+        "SITEID": site,
+        "TELID": telescope,
+        "RLEVEL": rlevel,
+        "FNAME": fname,
+    }
+
+
+# ── output routing ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_output_routes_to_different_archive_than_input(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+    write_fits(in_dir / "raw.fits", **make_frame_headers(fname="raw.fits"))
+
+    archive_in = LocalArchive(root=str(in_dir))
+    archive_out = LocalArchive(root=str(out_dir))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(
+        archive=archive_in, pipeline=pipeline, output=archive_out, create_calibs=False, calib_science=True
+    )
+    await reduction("siteA", "2024-01-01")
+
+    # calibrated frame landed in the output archive, not back into the input archive
+    assert (out_dir / "raw.fits").exists()
+    assert sorted(p.name for p in in_dir.glob("*.fits")) == ["raw.fits"]
+
+
+@pytest.mark.asyncio
+async def test_output_local_path_auto_creates_directory_and_writes_there(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    write_fits(in_dir / "raw.fits", **make_frame_headers(fname="raw.fits"))
+    out_dir = tmp_path / "does" / "not" / "exist" / "yet"
+
+    archive = LocalArchive(root=str(in_dir))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(
+        archive=archive, pipeline=pipeline, output=str(out_dir), create_calibs=False, calib_science=True
+    )
+
+    # directory should already exist after construction, before any write happens
+    assert out_dir.is_dir()
+
+    await reduction("siteA", "2024-01-01")
+
+    assert (out_dir / "raw.fits").exists()
+    # nothing new was written back into the input archive's directory
+    assert sorted(p.name for p in in_dir.glob("*.fits")) == ["raw.fits"]
+
+
+# ── unexpected kwargs ────────────────────────────────────────────────────────
+
+
+def test_unexpected_kwarg_raises_type_error(tmp_path: Path) -> None:
+    archive = LocalArchive(root=str(tmp_path))
+    pipeline = Pipeline(steps=[])
+
+    with pytest.raises(TypeError):
+        Reduction(archive=archive, pipeline=pipeline, worker_procs=4)  # type: ignore[call-arg]
+
+
+# ── calibration fault isolation ─────────────────────────────────────────────
+
+
+class _FlakyCalibArchive(Archive):
+    """Stub archive whose calibration-frame listing fails for one instrument only."""
+
+    fail_instrument: str = "cam2"
+
+    async def list_options(
+        self,
+        start: Time | None = None,
+        end: Time | None = None,
+        night: str | None = None,
+        site: str | None = None,
+        telescope: str | None = None,
+        instrument: str | None = None,
+        image_type: ImageType | None = None,
+        binning: str | None = None,
+        filter_name: str | None = None,
+        rlevel: int | None = None,
+    ) -> dict[str, list[Any]]:
+        return {"instruments": ["cam1", "cam2"], "binnings": ["1x1"], "filters": ["clear"]}
+
+    async def list_frames(
+        self,
+        start: Time | None = None,
+        end: Time | None = None,
+        night: str | None = None,
+        site: str | None = None,
+        telescope: str | None = None,
+        instrument: str | None = None,
+        image_type: ImageType | None = None,
+        binning: str | None = None,
+        filter_name: str | None = None,
+        rlevel: int | None = None,
+    ) -> list[FrameInfo]:
+        if image_type == ImageType.OBJECT:
+            info = FrameInfo()
+            info.filename = f"{instrument}.fits"
+            return [info]
+
+        # calibration-frame lookup: blow up for one instrument, return too few for the other
+        if instrument == self.fail_instrument:
+            raise RuntimeError("boom: archive unreachable for this instrument")
+        return []
+
+    async def download_frames(self, frames: list[FrameInfo]) -> list[Image]:
+        images = []
+        for frame in frames:
+            image = Image(data=np.zeros((2, 2)))
+            if frame.filename is not None:
+                image.header["FNAME"] = frame.filename
+            images.append(image)
+        return images
+
+
+@pytest.mark.asyncio
+async def test_calibration_failure_for_one_combination_does_not_abort_others(tmp_path: Path) -> None:
+    archive = _FlakyCalibArchive()
+    output = LocalArchive(root=str(tmp_path))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(archive=archive, pipeline=pipeline, output=output, create_calibs=True, calib_science=True)
+
+    # should not raise, despite cam2's calibration-frame lookup blowing up
+    await reduction("siteA", "2024-01-01")
+
+    # science calibration still ran (and uploaded) for both instruments
+    assert (tmp_path / "cam1.fits").exists()
+    assert (tmp_path / "cam2.fits").exists()


### PR DESCRIPTION
## Summary
- Renames `pyobs.utils.pipeline.Night` to `Reduction` (the name no longer implies nighttime-only observing, matching the `ReductionPeriod` naming used elsewhere for solar-site support).
- Replaces `store_local` with a single `output: str | dict[str, Any] | Archive | None` parameter on `Reduction.__init__`, so input and output can now be different archives (or a local directory) instead of always writing back to the read archive.
- Implements `LocalArchive.upload_frames`, which was previously a silent no-op that discarded calibrated frames; it now writes files by their `FNAME` header (raising `ValueError` if missing) and refreshes the in-memory index via `_update_root()` so newly-written frames are immediately queryable.
- Hardens `Reduction`: isolates calibration-frame creation failures per instrument/binning/filter combination instead of aborting the whole run, fixes a missing `return None` after the post-download frame-count check, auto-creates the local output directory if missing, removes the dead `worker_procs` parameter, and removes the `**kwargs` catch-all so typo'd/unexpected config keys now raise `TypeError`.

Full design rationale in `specs/plans/night-archive-io-hardening.md`.

## Test plan
- [x] `pytest tests/utils/pipeline/ tests/robotic/utils/archive/` — 41 passed
- [x] `ruff check` on all changed files
- [x] `black --check` on all changed files
- [x] `pyrefly check` on all changed files
- [x] Repo-wide grep confirms no remaining references to the old `Night` class path (including a docs `.rst` reference that's also updated)

Note: the three external site YAML configs that reference `pyobs.utils.pipeline.Night` live outside this repo and need manual updates to `pyobs.utils.pipeline.Reduction` at deploy time — not part of this PR.