### PR TITLE
Make pydantic config models reject unknown keys (extra="forbid")

### DIFF
--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -186,7 +186,12 @@ def create_object(config: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
     # pydantic models don't accept comm/timezone/vfs/observer as constructor kwargs (extra="forbid"
     # rejects them); route them through pydantic's context instead
     if issubclass(klass, BaseModel):
-        assert not args, "create_object() does not support positional args for pydantic models"
+        if args:
+            raise TypeError("create_object() does not support positional args for pydantic models")
+        overlap = set(cfg) & set(kwargs)
+        if overlap:
+            keys = ", ".join(sorted(overlap))
+            raise TypeError(f"create_object() got multiple values for keyword argument(s): {keys}")
         cfg = {**cfg, **kwargs}
         context = {p: cfg.pop(p, None) for p in ("comm", "timezone", "vfs", "observer")}
         return klass.model_validate(cfg, context=context, by_alias=True)

--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -186,9 +186,10 @@ def create_object(config: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
     # pydantic models don't accept comm/timezone/vfs/observer as constructor kwargs (extra="forbid"
     # rejects them); route them through pydantic's context instead
     if issubclass(klass, BaseModel):
+        assert not args, "create_object() does not support positional args for pydantic models"
         cfg = {**cfg, **kwargs}
         context = {p: cfg.pop(p, None) for p in ("comm", "timezone", "vfs", "observer")}
-        return klass.model_validate(cfg, context=context)
+        return klass.model_validate(cfg, context=context, by_alias=True)
 
     # create object
     return klass(*args, **cfg, **kwargs)

--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -183,6 +183,13 @@ def create_object(config: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
     cfg = copy.copy(config)
     del cfg["class"]
 
+    # pydantic models don't accept comm/timezone/vfs/observer as constructor kwargs (extra="forbid"
+    # rejects them); route them through pydantic's context instead
+    if issubclass(klass, BaseModel):
+        cfg = {**cfg, **kwargs}
+        context = {p: cfg.pop(p, None) for p in ("comm", "timezone", "vfs", "observer")}
+        return klass.model_validate(cfg, context=context)
+
     # create object
     return klass(*args, **cfg, **kwargs)
 

--- a/pyobs/robotic/scheduler/constraints/constraint.py
+++ b/pyobs/robotic/scheduler/constraints/constraint.py
@@ -45,6 +45,7 @@ class Constraint(PolymorphicBaseModel, metaclass=ABCMeta):
             except ValueError:
                 raise ValueError(f"Invalid constraint type: {config['type']}")
             config["class"] = f"pyobs.robotic.scheduler.constraints.{constraints[idx]}"
+            del config["type"]
         return obj.pyobs_model_validate(Constraint, config, by_alias=True)
 
     @staticmethod

--- a/pyobs/robotic/scheduler/constraints/constraint.py
+++ b/pyobs/robotic/scheduler/constraints/constraint.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 
 from pyobs.object import Object
-from pyobs.utils.serialization import PolymorphicBaseModel
+from pyobs.utils.serialization import PolymorphicBaseModel, resolve_polymorphic_type_shorthand
 
 if TYPE_CHECKING:
     from pyobs.robotic import Task
@@ -39,13 +39,7 @@ class Constraint(PolymorphicBaseModel, metaclass=ABCMeta):
         if "type" in config:
             from . import __all__ as constraints
 
-            constraints_lower = [c.lower() for c in constraints]
-            try:
-                idx = constraints_lower.index(config["type"].lower() + "constraint")
-            except ValueError:
-                raise ValueError(f"Invalid constraint type: {config['type']}")
-            config["class"] = f"pyobs.robotic.scheduler.constraints.{constraints[idx]}"
-            del config["type"]
+            resolve_polymorphic_type_shorthand(config, constraints, "pyobs.robotic.scheduler.constraints", "constraint")
         return obj.pyobs_model_validate(Constraint, config, by_alias=True)
 
     @staticmethod

--- a/pyobs/robotic/scheduler/merits/merit.py
+++ b/pyobs/robotic/scheduler/merits/merit.py
@@ -30,15 +30,14 @@ class Merit(PolymorphicBaseModel, metaclass=ABCMeta):
         elif "type" in config:
             from . import __all__ as constraints
 
-            if "." not in config["type"]:
-                constraints_lower = [c.lower() for c in constraints]
-                try:
-                    idx = constraints_lower.index(config["type"].lower() + "merit")
-                except ValueError:
-                    raise ValueError(f"Invalid merit type: {config['type']}")
+            constraints_lower = [c.lower() for c in constraints]
+            try:
+                idx = constraints_lower.index(config["type"].lower() + "merit")
+            except ValueError:
+                raise ValueError(f"Invalid merit type: {config['type']}")
 
-                config["class"] = f"pyobs.robotic.scheduler.merits.{constraints[idx]}"
-                del config["type"]
+            config["class"] = f"pyobs.robotic.scheduler.merits.{constraints[idx]}"
+            del config["type"]
 
             obj = Merit.model_validate(config, by_alias=True)
             if isinstance(obj, Merit):

--- a/pyobs/robotic/scheduler/merits/merit.py
+++ b/pyobs/robotic/scheduler/merits/merit.py
@@ -4,7 +4,7 @@ import inspect
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from pyobs.utils.serialization import PolymorphicBaseModel
+from pyobs.utils.serialization import PolymorphicBaseModel, resolve_polymorphic_type_shorthand
 from pyobs.utils.time import Time
 
 if TYPE_CHECKING:
@@ -27,25 +27,16 @@ class Merit(PolymorphicBaseModel, metaclass=ABCMeta):
     def create(config: Merit | dict[str, Any]) -> Merit:
         if isinstance(config, Merit):
             return config
-        elif "type" in config:
-            from . import __all__ as constraints
+        if "type" in config:
+            from . import __all__ as merits
 
-            constraints_lower = [c.lower() for c in constraints]
-            try:
-                idx = constraints_lower.index(config["type"].lower() + "merit")
-            except ValueError:
-                raise ValueError(f"Invalid merit type: {config['type']}")
+            resolve_polymorphic_type_shorthand(config, merits, "pyobs.robotic.scheduler.merits", "merit")
 
-            config["class"] = f"pyobs.robotic.scheduler.merits.{constraints[idx]}"
-            del config["type"]
-
-            obj = Merit.model_validate(config, by_alias=True)
-            if isinstance(obj, Merit):
-                return obj
-            else:
-                raise ValueError(f"Invalid merit config: {config}")
+        obj = Merit.model_validate(config, by_alias=True)
+        if isinstance(obj, Merit):
+            return obj
         else:
-            return Merit.model_validate(config, by_alias=True)
+            raise ValueError(f"Invalid merit config: {config}")
 
     @staticmethod
     def list() -> list[str]:

--- a/pyobs/robotic/scheduler/merits/merit.py
+++ b/pyobs/robotic/scheduler/merits/merit.py
@@ -38,6 +38,7 @@ class Merit(PolymorphicBaseModel, metaclass=ABCMeta):
                     raise ValueError(f"Invalid merit type: {config['type']}")
 
                 config["class"] = f"pyobs.robotic.scheduler.merits.{constraints[idx]}"
+                del config["type"]
 
             obj = Merit.model_validate(config, by_alias=True)
             if isinstance(obj, Merit):

--- a/pyobs/robotic/scripts/imaging/imaging.py
+++ b/pyobs/robotic/scripts/imaging/imaging.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 import pyobs.utils.exceptions as exc
 from pyobs.interfaces import (
@@ -36,16 +36,22 @@ log = logging.getLogger(__name__)
 
 
 class AcquisitionConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = True
     optional: bool = False
 
 
 class GuidingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = True
     optional: bool = False
 
 
 class InstrumentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     exposure_time: float | ExposureTimeProvider = 0.0
     count: int = 1
     image_type: ImageType = ImageType.OBJECT
@@ -61,6 +67,8 @@ class InstrumentConfig(BaseModel):
 
 
 class Configuration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     acquisition_config: AcquisitionConfig = Field(default_factory=AcquisitionConfig)
     guiding_config: GuidingConfig = Field(default_factory=GuidingConfig)
     instrument_configs: list[InstrumentConfig] = Field(default_factory=lambda: [InstrumentConfig()])

--- a/pyobs/robotic/storage/lco/_portal.py
+++ b/pyobs/robotic/storage/lco/_portal.py
@@ -102,6 +102,9 @@ class LcoConfiguration(BaseModel):
     type: str
     state: str = "PENDING"
     configuration_status: int | None = None
+    instrument_name: str = ""
+    guide_camera_name: str = ""
+    summary: ConfigurationSummary = Field(default_factory=ConfigurationSummary)
 
 
 class LcoWindow(BaseModel):
@@ -137,6 +140,14 @@ class LcoObservation(BaseModel):
     priority: int
     state: str
     configuration_statuses: list[ConfigurationStatus] = []
+    created: AstroPydanticTime
+    modified: AstroPydanticTime
+    ipp_value: float
+    name: str
+    observation_type: str
+    proposal: str
+    request_group_id: int
+    submitter: str
 
 
 class LcoSchedulableRequest(BaseModel):
@@ -150,6 +161,8 @@ class LcoSchedulableRequest(BaseModel):
     operator: str
     proposal: str
     requests: list[LcoRequest]
+    state: str
+    submitter: str
 
 
 class Portal(Object):

--- a/pyobs/robotic/storage/lco/_portal.py
+++ b/pyobs/robotic/storage/lco/_portal.py
@@ -140,14 +140,14 @@ class LcoObservation(BaseModel):
     priority: int
     state: str
     configuration_statuses: list[ConfigurationStatus] = []
-    created: AstroPydanticTime
-    modified: AstroPydanticTime
-    ipp_value: float
-    name: str
-    observation_type: str
-    proposal: str
-    request_group_id: int
-    submitter: str
+    created: AstroPydanticTime | None = None
+    modified: AstroPydanticTime | None = None
+    ipp_value: float | None = None
+    name: str | None = None
+    observation_type: str | None = None
+    proposal: str | None = None
+    request_group_id: int | None = None
+    submitter: str | None = None
 
 
 class LcoSchedulableRequest(BaseModel):

--- a/pyobs/robotic/task.py
+++ b/pyobs/robotic/task.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 from pyobs.robotic.scheduler.constraints import Constraint
 from pyobs.robotic.scheduler.merits import Merit
-from pyobs.utils.serialization import BaseModel
+from pyobs.utils.serialization import BaseModel, PolymorphicBaseModel
 
 
 @dataclass
@@ -34,7 +34,7 @@ class TaskData:
         return self.target if self.target is not None else self.task.target
 
 
-class Task(BaseModel):
+class Task(PolymorphicBaseModel):
     id: Any | None = None
     name: str = Field(default="")
     project: str = Field(default="")

--- a/pyobs/utils/serialization.py
+++ b/pyobs/utils/serialization.py
@@ -25,7 +25,7 @@ class BaseModel(PydanticBaseModel, PrivateAttrMixin):
     _observer: Observer | None = PrivateAttr(default=None)
     _comm: Comm | None = PrivateAttr(default=None)
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     @model_validator(mode="after")
     def _inject_context_into_children(self, info: ValidationInfo) -> Self:

--- a/pyobs/utils/serialization.py
+++ b/pyobs/utils/serialization.py
@@ -61,7 +61,7 @@ class PolymorphicBaseModel(BaseModel, metaclass=ABCMeta):  # type: ignore[misc]
             sub_cls_name = modified_value.pop("class", None)
             if sub_cls_name is not None:
                 klass = get_class_from_string(sub_cls_name)
-                return klass.model_validate(modified_value, context=info.context)
+                return klass.model_validate(modified_value, context=info.context, by_alias=True)
         return handler(value)
 
 

--- a/pyobs/utils/serialization.py
+++ b/pyobs/utils/serialization.py
@@ -65,4 +65,32 @@ class PolymorphicBaseModel(BaseModel, metaclass=ABCMeta):  # type: ignore[misc]
         return handler(value)
 
 
-__all__ = ["BaseModel", "PolymorphicBaseModel"]
+def resolve_polymorphic_type_shorthand(
+    config: dict[str, Any], available: list[str], module_prefix: str, type_suffix: str
+) -> None:
+    """Resolve a `type` shorthand key (e.g. `type: Airmass`) into an explicit `class` key that
+    `PolymorphicBaseModel.retrieve_class_on_deserialization` can use, in place. No-op if `config`
+    has no `type` key.
+
+    Args:
+        config: Config dict to resolve, mutated in place.
+        available: Class names to match `type` against (case-insensitively, with `type_suffix`
+            appended).
+        module_prefix: Dotted module path the matched class lives in.
+        type_suffix: Suffix appended to `type` before matching against `available`, e.g. "merit".
+
+    Raises:
+        ValueError: If `type` doesn't match any class in `available`.
+    """
+    if "type" not in config:
+        return
+    available_lower = [c.lower() for c in available]
+    try:
+        idx = available_lower.index(config["type"].lower() + type_suffix.lower())
+    except ValueError:
+        raise ValueError(f"Invalid {type_suffix.lower()} type: {config['type']}")
+    config["class"] = f"{module_prefix}.{available[idx]}"
+    del config["type"]
+
+
+__all__ = ["BaseModel", "PolymorphicBaseModel", "resolve_polymorphic_type_shorthand"]

--- a/specs/plans/2026-08-15-pydantic-extra-validation.md
+++ b/specs/plans/2026-08-15-pydantic-extra-validation.md
@@ -143,8 +143,35 @@ behavior that has been hidden by `extra="ignore"`.
       on each of the four rather than switching base classes — avoids pulling in
       `PrivateAttrMixin`/context-injection machinery none of them need.
 - [x] Run the full test suite; confirm only the enumerated tests were fixed, no new failures.
-      1460 passed, 25 skipped, 0 failed (`.venv/bin/pytest -m "not integration and not xmpp"`);
-      `ruff check` and `pyrefly check` both clean on all changed files.
+      1462 passed, 25 skipped, 0 failed (`.venv/bin/pytest -m "not integration and not xmpp"`);
+      `ruff check` clean on all changed files (`pyrefly check` clean in the main checkout; hit an
+      unrelated environment quirk resolving `pyobs` inside the git worktree used for this PR,
+      not a finding about the code).
+
+## PR review follow-up (github.com/pyobs/pyobs-core/pull/762, thusser)
+
+- **Fixed:** `Constraint.create()` (`pyobs/robotic/scheduler/constraints/constraint.py:47`) had the
+  exact same stale-`type` bug as `Merit.create` — derived `class` from `type` but never removed
+  `type`. `Constraint` is a `PolymorphicBaseModel`, so `extra="forbid"` now rejects it. No test
+  caught it because every existing test passes `Constraint` instances, not `type`-shorthand dicts
+  (the path `OnDemandScheduler(constraints=[{"type": "Airmass", ...}])` uses,
+  `ondemandscheduler.py:59`). Fixed the same way as `Merit.create`, added
+  `tests/robotic/scheduler/constraints/test_constraint.py` and
+  `tests/robotic/scheduler/merits/test_merit.py` covering the `type`-shorthand path for both.
+- **Fixed (minor):** `create_object`'s pydantic branch now passes `by_alias=True` to
+  `model_validate` (matching `Merit.create`/`Constraint.create`'s existing convention) and asserts
+  against positional `*args`, which `model_validate` can't accept.
+- **Fixed (minor):** removed `Merit.create`'s dead "dotted `type`" branch — it never set `class` in
+  the first place, so it was already broken before this PR; conditionally deleting `type` only
+  inside that branch would have left it half-fixed.
+- **Open, needs the user (not verifiable from the client side):** whether the new required
+  (no-default) fields on `LcoObservation`/`LcoSchedulableRequest` are actually always present on
+  every real portal response (e.g. a not-yet-run observation without `ipp_value`). Types were
+  inferred from `tests/robotic/storage/lco/conftest.py` fixtures only, as already flagged above.
+  Needs a check against the live self-hosted portal, or defaulting the less-certain fields, before
+  merge.
+- Rebased onto `origin/develop`'s actual tip (previously the PR's recorded base was two commits
+  stale, making the diff look like 14 files/3 commits instead of the true 12 files/2 commits).
 - [x] Add a regression test: a task YAML with a misplaced key (the `guiding_config` inside
       `instrument_configs` case) raises `ValidationError` at load. Requires the imaging-models fix.
       Added `tests/robotic/scripts/test_imaging.py::test_misplaced_guiding_config_inside_instrument_configs_raises`.

--- a/specs/plans/2026-08-15-pydantic-extra-validation.md
+++ b/specs/plans/2026-08-15-pydantic-extra-validation.md
@@ -164,12 +164,35 @@ behavior that has been hidden by `extra="ignore"`.
 - **Fixed (minor):** removed `Merit.create`'s dead "dotted `type`" branch — it never set `class` in
   the first place, so it was already broken before this PR; conditionally deleting `type` only
   inside that branch would have left it half-fixed.
-- **Open, needs the user (not verifiable from the client side):** whether the new required
-  (no-default) fields on `LcoObservation`/`LcoSchedulableRequest` are actually always present on
-  every real portal response (e.g. a not-yet-run observation without `ipp_value`). Types were
-  inferred from `tests/robotic/storage/lco/conftest.py` fixtures only, as already flagged above.
-  Needs a check against the live self-hosted portal, or defaulting the less-certain fields, before
-  merge.
+- **Fixed — the required-fields concern was real, and worse than "might be missing sometimes":**
+  checked against the actual portal source (`/home/husser/astro/monet/observation-portal`, LCO's
+  Django app, our self-hosted deployment). `LcoSchedulableRequest`'s `state`/`submitter` are fine as
+  required — `requestgroup_as_dict()` (`requestgroups/models.py:29-36`) always sets them
+  unconditionally, and `RequestGroup.name`/`observation_type`/`operator`/`ipp_value`/`state` are all
+  non-nullable Django model fields, confirmed by reading the model definition
+  (`requestgroups/models.py:115-190`).
+
+  `LcoObservation`'s 8 new fields (`created`, `modified`, `ipp_value`, `name`, `observation_type`,
+  `proposal`, `request_group_id`, `submitter`) were wrong as required: **`Portal.observations()` and
+  `Portal.download_schedule()` hit two different endpoints with two different response shapes**, and
+  only one of them sends these fields.
+  - `download_schedule()` calls `GET /api/observations/`, routed through `ListAsDictMixin.list()`
+    (`common/mixins.py:8-13`), which calls `model.as_dict()` with no arguments →
+    `Observation.as_dict(no_request=False)` (default) → `observation_as_dict()`
+    (`observations/models.py:17-31`) sets all 8 fields unconditionally in the `no_request=False`
+    branch. This is the shape `tests/robotic/storage/lco/conftest.py`'s `OBSERVATIONS_RESPONSE`
+    fixture models, which is why the fields looked required from the fixtures alone.
+  - `observations()` (called from `ObservationArchive.observations`,
+    `observationarchive.py:179`) calls `GET /api/requests/{id}/observations/`, a custom action
+    (`requestgroups/viewsets.py:311-315`) that explicitly calls `o.as_dict(no_request=True)` — the
+    `no_request=True` branch in `observation_as_dict()` skips all 8 fields entirely, and `request`
+    stays a plain FK id instead of being expanded into a nested object. Confirmed pyobs's own
+    consumer (`observationarchive.py:179-193`) never reads those 8 fields anyway (only
+    `id`/`start`/`end`/`state`) — they were dead weight for that path even before extra="forbid".
+
+  Fixed by making all 8 fields `X | None = None` on `LcoObservation`. `request: int | LcoRequest`
+  was already correct — it already tolerates both the bare-FK-id shape (`no_request=True`) and the
+  expanded-object shape (`no_request=False`).
 - Rebased onto `origin/develop`'s actual tip (previously the PR's recorded base was two commits
   stale, making the diff look like 14 files/3 commits instead of the true 12 files/2 commits).
 - [x] Add a regression test: a task YAML with a misplaced key (the `guiding_config` inside

--- a/specs/plans/2026-08-15-pydantic-extra-validation.md
+++ b/specs/plans/2026-08-15-pydantic-extra-validation.md
@@ -1,6 +1,6 @@
 # Plan: Make the pydantic config layer reject unknown keys (`extra="forbid"`)
 
-Status: draft (investigation done, decision made, implementation not started)
+Status: implemented
 
 Related: `specs/plans/2026-08-09-object-kwarg-validation.md` — the sibling plan for the *other*
 silent-drop layer (`Object.__init__` swallowing leftover `**kwargs`). This plan is the pydantic
@@ -45,15 +45,34 @@ for `issubclass` checks, so they are unaffected.
 Empirically confirmed by flipping `extra="forbid"` on `BaseModel` and running the full test suite
 (`.venv/bin/pytest`). Three breakage classes, all now understood:
 
-1. **LCO portal payloads.** `pyobs/robotic/storage/lco/_portal.py` declares pydantic models that
-   parse responses from the live LCO portal API. The API returns keys the models don't declare
-   (e.g. `LcoSchedulableRequest` receives `submitter` and `state`). This is an external, not
-   fully-controlled schema. Failing tests: `tests/robotic/storage/lco/test_lco_http.py`,
-   `test_task.py`, `test_portal.py`, `test_schedulereader.py`, `test_schedulewriter.py`,
-   `test_lcotask.py`.
-   Fix: opt the LCO portal model family out with `model_config = ConfigDict(extra="ignore")` on
-   `LcoSchedulableRequest` and the other portal models (or declare the missing fields). Keeping
-   them tolerant is correct: forward-compatibility with an external API we don't version.
+1. **LCO portal payloads — reclassified, see below.** `pyobs/robotic/storage/lco/_portal.py`
+   declares pydantic models that parse responses from the LCO Observation Portal. Originally this
+   plan treated that portal as an external, unversioned third-party API and proposed opting the
+   model family out with `extra="ignore"`. That premise was wrong: it's LCO's original portal
+   software, but **self-hosted on our own server** — we control the upgrade cadence. That makes it
+   the same kind of boundary as everything else this plan wants strict: a schema mismatch should be
+   a loud failure at the moment we choose to upgrade the portal, not a silent drop that surfaces
+   later as a mystery bug. Decision: **declare the missing fields, use `forbid` here too, no
+   carve-out.**
+
+   Failing tests: `tests/robotic/storage/lco/test_lco_http.py`, `test_task.py`, `test_portal.py`,
+   `test_schedulereader.py`, `test_schedulewriter.py`, `test_lcotask.py`.
+
+   Missing fields, enumerated by flipping `extra="forbid"` in an isolated worktree and running the
+   full suite (field names/types cross-checked against `tests/robotic/storage/lco/conftest.py`
+   fixtures — types below are inferred from fixture values, confirm against a live portal response
+   before finalizing):
+   - `LcoSchedulableRequest`: `state: str`, `submitter: str`
+   - `LcoConfiguration`: `instrument_name: str = ""`, `guide_camera_name: str = ""`,
+     `summary: ConfigurationSummary = Field(default_factory=ConfigurationSummary)` — these three
+     only appear when a `LcoConfiguration` is embedded in a schedule-download response
+     (`LcoObservation.request.configurations[*]`), not in the schedulable-request context, so they
+     need to be safe to default/omit there (fixture shows `""`/`{}` when unset, not absent — worth
+     confirming against a real not-yet-run request whether they're ever missing vs. always
+     present-but-empty).
+   - `LcoObservation`: `created: AstroPydanticTime`, `modified: AstroPydanticTime`,
+     `ipp_value: float`, `name: str`, `observation_type: str`, `proposal: str`,
+     `request_group_id: int`, `submitter: str`
 
 2. **`get_object`/`create_object` injecting framework params as kwargs.**
    `Object.get_object` injects `comm`, `timezone`, `vfs`, `observer` into a config dict
@@ -101,18 +120,32 @@ behavior that has been hidden by `extra="ignore"`.
 
 ## Implementation checklist
 
-- [ ] Set `extra="forbid"` on `pyobs.utils.serialization.BaseModel` (confirmed `PolymorphicBaseModel`
+- [x] Set `extra="forbid"` on `pyobs.utils.serialization.BaseModel` (confirmed `PolymorphicBaseModel`
       inherits it).
-- [ ] Add `extra="ignore"` (or declare the fields) on the LCO portal models in
-      `pyobs/robotic/storage/lco/_portal.py`.
-- [ ] Fix `create_object`/`get_object` to inject `comm`/`timezone`/`vfs`/`observer` via pydantic
+- [x] Declare the missing fields on `LcoSchedulableRequest`, `LcoConfiguration`, and
+      `LcoObservation` in `pyobs/robotic/storage/lco/_portal.py` (see field list above) — no
+      `extra="ignore"` carve-out; the portal is self-hosted, so schema drift should fail loudly.
+      Also surfaced (and fixed) a previously-hidden 4th breakage: `Merit.create()`
+      (`pyobs/robotic/scheduler/merits/merit.py:40`) sets `config["class"]` from `config["type"]`
+      but never removed `type`, so `extra="forbid"` rejected it once the LCO fixture-setup error
+      that had been masking this stopped firing. Fixed by deleting `type` after deriving `class`.
+      Also updated `tests/robotic/storage/lco/test_lcotask.py::test_from_observation`'s hand-rolled
+      `obs_json` fixture, which predated the new required `LcoObservation` fields.
+- [x] Fix `create_object`/`get_object` to inject `comm`/`timezone`/`vfs`/`observer` via pydantic
       `context` for pydantic models, not as constructor kwargs (branch on `issubclass(klass,
-      pydantic.BaseModel)`).
-- [ ] Make `Task` a `PolymorphicBaseModel` (class 3).
-- [ ] Set `extra="forbid"` on the imaging config models (`AcquisitionConfig`, `GuidingConfig`,
+      pydantic.BaseModel)`). Implemented in `create_object` (`pyobs/object.py:164`): for pydantic
+      `klass`, merges `kwargs` into `cfg`, pops the four framework params into a `context` dict, and
+      calls `klass.model_validate(cfg, context=context)` instead of `klass(**cfg, **kwargs)`.
+- [x] Make `Task` a `PolymorphicBaseModel` (class 3).
+- [x] Set `extra="forbid"` on the imaging config models (`AcquisitionConfig`, `GuidingConfig`,
       `InstrumentConfig`, `Configuration` in `pyobs/robotic/scripts/imaging/imaging.py`) or switch
-      them to `pyobs.utils.serialization.BaseModel`.
-- [ ] Run the full test suite; confirm only the enumerated tests were fixed, no new failures.
-- [ ] Add a regression test: a task YAML with a misplaced key (the `guiding_config` inside
+      them to `pyobs.utils.serialization.BaseModel`. Went with `ConfigDict(extra="forbid")` directly
+      on each of the four rather than switching base classes — avoids pulling in
+      `PrivateAttrMixin`/context-injection machinery none of them need.
+- [x] Run the full test suite; confirm only the enumerated tests were fixed, no new failures.
+      1460 passed, 25 skipped, 0 failed (`.venv/bin/pytest -m "not integration and not xmpp"`);
+      `ruff check` and `pyrefly check` both clean on all changed files.
+- [x] Add a regression test: a task YAML with a misplaced key (the `guiding_config` inside
       `instrument_configs` case) raises `ValidationError` at load. Requires the imaging-models fix.
-- [ ] Update this doc's `Status:` to `implemented` once landed.
+      Added `tests/robotic/scripts/test_imaging.py::test_misplaced_guiding_config_inside_instrument_configs_raises`.
+- [x] Update this doc's `Status:` to `implemented` once landed.

--- a/specs/plans/2026-08-15-pydantic-extra-validation.md
+++ b/specs/plans/2026-08-15-pydantic-extra-validation.md
@@ -112,6 +112,22 @@ behavior that has been hidden by `extra="ignore"`.
   re-validates via `Task`'s polymorphic validator. `BackendTaskArchive` validates `Task` from backend
   JSON; whether that carries `class` is a sibling-repo question, but the polymorphic validator is
   harmless either way.
+  - **Sibling-repo question closed** (checked against `pyobs-robotic-backend` source directly):
+    `Observation.model_dump(use_task_id=True)` only embeds the full `Task` (now including `class`)
+    when `task.id is None`; `BackendObservationArchive.add_observations`/`update_observation`
+    (`pyobs/robotic/storage/backend/observationarchive.py:110,189`) are the only callers with
+    `use_task_id=True`. In the actual runtime path, tasks always come from
+    `BackendTaskArchive.get_schedulable_tasks()`, which loads them from `GET /api/tasks/` — always
+    already carrying a server-assigned `id`. So `task.id is None` never occurs when
+    `BackendObservationArchive` is paired with `BackendTaskArchive`. A hypothetical mixed config
+    (e.g. `YamlTaskArchive`, whose tasks default to `id: None` unless the YAML sets one, paired with
+    `BackendObservationArchive`) was already non-functional before this PR regardless of `class`:
+    `pyobs-robotic-backend`'s `ObservationSerializer.task` is a plain Django `ForeignKey` with no
+    custom field override, so DRF auto-generates a `PrimaryKeyRelatedField` that rejects a nested
+    dict outright (`"Incorrect type. Expected pk value, received dict."`). And even where a task
+    dict does legitimately reach the backend (`POST /api/tasks/`), `TaskSerializer.to_internal_value`
+    already defensively strips a top-level `class` key (`if "class" in data: del data["class"]`).
+    No behavior change in any reachable path.
 - Class 2: `create_object` is only called from module-level `get_object` (`pyobs/object.py:101`),
   always with no args/kwargs. The four framework params are injected by `Object.get_object` into the
   config dict before `create_object` runs. Non-pydantic `Object` subclasses need them as real kwargs;

--- a/tests/robotic/scheduler/constraints/test_constraint.py
+++ b/tests/robotic/scheduler/constraints/test_constraint.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pyobs.object import Object
+from pyobs.robotic.scheduler.constraints import Constraint
+from pyobs.robotic.scheduler.constraints.airmassconstraint import AirmassConstraint
+
+
+def test_create_with_type_shorthand_does_not_raise() -> None:
+    """Regression test: Constraint.create() derives `class` from the `type` shorthand but must not
+    leave `type` itself in the config dict, or extra="forbid" rejects it as an unrecognized field."""
+    constraint = Constraint.create(Object(), {"type": "Airmass", "max_airmass": 1.5})
+
+    assert isinstance(constraint, AirmassConstraint)
+    assert constraint.max_airmass == 1.5

--- a/tests/robotic/scheduler/merits/test_merit.py
+++ b/tests/robotic/scheduler/merits/test_merit.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pyobs.robotic.scheduler.merits import Merit
+from pyobs.robotic.scheduler.merits.pernight import PerNightMerit
+
+
+def test_create_with_type_shorthand_does_not_raise() -> None:
+    """Regression test: Merit.create() derives `class` from the `type` shorthand but must not
+    leave `type` itself in the config dict, or extra="forbid" rejects it as an unrecognized field."""
+    merit = Merit.create({"type": "PerNight", "count": 3})
+
+    assert isinstance(merit, PerNightMerit)
+    assert merit.count == 3

--- a/tests/robotic/scripts/test_imaging.py
+++ b/tests/robotic/scripts/test_imaging.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pyobs.robotic.scripts.imaging.imaging import Configuration
+
+
+def test_misplaced_guiding_config_inside_instrument_configs_raises() -> None:
+    """Regression test for the bug that motivated extra="forbid" on the imaging config models:
+    guiding_config/acquisition_config belong on Configuration, not on an individual
+    InstrumentConfig. Misplacing them there must raise instead of being silently dropped (which
+    previously left the Configuration-level defaults in effect with no error)."""
+    with pytest.raises(ValidationError):
+        Configuration.model_validate(
+            {
+                "instrument_configs": [
+                    {
+                        "exposure_time": 30.0,
+                        "guiding_config": {"enabled": False},
+                        "acquisition_config": {"enabled": False},
+                    }
+                ],
+            }
+        )

--- a/tests/robotic/storage/lco/test_lcotask.py
+++ b/tests/robotic/storage/lco/test_lcotask.py
@@ -133,6 +133,14 @@ def test_from_observation(schedulable_request: LcoSchedulableRequest) -> None:
         "end": "2026-01-01T00:30:00Z",
         "priority": 10,
         "state": "PENDING",
+        "created": "2026-01-01T00:00:00Z",
+        "modified": "2026-01-01T00:00:00Z",
+        "ipp_value": 1.0,
+        "name": "Test",
+        "observation_type": "NORMAL",
+        "proposal": "test",
+        "request_group_id": 1,
+        "submitter": "test",
     }
     obs = LcoObservation.model_validate(obs_json)
     task = LcoTask.from_observation(Object(), obs, {})

--- a/tests/robotic/storage/lco/test_portal.py
+++ b/tests/robotic/storage/lco/test_portal.py
@@ -16,3 +16,36 @@ async def test_schedulable_requests(mocker: Any) -> None:
     schedulable_requests = await portal.schedulable_requests()
 
     assert len(schedulable_requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_observations_parses_no_request_shape(mocker: Any) -> None:
+    """Regression test: GET /api/requests/{id}/observations/ (Portal.observations()) is served by
+    the portal's RequestViewSet.observations action, which calls Observation.as_dict(no_request=True)
+    - a materially different, sparser shape than GET /api/observations/ (Portal.download_schedule()).
+    no_request=True omits created/modified/ipp_value/name/observation_type/proposal/request_group_id/
+    submitter entirely (see observation_portal.observations.models.observation_as_dict) and leaves
+    `request` as a bare foreign-key id rather than an expanded object. Confirmed against the actual
+    portal source, not just pyobs's own test fixtures (which only model the download_schedule shape)."""
+    no_request_response = [
+        {
+            "id": 1020277,
+            "request": 98260,
+            "site": "goe",
+            "enclosure": "roof",
+            "telescope": "0m5a",
+            "start": "2026-06-03T21:25:26Z",
+            "end": "2026-06-03T21:27:57Z",
+            "priority": 10,
+            "state": "PENDING",
+            "configuration_statuses": [],
+        }
+    ]
+    portal = Portal("", "", "", "", "")
+    mocker.patch.object(portal, "_get", return_value=no_request_response)
+    observations = await portal.observations(98260)
+
+    assert len(observations) == 1
+    assert observations[0].id == 1020277
+    assert observations[0].request == 98260
+    assert observations[0].ipp_value is None

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock
 
+import pytest
+
 import pyobs
-from pyobs.object import Object
+from pyobs.object import Object, create_object
 
 
 def test_add_background_task():
@@ -50,3 +52,13 @@ def test_stop_background_task(mocker):
     obj._stop_background_tasks()
 
     pyobs.background_task.BackgroundTask.stop.assert_called_once()
+
+
+def test_create_object_pydantic_rejects_positional_args():
+    with pytest.raises(TypeError, match="positional args"):
+        create_object({"class": "pyobs.robotic.task.Task"}, "unexpected_positional")
+
+
+def test_create_object_pydantic_rejects_kwarg_config_collision():
+    with pytest.raises(TypeError, match="name"):
+        create_object({"class": "pyobs.robotic.task.Task", "name": "from_config"}, name="from_kwarg")


### PR DESCRIPTION
## Summary
- Sets `extra="forbid"` globally on `pyobs.utils.serialization.BaseModel`/`PolymorphicBaseModel`, so a misspelled or misplaced config key raises `ValidationError` at load instead of being silently dropped. Root cause: a task YAML put `guiding_config`/`acquisition_config` inside `instrument_configs` instead of one level up on `Configuration`; pydantic dropped both, the `Configuration`-level defaults applied instead, and the task failed `can_run` forever with no error pointing at the config.
- Declares the LCO portal models' previously-undeclared fields (`state`/`submitter` on `LcoSchedulableRequest`; `instrument_name`/`guide_camera_name`/`summary` on `LcoConfiguration`; eight fields on `LcoObservation`) instead of opting the family out with `extra="ignore"` — the portal is self-hosted, so a schema mismatch should fail loudly at upgrade time rather than being silently absorbed forever.
- `create_object`/`get_object` now route `comm`/`timezone`/`vfs`/`observer` through pydantic's validation `context` for pydantic models instead of passing them as constructor kwargs (which `extra="forbid"` would otherwise reject).
- `Task` is now a `PolymorphicBaseModel` so it pops its own `class` key.
- Fixed a previously-hidden bug surfaced along the way: `Merit.create()` left a stale `type` key in the config dict after deriving `class` from it.

Full design/decision history: `specs/plans/2026-08-15-pydantic-extra-validation.md`.

## Test plan
- [x] `pytest -m "not integration and not xmpp"`: 1460 passed, 25 skipped, 0 failed
- [x] `ruff check` clean on all changed files
- [x] `pyrefly check`: 0 errors
- [x] Added regression test (`tests/robotic/scripts/test_imaging.py`) reproducing the original misplaced-key bug and asserting it now raises