### PR TITLE
Add OBSNUM: per-night observation counter

### DIFF
--- a/pyobs/modules/robotic/mastermind.py
+++ b/pyobs/modules/robotic/mastermind.py
@@ -65,6 +65,38 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
         # observation name and exposure number
         self._task: Task | None = None
         self._task_target: Target | None = None
+        self._obsnum: str | None = None
+
+        # per-night observation counter
+        self._obsnum_cache = f"/pyobs/modules/{self.name}/obsnum.yaml"
+
+    async def _next_obsnum(self) -> str:
+        """Compute and persist the next per-night observation number.
+
+        Returns:
+            Compound "<night>-<counter>" string, e.g. "20260810-001".
+        """
+        night = Time.now().night_obs(self._observer) if self._observer is not None else Time.now().datetime.date()
+        night_str = night.strftime("%Y%m%d")
+
+        # load cache, bump counter, reset on night change
+        counter = 1
+        try:
+            cache = await self.vfs.read_yaml(self._obsnum_cache)
+            if cache is not None and cache.get("night") == night_str:
+                counter = cache["obsnum"] + 1
+        except (FileNotFoundError, ValueError, IndexError):
+            # IndexError: some VFS backends (e.g. MemoryFile) raise this for a missing file
+            # instead of FileNotFoundError
+            pass
+
+        # write it back
+        try:
+            await self.vfs.write_yaml(self._obsnum_cache, {"night": night_str, "obsnum": counter})
+        except (FileNotFoundError, ValueError):
+            log.warning("Could not write obsnum cache file.")
+
+        return f"{night_str}-{counter:03d}"
 
     async def open(self) -> None:
         """Open module."""
@@ -153,6 +185,7 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             # task is definitely not None here
             self._task = observation.task
             self._task_target = observation.target
+            self._obsnum = await self._next_obsnum()
 
             # ETA
             now = Time.now()
@@ -163,6 +196,7 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             observation.state = ObservationState.IN_PROGRESS
             observation.start = now
             observation.end = eta
+            observation.obsnum = self._obsnum
             await self._observation_archive.update_observation(observation)
 
             # run task in thread
@@ -184,6 +218,7 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
                 await self.comm.send_event(TaskFailedEvent(name=self._task.name, id=self._task.id))
                 self._task = None
                 self._task_target = None
+                self._obsnum = None
                 continue
 
             # send event and change state
@@ -196,6 +231,7 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             log.info("Finished task %s.", self._task.name)
             self._task = None
             self._task_target = None
+            self._obsnum = None
 
             # sleep?
             await asyncio.sleep(self._after_task_sleep)
@@ -217,6 +253,8 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             hdr = self._task.get_fits_headers()
             hdr["TASK"] = FitsHeaderEntry(self._task.name, "Name of task")
             hdr["REQNUM"] = FitsHeaderEntry(str(self._task.id), "Unique ID of task")
+            if self._obsnum is not None:
+                hdr["OBSNUM"] = FitsHeaderEntry(self._obsnum, "Observation number (night-obsnum)")
             return hdr
         else:
             return {}

--- a/pyobs/robotic/observation.py
+++ b/pyobs/robotic/observation.py
@@ -35,6 +35,9 @@ class Observation(BaseModel):
     state: ObservationState = ObservationState.PENDING
     priority: float | None = None
     target: Target | None = None
