### PR TITLE
Bound FITS-header fetch so a dead peer can't stall the frame

### DIFF
--- a/pyobs/mixins/fitsheader.py
+++ b/pyobs/mixins/fitsheader.py
@@ -31,6 +31,7 @@ class FitsHeaderMixin:
         filenames: str = "/cache/pyobs-{DAY-OBS|date:}-{FRAMENUM|string:04d}.fits",
         frame_number: bool = True,
         night_obs: bool = True,
+        fits_header_timeout: float = 15.0,
         **kwargs: Any,
     ):
         """Initialise the mixin.
@@ -41,6 +42,9 @@ class FitsHeaderMixin:
             filename: Filename pattern for FITS images.
             frame_number: Whether to add frame number to FITS file header.
             night_obs: If True, DAY-OBS will contain the night of observation, not the calendar day.
+            fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping
+                them. A peer that never answers (e.g. a laptop put to sleep without closing its
+                client) would otherwise stall the frame for the full XMPP IQ timeout.
         """
         module = cast(Module, self)
 
@@ -48,6 +52,7 @@ class FitsHeaderMixin:
         self._fitsheadermixin_fits_namespaces = fits_namespaces
         self._fitsheadermixin_filename_pattern = filenames
         self._fitsheadermixin_fits_headers = fits_headers if fits_headers is not None else {}
+        self._fitsheadermixin_header_timeout = fits_header_timeout
         if "OBSERVER" not in self._fitsheadermixin_fits_headers:
             self._fitsheadermixin_fits_headers["OBSERVER"] = ["pyobs", "Name of observer"]
         self._fitsheadermixin_night_obs = night_obs
@@ -98,12 +103,26 @@ class FitsHeaderMixin:
             futures: Futures to get headers from.
         """
 
+        # Bound the whole collection to a single deadline: a peer that never answers its
+        # IQ (e.g. a laptop put to sleep without closing its client) would otherwise stall
+        # the frame for the full XMPP IQ timeout (~120s) per dead peer. Give up on anything
+        # still pending and proceed without its headers.
+        done, pending = await asyncio.wait(futures.values(), timeout=self._fitsheadermixin_header_timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
         # get fits headers from other clients
         for client, future in futures.items():
             # join thread
             log.info("Fetching FITS headers from %s...", client)
+            if future in pending:
+                log.warning("Could not fetch FITS headers from %s: timed out.", client)
+                continue
+
             try:
-                headers = await future
+                headers = future.result()
             except exc.RemoteError as e:
                 log.warning("Could not fetch FITS headers from %s: %s.", client, str(e))
                 continue

--- a/pyobs/mixins/fitsheader.py
+++ b/pyobs/mixins/fitsheader.py
@@ -107,11 +107,13 @@ class FitsHeaderMixin:
         # IQ (e.g. a laptop put to sleep without closing its client) would otherwise stall
         # the frame for the full XMPP IQ timeout (~120s) per dead peer. Give up on anything
         # still pending and proceed without its headers.
-        done, pending = await asyncio.wait(futures.values(), timeout=self._fitsheadermixin_header_timeout)
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        pending: set[Task[Any]] = set()
+        if futures:
+            _, pending = await asyncio.wait(futures.values(), timeout=self._fitsheadermixin_header_timeout)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
         # get fits headers from other clients
         for client, future in futures.items():

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -60,6 +60,7 @@ class BaseCamera(
         filenames: str = "/cache/pyobs-{DAY-OBS|date:}-{FRAMENUM|string:04d}-{IMAGETYP|type}00.fits.gz",
         fits_namespaces: list[str] | None = None,
         meridian_flip_on: str | None = None,
+        fits_header_timeout: float = 15.0,
         **kwargs: Any,
     ):
         """Creates a new BaseCamera.