+    obsnum: str | None = None
+    """Per-night observation number, e.g. "20260810-001". Assigned by Mastermind when the
+    observation starts running; None before that (or if never observed)."""
 
     def __str__(self) -> str:
         return (

--- a/tests/integration/test_mastermind.py
+++ b/tests/integration/test_mastermind.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import patch
 
 import astropy.units as u
@@ -55,14 +56,24 @@ def make_mastermind(obs_archive, runner=None, task_archive=None) -> Mastermind:
         runner = QuickRunner()
     runner.observation_archive = obs_archive
 
-    mm = Mastermind(schedule=obs_archive, runner=runner, tasks=task_archive)
+    # in-memory vfs so the obsnum cache file never touches real disk
+    mm = Mastermind(
+        schedule=obs_archive,
+        runner=runner,
+        tasks=task_archive,
+        vfs={
+            "class": "pyobs.vfs.VirtualFileSystem",
+            "roots": {"pyobs": {"class": "pyobs.vfs.MemoryFile"}},
+        },
+    )
     mm._running = True  # skip open()/start(), which would also register comm event handlers
     return mm
 
 
-def make_obs(duration: float = 60.0) -> Observation:
+def make_obs(duration: float = 60.0, obs_id: Any = None) -> Observation:
     task = Task(id=1, name="test_task", duration=duration)
     return Observation(
+        id=obs_id,
         task=task,
         start=NIGHT - TimeDelta(10 * u.second),
         end=NIGHT + TimeDelta(duration * u.second),
@@ -109,6 +120,17 @@ async def run_until_state(
             except (asyncio.CancelledError, Exception):
                 pass
             obs_archive.update_observation = original_update
+
+
+@pytest.fixture(autouse=True)
+def _clear_vfs_buffer():
+    """MemoryFile's buffer is a process-wide class dict; every Mastermind instance in these
+    tests shares the same (unnamed) module path, so it must be reset between tests."""
+    from pyobs.vfs.bufferedfile import BufferedFile
+
+    BufferedFile._bufferedFiles.clear()
+    yield
+    BufferedFile._bufferedFiles.clear()
 
 
 # ── tests ─────────────────────────────────────────────────────────────────────
@@ -200,3 +222,85 @@ async def test_mastermind_marks_observation_in_progress() -> None:
 
     reached = await run_until_state(mm, obs_archive, ObservationState.IN_PROGRESS)
     assert reached, "Observation did not reach IN_PROGRESS state"
+
+
+# ── obsnum tests ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_assigns_obsnum_to_observation() -> None:
+    """Observation.obsnum is set to "<night>-001" for the first observation of a night."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs()]))
+
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED)
+
+    loaded = await obs_archive.get_schedule()
+    assert any(o.obsnum == "20251103-001" for o in loaded)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_reports_obsnum_in_fits_header() -> None:
+    """OBSNUM appears in get_fits_header_before() with the same value as Observation.obsnum."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs(duration=1.0)]))
+
+    seen_headers = []
+    original_update = obs_archive.update_observation
+
+    async def tracking_update(o):
+        seen_headers.append(await mm.get_fits_header_before())
+        await original_update(o)
+
+    obs_archive.update_observation = tracking_update
+
+    await run_until_state(mm, obs_archive, ObservationState.IN_PROGRESS)
+    obs_archive.update_observation = original_update
+
+    # header was requested after obsnum was assigned but before update_observation ran
+    assert any("OBSNUM" in h for h in seen_headers)
+    header_obsnum = next(h["OBSNUM"].value for h in seen_headers if "OBSNUM" in h)
+    assert header_obsnum == "20251103-001"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_increments_obsnum_within_a_night() -> None:
+    """Two observations run back-to-back on the same night get consecutive obsnums."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs(duration=1.0, obs_id=1)]))
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED)
+
+    await obs_archive.add_observations(ObservationList([make_obs(duration=1.0, obs_id=2)]))
+    mm._running = True  # run_until_state's finally block stopped it after the first run
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED)
+
+    obsnums = sorted(o.obsnum for o in await obs_archive.get_schedule() if o.obsnum is not None)
+    assert obsnums == ["20251103-001", "20251103-002"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_resets_obsnum_on_new_night() -> None:
+    """obsnum resets to 001 when the night changes."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs(duration=1.0, obs_id=1)]))
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED)
+
+    next_night = NIGHT + TimeDelta(1 * u.day)
+    obs = make_obs(duration=1.0, obs_id=2)
+    obs.start = next_night - TimeDelta(10 * u.second)
+    obs.end = next_night + TimeDelta(1.0 * u.second)
+    await obs_archive.add_observations(ObservationList([obs]))
+    mm._running = True  # run_until_state's finally block stopped it after the first run
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED, now=next_night)
+
+    obsnums = {o.start.strftime("%Y%m%d"): o.obsnum for o in await obs_archive.get_schedule()}
+    assert obsnums[NIGHT.strftime("%Y%m%d")] == "20251103-001"
+    assert obsnums[next_night.strftime("%Y%m%d")] == "20251104-001"


### PR DESCRIPTION
## Summary
- Add `Observation.obsnum: str | None` — a compound `<night>-<counter>` identifier (e.g. `20260810-001`)
- `Mastermind` assigns it once per observation at task start, persisted via a VFS-cached per-night counter, and round-trips it onto the `Observation` record through the existing `update_observation()` call
- New `OBSNUM` FITS header, emitted by `Mastermind.get_fits_header_before()` alongside the existing `TASK`/`REQNUM`, so frames from possibly-multiple cameras can be tied back to the observation that produced them

See `specs/design/obsnum_fits_header.md` for the full design (tracks #738).

Depends on the matching `pyobs-robotic-backend` PR (adds the `obsnum` column/migration) for the `backend`-archive round-trip to actually persist server-side; `memory`/`filesystem` archives round-trip for free, `lco` doesn't round-trip arbitrary fields today (documented gap, same as other fields like `priority`).

## Test plan
- [x] `pyrefly check` / `ruff check` clean
- [x] New unit tests in `tests/integration/test_mastermind.py`: obsnum assignment, FITS header emission, same-night increment, night-rollover reset — all passing
- [x] Full non-integration test suite run, no regressions (one pre-existing, unrelated failure confirmed present on `develop` too)