@@ -73,6 +74,7 @@ class BaseCamera(
             flip_y: Whether or not to flip the image along its second axis.
             filenames: Template for file naming.
             fits_namespaces: List of namespaces for FITS headers that this camera should request
+            fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping them.
         """
         Module.__init__(self, **kwargs)
         ImageFitsHeaderMixin.__init__(
@@ -82,6 +84,7 @@ class BaseCamera(
             centre=centre,
             rotation=rotation,
             filenames=filenames,
+            fits_header_timeout=fits_header_timeout,
         )
 
         # check

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -86,6 +86,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         live_view: bool = True,
         flip: bool = False,
         sleep_time: int = 600,
+        fits_header_timeout: float = 15.0,
         **kwargs: Any,
     ):
         """Creates a new BaseWebcam.
@@ -107,6 +108,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             live_view: If True, live view is served via web server.
             flip: Whether to flip around Y axis.
             sleep_time: Time in s with inactivity after which the camera should go to sleep.
+            fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping them.
         """
         Module.__init__(self, **kwargs)
         ImageFitsHeaderMixin.__init__(
@@ -116,6 +118,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             centre=centre,
             rotation=rotation,
             filenames=filenames,
+            fits_header_timeout=fits_header_timeout,
         )
 
         # store

--- a/specs/plans/2026-08-16-fits-header-fetch-timeout.md
+++ b/specs/plans/2026-08-16-fits-header-fetch-timeout.md
@@ -1,0 +1,48 @@
+# Plan: Bound the FITS-header fetch so a dead peer can't stall the frame
+
+Status: proposed
+
+## Problem
+
+`FitsHeaderMixin.add_requested_fits_headers()` (`pyobs/mixins/fitsheader.py`) awaits every
+requested header future in a plain `for` loop with no timeout. The futures are created before the
+exposure (`request_fits_headers()`, called from `BaseCamera.grab_data()`) and awaited after readout,
+so a peer that never answers its IQ stalls frame finalization for the full XMPP IQ timeout.
+
+That timeout is ~120s (slixmpp's `Iq.send(timeout=None)` default), because `get_fits_header_before`/
+`get_fits_header_after` carry no `@timeout` decorator. A `@timeout` decorator would not fix it
+anyway: it works by having the *server* reply with a `method_timeout` IQ before running, and a dead
+peer never replies at all.
+
+The trigger that surfaced this (issue #764): `admin` was a pyobs-gui on a laptop sent to sleep
+without closing the client. Its XMPP session lingered on ejabberd, and `fli230` spent ~120s per
+exposure trying to fetch headers from it before giving up and writing the frame without them.
+
+## Design
+
+Bound the whole collection to a single deadline in `add_requested_fits_headers()`, replacing the
+sequential `await future` with `asyncio.wait(..., timeout=...)`:
+
+- `asyncio.wait` returns `(done, pending)`. Cancel anything still pending and
+  `await asyncio.gather(*pending, return_exceptions=True)` so no lingering task raises an
+  unretrieved exception later.
+- Skip pending clients with a `timed out` warning, mirroring the existing `RemoteError` path.
+- `future.result()` on done tasks; `RemoteError` handling unchanged.
+
+New constructor kwarg `fits_header_timeout: float = 15.0` on `FitsHeaderMixin` (flows through
+`ImageFitsHeaderMixin`/`SpectrumFitsHeaderMixin` via `**kwargs`), stored as
+`_fitsheadermixin_header_timeout`. 15s is generous for live peers (they answer in ms) while keeping
+a dead peer from stalling the pipeline for ~120s.
+
+## Testing
+
+`tests/mixins/test_fitsheader.py`:
+
+- a never-resolving peer times out (bounded, task cancelled) and the image is written without its
+  headers
+- a mix of live + dead peers: live headers added, dead skipped
+
+## Rollout
+
+No server or sibling-repo changes. Configs that don't set `fits_header_timeout` keep the default.
+Rollback is removing the kwarg and reverting `add_requested_fits_headers()`.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -74,3 +74,5 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-08-16-explicit-pubsub-event-subscriptions.md](2026-08-16-explicit-pubsub-event-subscriptions.md) —
   real interest-based event delivery via explicit XEP-0060 subscriptions, decoupled from
   presence. **proposed**
+- [2026-08-16-fits-header-fetch-timeout.md](2026-08-16-fits-header-fetch-timeout.md) — bound the
+  FITS-header fetch so a dead peer can't stall the frame. **proposed**

--- a/tests/mixins/test_fitsheader.py
+++ b/tests/mixins/test_fitsheader.py
@@ -170,6 +170,16 @@ async def test_add_requested_fits_headers_skips_empty_headers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_add_requested_fits_headers_handles_empty_futures() -> None:
+    m = make_module()
+    image = make_image()
+
+    # should not raise (e.g. no comm, or no peer implements IFitsHeaderBefore/After)
+    await m.add_requested_fits_headers(image, {})
+    assert "FOO" not in image.header
+
+
+@pytest.mark.asyncio
 async def test_add_requested_fits_headers_times_out_dead_client() -> None:
     m = make_module(fits_header_timeout=0.05)
     image = make_image()

--- a/tests/mixins/test_fitsheader.py
+++ b/tests/mixins/test_fitsheader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
@@ -166,6 +167,39 @@ async def test_add_requested_fits_headers_skips_empty_headers() -> None:
     await m.add_requested_fits_headers(image, {"client1": asyncio.ensure_future(fut())})
     # nothing added, no error
     assert set(image.header.keys()) == header_keys_before
+
+
+@pytest.mark.asyncio
+async def test_add_requested_fits_headers_times_out_dead_client() -> None:
+    m = make_module(fits_header_timeout=0.05)
+    image = make_image()
+
+    dead = asyncio.create_task(asyncio.Event().wait())  # never resolves
+
+    start = time.monotonic()
+    await m.add_requested_fits_headers(image, {"dead": dead})
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0
+    assert dead.cancelled()
+    assert "FOO" not in image.header
+
+
+@pytest.mark.asyncio
+async def test_add_requested_fits_headers_adds_live_and_skips_dead() -> None:
+    m = make_module(fits_header_timeout=0.05)
+    image = make_image()
+
+    async def live() -> dict:
+        return {"FOO": FitsHeaderEntry(42, "the answer")}
+
+    live_task = asyncio.ensure_future(live())
+    dead = asyncio.create_task(asyncio.Event().wait())  # never resolves
+
+    await m.add_requested_fits_headers(image, {"live": live_task, "dead": dead})
+
+    assert image.header["FOO"] == 42
+    assert dead.cancelled()
 
 
 # ── add_fits_headers (top-level orchestration) ──────────────────────────────

--- a/tests/modules/camera/test_basecamera.py
+++ b/tests/modules/camera/test_basecamera.py
@@ -29,6 +29,13 @@ async def test_aborted_exposure_raises_aborted_error():
     await camera.close()
 
 
+def test_fits_header_timeout_reaches_mixin():
+    """BaseCamera must forward fits_header_timeout to ImageFitsHeaderMixin, not swallow it into
+    Module's catch-all **kwargs -- see issue #764 / PR #765."""
+    camera = DummyCamera(fits_header_timeout=1.0)
+    assert camera._fitsheadermixin_header_timeout == 1.0
+
+
 @pytest.mark.asyncio
 async def test_open_close():
     """Test basic open/close of BaseCamera."""

--- a/tests/modules/camera/test_basespectrograph.py
+++ b/tests/modules/camera/test_basespectrograph.py
@@ -1,0 +1,9 @@
+from pyobs.modules.camera import DummySpectrograph
+
+
+def test_fits_header_timeout_reaches_mixin():
+    """BaseSpectrograph forwards fits_header_timeout to SpectrumFitsHeaderMixin via **kwargs --
+    see issue #764 / PR #765. Unlike BaseCamera/BaseVideo, this path already used **kwargs
+    forwarding before the fix; this test guards against a future regression."""
+    spectrograph = DummySpectrograph(fits_header_timeout=1.0)
+    assert spectrograph._fitsheadermixin_header_timeout == 1.0

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -53,6 +53,13 @@ def test_init_custom_values() -> None:
     assert bv._sleep_time == 30
 
 
+def test_fits_header_timeout_reaches_mixin() -> None:
+    """BaseVideo must forward fits_header_timeout to ImageFitsHeaderMixin, not swallow it into
+    Module's catch-all **kwargs -- see issue #764 / PR #765."""
+    bv = make_basevideo(fits_header_timeout=1.0)
+    assert bv._fitsheadermixin_header_timeout == 1.0
+
+
 # ── open / close ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`FitsHeaderMixin.add_requested_fits_headers()` awaited every requested header future with no timeout. The futures are created before the exposure and awaited after readout, so a peer that never answers its IQ stalls frame finalization for the full XMPP IQ timeout (~120s — slixmpp's `Iq.send` default).

Trigger (issue #764): `admin` was a pyobs-gui on a laptop sent to sleep without closing the client. Its session lingered on ejabberd, and `fli230` spent ~120s per exposure fetching headers from it before giving up.

## Change

- Bound the whole collection to a single `asyncio.wait(..., timeout=...)` deadline; cancel + gather anything still pending, then skip it with a `timed out` warning (mirrors the existing `RemoteError` path).
- New `fits_header_timeout: float = 15.0` kwarg on `FitsHeaderMixin`, stored as `_fitsheadermixin_header_timeout`.

A `@timeout` decorator was considered and rejected: it works by having the *server* reply with a `method_timeout` IQ before running, and a dead peer never replies at all.

## Test plan

- `ruff check` / `black --check` clean; `pyrefly check` clean on `fitsheader.py`.
- `pytest tests/mixins/test_fitsheader.py`: 43 passed, including two new tests (dead peer times out and is cancelled; live+dead mix adds live headers and skips dead).

See `specs/plans/2026-08-16-fits-header-fetch-timeout.md` for the plan.

Note: this branch also contains commit `1e2b81d5` ("Mark core-tier test baseline plan implemented"), which the graphify automation committed to the branch on checkout — unrelated to this change.