### PR TITLE
Add raw-frame streaming endpoint to BaseVideo alongside MJPEG

### DIFF
--- a/pyobs/images/image.py
+++ b/pyobs/images/image.py
@@ -197,6 +197,32 @@ class Image:
             return cls._from_hdu_list(d)
 
     @classmethod
+    def from_ndarray(cls, data: npt.NDArray[Any], meta: dict[str, Any]) -> Image:
+        """Create an Image from a raw numpy array and a metadata dict.
+
+        This is the consumer side of BaseVideo's raw-frame wire format: the meta dict
+        carries FITS keywords (plus a DTYPE entry used to decode the raw bytes on the
+        wire) and is mapped straight onto a FITS header, bypassing FITS bytes entirely.
+
+        Args:
+            data: Numpy array of pixel data.
+            meta: Dictionary of metadata -- FITS keywords plus an optional DTYPE marker.
+
+        Returns:
+            New image.
+        """
+
+        # build header from the FITS-named keys, skipping the DTYPE marker
+        header = fits.Header()
+        for key, value in meta.items():
+            if key == "DTYPE":
+                continue
+            header[key] = value
+
+        # create image (also sets NAXIS1/NAXIS2 from the data shape)
+        return cls(data=data, header=header)
+
+    @classmethod
     def from_file(cls, filename: str) -> Image:
         """Create image from FITS file.
 

--- a/pyobs/interfaces/IVideo.py
+++ b/pyobs/interfaces/IVideo.py
@@ -8,7 +8,8 @@ from .IData import IData
 
 @dataclass
 class VideoCapabilities:
-    video: str = ""
+    mjpeg: str | None = None
+    raw: str | None = None
 
 
 class IVideo(IData, metaclass=ABCMeta):

--- a/pyobs/mixins/fitsheader.py
+++ b/pyobs/mixins/fitsheader.py
@@ -114,8 +114,13 @@ class FitsHeaderMixin:
                 for key, entry in headers.items():
                     image.header[key] = (entry.value, entry.comment)
 
-    async def add_fits_headers(self, image: Image | fits.PrimaryHDU) -> None:
-        """Add requested FITS headers to header of given image.
+    def add_local_fits_headers(self, image: Image | fits.PrimaryHDU) -> None:
+        """Add the cheap, local FITS headers to the given image (no I/O, no comm).
+
+        This is the always-on half of add_fits_headers(): the configured static
+        fits_headers dict plus the computed fields from _fitsheadermixin_add_fits_headers().
+        The frame-sequence-number step is deliberately kept out (it does a VFS read+write
+        per call), so video-rate callers can reuse this without hitting the VFS on every frame.
 
         Args:
             image: Image with header to add to.
@@ -130,6 +135,18 @@ class FitsHeaderMixin:
 
         # add more fits headers
         self._fitsheadermixin_add_fits_headers(image)
+
+    async def add_fits_headers(self, image: Image | fits.PrimaryHDU) -> None:
+        """Add requested FITS headers to header of given image.
+
+        Args:
+            image: Image with header to add to.
+        """
+
+        # cheap, local half
+        self.add_local_fits_headers(image)
+
+        # persistent nightly frame-sequence number (VFS I/O -- not per-frame safe)
         if self._fitsheadermixin_enable_frame_number:
             await self._fitsheadermixin_add_framenum(image)
 
@@ -281,6 +298,7 @@ class ImageFitsHeaderMixin(FitsHeaderMixin):
         self._fitsheadermixin_warned_cdelt = False
         self._fitsheadermixin_warned_crpix = False
         self._fitsheadermixin_warned_cd_matrix = False
+        self._fitsheadermixin_warned_centre = False
 
     @property
     def rotation(self) -> float | None:
@@ -335,8 +353,9 @@ class ImageFitsHeaderMixin(FitsHeaderMixin):
         if self._fitsheadermixin_centre is not None:
             hdr["DET-CPX1"] = (self._fitsheadermixin_centre[0], "x-pixel on mechanical axis in unbinned image")
             hdr["DET-CPX2"] = (self._fitsheadermixin_centre[1], "y-pixel on mechanical axis in unbinned image")
-        else:
+        elif not self._fitsheadermixin_warned_centre:
             log.warning("Could not calculate DET-CPX1/DET-CPX2 (centre not given in config).")
+            self._fitsheadermixin_warned_centre = True
 
         # reference pixel in binned image
         if "DET-CPX1" in hdr and "DET-BIN1" in hdr and "DET-CPX2" in hdr and "DET-BIN2" in hdr:

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -67,6 +67,7 @@ class LastImage(NamedTuple):
     image: Image | None
     jpeg: bytes | None
     filename: str | None
+    date_obs: str
 
 
 class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCMeta):
@@ -134,6 +135,9 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self._last_image: LastImage | None = None
         self._last_time = 0.0
         self._flip = flip
+        # 60s is a starting point, not measured -- trades off against _activate_camera()/
+        # _deactivate_camera() cost, which is driver-specific and mostly unknown right now;
+        # too short relative to that cost risks flapping (rapid activate/deactivate cycling)
         self._sleep_time = sleep_time
         self._new_frame = asyncio.Event()
 
@@ -273,8 +277,16 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         while True:
             # wait for a new frame; the event coalesces multiple frames that
-            # arrive while a slow consumer is still writing into a single wake
-            await self._new_frame.wait()
+            # arrive while a slow consumer is still writing into a single wake.
+            # Bounded by a timeout so a connected-but-frame-less stretch (producer
+            # paused, exposure gap) still re-touches activity -- otherwise the
+            # camera could go back to sleep out from under an active raw consumer
+            # even though the connection is still open (design doc §5).
+            try:
+                await asyncio.wait_for(self._new_frame.wait(), timeout=self._sleep_time / 2)
+            except TimeoutError:
+                await self.activate_camera()
+                continue
             self._new_frame.clear()
 
             # keep activity fresh for the duration of this connection
@@ -286,7 +298,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
                 continue
 
             # build frame bytes (JSON meta header + raw little-endian bytes)
-            meta, frame = self._raw_frame(last.data)
+            meta, frame = self._raw_frame(last.data, last.date_obs)
 
             # now send it!
             try:
@@ -302,11 +314,12 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         # return response
         return response
 
-    def _raw_frame(self, data: NDArray[Any]) -> tuple[bytes, bytes]:
+    def _raw_frame(self, data: NDArray[Any], date_obs: str) -> tuple[bytes, bytes]:
         """Build the JSON meta header and raw bytes for one frame.
 
         Args:
             data: Numpy array to send.
+            date_obs: Acquisition timestamp, captured in _set_image() -- not send time.
 
         Returns:
             Tuple of (meta header bytes, raw frame bytes).
@@ -315,7 +328,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         # build a header using the same cheap, local sub-step as grab_data()'s FITS
         # path (no VFS I/O, no cross-module comm) -- see design doc §3
         image = Image(data)
-        image.header["DATE-OBS"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")
+        image.header["DATE-OBS"] = date_obs
         image.header["IMAGETYP"] = self._image_type
         self.add_local_fits_headers(image)
 
@@ -432,6 +445,9 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
     async def _set_image(self, data: NDArray[Any]) -> None:
         """Create FITS and JPEG images from data."""
 
+        # capture acquisition time now, not when a raw-stream consumer later sends it
+        date_obs = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")
+
         # flip image?
         if self._flip:
             data: NDArray[Any] = np.flip(data, axis=0)
@@ -460,7 +476,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
                 self._last_time = now
 
         # store both
-        self._last_image = LastImage(data=data, image=image, jpeg=jpeg, filename=filename)
+        self._last_image = LastImage(data=data, image=image, jpeg=jpeg, filename=filename, date_obs=date_obs)
         self._frame_num += 1
 
         # signal any raw-stream consumers that a new frame is available

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -1,9 +1,11 @@
 import asyncio
 import io
+import json
 import logging
 import time
 from abc import ABCMeta
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any, NamedTuple
 
 import aiohttp
@@ -76,16 +78,16 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self,
         http_port: int = 37077,
         interval: float = 0.5,
-        video_path: str = "/webcam/video.mjpg",
+        video_path: str | None = "/webcam/video.mjpg",
+        raw_path: str | None = "/webcam/video.raw",
         filenames: str = "/webcam/pyobs-{DAY-OBS|date:}-{FRAMENUM|string:04d}.fits",
         fits_namespaces: list[str] | None = None,
         fits_headers: dict[str, Any] | None = None,
         centre: tuple[float, float] | None = None,
         rotation: float = 0.0,
         cache_size: int = 5,
-        live_view: bool = True,
         flip: bool = False,
-        sleep_time: int = 600,
+        sleep_time: int = 60,
         **kwargs: Any,
     ):
         """Creates a new BaseWebcam.
@@ -97,14 +99,14 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             http_port: HTTP port for webserver.
             exposure_time: Initial exposure time.
             interval: Min interval for grabbing images.
-            video_path: VFS path to video.
+            video_path: VFS path to video. None disables the MJPEG live view.
+            raw_path: VFS path to the raw frame stream. None disables it.
             filename: Filename pattern for FITS images.
             fits_namespaces: List of namespaces for FITS headers that this camera should request.
             fits_headers: Additional FITS headers.
             centre: (x, y) tuple of camera centre.
             rotation: Rotation east of north.
             cache_size: Size of cache for previous images.
-            live_view: If True, live view is served via web server.
             flip: Whether to flip around Y axis.
             sleep_time: Time in s with inactivity after which the camera should go to sleep.
         """
@@ -123,8 +125,8 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self._port = http_port
         self._interval = interval
         self._video_path = video_path
+        self._raw_path = raw_path
         self._frame_num = 0
-        self._live_view = live_view
         self._image_type = ImageType.OBJECT
         self._image_request_lock = asyncio.Lock()
         self._image_requests: list[ImageRequest] = []
@@ -133,6 +135,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self._last_time = 0.0
         self._flip = flip
         self._sleep_time = sleep_time
+        self._new_frame = asyncio.Event()
 
         # active
         self._active = False
@@ -144,14 +147,12 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         # define web server
         self._app = web.Application()
-        self._app.add_routes(
-            [
-                web.get("/", self.web_handler),
-                web.get("/ping", self.ping_handler),
-                web.get("/video.mjpg", self.video_handler),
-                web.get("/{filename}", self.image_handler),
-            ]
-        )
+        routes = [web.get("/ping", self.ping_handler), web.get("/{filename}", self.image_handler)]
+        if self._video_path is not None:
+            routes += [web.get("/", self.web_handler), web.get("/video.mjpg", self.video_handler)]
+        if self._raw_path is not None:
+            routes.append(web.get("/video.raw", self.raw_handler))
+        self._app.add_routes(routes)
         self._runner = web.AppRunner(self._app)
         self._site: web.TCPSite | None = None
 
@@ -166,8 +167,8 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         await self._site.start()
         self._is_listening = True
 
-        # publish video URL as capability
-        await self.comm.set_capabilities(IVideo, VideoCapabilities(video=self._video_path))
+        # publish video URLs as capabilities
+        await self.comm.set_capabilities(IVideo, VideoCapabilities(mjpeg=self._video_path, raw=self._raw_path))
 
         # publish initial state
         await self.comm.set_state(IImageType, ImageTypeState(image_type=self._image_type))
@@ -223,10 +224,9 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         last_num = None
         last_time = 0.0
-        interval = 1.0
         while True:
             # not reached interval?
-            if time.time() < last_time + interval:
+            if time.time() < last_time + self._interval:
                 await asyncio.sleep(0.01)
                 continue
 
@@ -252,6 +252,92 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         # return response
         return response
+
+    async def raw_handler(self, request: web.Request) -> web.StreamResponse:
+        """Handles access to /video.raw and returns raw frames.
+
+        Args:
+            request: Request to respond to.
+
+        Returns:
+            Response containing raw frame stream.
+        """
+
+        # activate camera
+        await self.activate_camera()
+
+        # create response
+        response = web.StreamResponse()
+        response.content_type = "multipart/x-mixed-replace; boundary=--rawboundary"
+        await response.prepare(request)
+
+        while True:
+            # wait for a new frame; the event coalesces multiple frames that
+            # arrive while a slow consumer is still writing into a single wake
+            await self._new_frame.wait()
+            self._new_frame.clear()
+
+            # keep activity fresh for the duration of this connection
+            await self.activate_camera()
+
+            # get current frame
+            last = self._last_image
+            if last is None:
+                continue
+
+            # build frame bytes (JSON meta header + raw little-endian bytes)
+            meta, frame = self._raw_frame(last.data)
+
+            # now send it!
+            try:
+                await response.write(
+                    b"--rawboundary\r\n"
+                    b"Content-Type: application/octet-stream\r\n"
+                    b"X-Pyobs-Frame-Meta: " + meta + b"\r\n\r\n" + frame + b"\r\n"
+                )
+            except aiohttp.client_exceptions.ClientConnectionResetError:
+                # end stream
+                break
+
+        # return response
+        return response
+
+    def _raw_frame(self, data: NDArray[Any]) -> tuple[bytes, bytes]:
+        """Build the JSON meta header and raw bytes for one frame.
+
+        Args:
+            data: Numpy array to send.
+
+        Returns:
+            Tuple of (meta header bytes, raw frame bytes).
+        """
+
+        # build a header using the same cheap, local sub-step as grab_data()'s FITS
+        # path (no VFS I/O, no cross-module comm) -- see design doc §3
+        image = Image(data)
+        image.header["DATE-OBS"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")
+        image.header["IMAGETYP"] = self._image_type
+        self.add_local_fits_headers(image)
+
+        # serialize header as a JSON dict, carrying DTYPE so the consumer can
+        # decode the raw bytes unambiguously (numpy's dtype string bakes in byte order)
+        meta: dict[str, Any] = {}
+        for key in image.header:
+            meta[key] = self._json_safe(image.header[key])
+        meta["DTYPE"] = data.dtype.newbyteorder("<").str
+        meta_bytes = json.dumps(meta, separators=(",", ":")).encode()
+
+        # raw bytes, forced to little-endian regardless of host order
+        frame = np.ascontiguousarray(data, dtype=data.dtype.newbyteorder("<")).tobytes()
+
+        return meta_bytes, frame
+
+    @staticmethod
+    def _json_safe(value: Any) -> Any:
+        """Convert a FITS header value to a JSON-serializable Python scalar."""
+        if isinstance(value, np.generic):
+            return value.item()
+        return str(value) if isinstance(value, StrEnum) else value
 
     async def image_handler(self, request: web.Request) -> web.Response:
         """Handles access to /* and returns a specified image.
@@ -365,7 +451,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         # convert to jpeg only if we need live view
         now = time.time()
         jpeg = None
-        if self._live_view:
+        if self._video_path is not None:
             # check interval
             if now - self._last_time > self._interval:
                 # write to buffer and reset interval
@@ -376,6 +462,9 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         # store both
         self._last_image = LastImage(data=data, image=image, jpeg=jpeg, filename=filename)
         self._frame_num += 1
+
+        # signal any raw-stream consumers that a new frame is available
+        self._new_frame.set()
 
         # prepare next image
         if len(self._image_requests) > 0:

--- a/specs/design/basevideo-raw-frame-streaming.md
+++ b/specs/design/basevideo-raw-frame-streaming.md
@@ -1,6 +1,6 @@
 # `BaseVideo`: raw-frame streaming endpoint, alongside the existing MJPEG live view
 
-Status: proposed
+Status: implemented
 
 ## Problem
 

--- a/specs/design/index.md
+++ b/specs/design/index.md
@@ -4,7 +4,7 @@ Living architecture/design docs, one per feature or subsystem. Kept around after
 (`status: implemented`), not deleted.
 
 - [basevideo-raw-frame-streaming.md](basevideo-raw-frame-streaming.md) — `BaseVideo` raw-frame
-  streaming endpoint alongside the existing MJPEG live view. *proposed*
+  streaming endpoint alongside the existing MJPEG live view. *implemented*
 - [exception_handling.md](exception_handling.md) — exception handling across the RPC boundary.
   *implemented*
 - [external_interfaces_registry.md](external_interfaces_registry.md) — external interfaces

--- a/specs/plans/2026-08-11-basevideo-raw-frame-streaming.md
+++ b/specs/plans/2026-08-11-basevideo-raw-frame-streaming.md
@@ -56,7 +56,9 @@ on `BaseVideo`). Just the producer-side changes to `pyobs/modules/camera/basevid
       - wait on `self._new_frame`, clear after each read — coalesces backpressure automatically,
         no explicit frame-drop bookkeeping needed
       - call `activate_camera()` on connect; keep updating `_active_time` for the duration of the
-        connection (every frame served, not just at connect)
+        connection, independent of frame arrival (a bounded `asyncio.wait_for` on `self._new_frame`
+        re-touches activity on timeout too, not just on frame arrival — otherwise a connected but
+        frame-less raw client, e.g. producer paused, could let the camera sleep out from under it)
       - clean up (deregister, let `_active_time` age out normally) on client disconnect
         (`aiohttp.client_exceptions.ClientConnectionResetError`, matching `video_handler`'s existing
         handling at `basevideo.py:248-251`)

--- a/specs/plans/2026-08-11-basevideo-raw-frame-streaming.md
+++ b/specs/plans/2026-08-11-basevideo-raw-frame-streaming.md
@@ -1,6 +1,6 @@
 # Plan: raw-frame streaming endpoint in `BaseVideo`
 
-Status: proposed
+Status: implemented
 Design: `specs/design/basevideo-raw-frame-streaming.md`
 
 ## Context
@@ -12,34 +12,34 @@ on `BaseVideo`). Just the producer-side changes to `pyobs/modules/camera/basevid
 
 ## Todo
 
-- [ ] Fix the existing `video_handler` latency bug first, independently of the new endpoint:
+- [x] Fix the existing `video_handler` latency bug first, independently of the new endpoint:
       hardcoded local `interval = 1.0` (`basevideo.py:226`) ignores `self._interval` — decide
       whether to just use `self._interval` there, or keep MJPEG intentionally throttled separately
       from the new raw stream's rate (see next item).
-- [ ] Add `self._new_frame: asyncio.Event` (or similar name), set at the end of `_set_image()`
+- [x] Add `self._new_frame: asyncio.Event` (or similar name), set at the end of `_set_image()`
       (`basevideo.py:346-393`) on every call. Confirm this is cheap enough to leave unconditional
       (it should be — setting an `Event` with no waiters is trivial) rather than gating it behind
       whether a raw consumer is connected.
-- [ ] Rename `VideoCapabilities.video: str` -> `mjpeg: str | None = None` (`IVideo.py:10-11`) and
+- [x] Rename `VideoCapabilities.video: str` -> `mjpeg: str | None = None` (`IVideo.py:10-11`) and
       add `raw: str | None = None`. Breaking rename, no deprecation shim — fine, project is
       `2.0.0.dev`.
-- [ ] Collapse `live_view: bool = True` + `video_path: str = "/webcam/video.mjpg"`
+- [x] Collapse `live_view: bool = True` + `video_path: str = "/webcam/video.mjpg"`
       (`basevideo.py:79,86`) into a single `video_path: str | None = "/webcam/video.mjpg"`. Drop
       `live_view` entirely — it had no other use in the file. `_set_image()`'s
       `if self._live_view:` (`basevideo.py:368`) becomes `if self._video_path is not None:`.
       `open()`'s capability publish becomes `mjpeg=self._video_path` (fixes the existing bug: today
       it unconditionally advertises `video` even when `live_view=False` means no frame is ever
       emitted, `basevideo.py:170` vs. `:368-374`).
-- [ ] Register `/` and `/video.mjpg` only when `self._video_path is not None` (currently
+- [x] Register `/` and `/video.mjpg` only when `self._video_path is not None` (currently
       unconditional in `_app.add_routes(...)`) — matches the gating being added for the raw route
       below; `/ping` and `/{filename}` stay unconditional (unrelated to live view).
-- [ ] Add `raw_path: str | None = "/webcam/video.raw"` to the constructor (mirroring the collapsed
+- [x] Add `raw_path: str | None = "/webcam/video.raw"` to the constructor (mirroring the collapsed
       `video_path` param above) — a single knob, not a bool-plus-path. `None` disables both route
       registration and capability advertisement; a string enables both and is the value passed to
       `VideoCapabilities(raw=self._raw_path)`.
-- [ ] Register the new raw route, literal path `/video.raw` (mirrors `/video.mjpg`'s hardcoded
+- [x] Register the new raw route, literal path `/video.raw` (mirrors `/video.mjpg`'s hardcoded
       form), only when `self._raw_path is not None`.
-- [ ] Split `ImageFitsHeaderMixin.add_fits_headers()` (`fitsheader.py:117-134`): pull out the cheap,
+- [x] Split `ImageFitsHeaderMixin.add_fits_headers()` (`fitsheader.py:117-134`): pull out the cheap,
       local sub-step (static `fits_headers` dict + `_fitsheadermixin_add_fits_headers()`'s computed
       fields — MJD-OBS/LST/EQUINOX/DAY-OBS/location, no I/O) so it's callable without also running
       `_fitsheadermixin_add_framenum()` (VFS read+write per call). `grab_data()`'s FITS path keeps
@@ -47,7 +47,7 @@ on `BaseVideo`). Just the producer-side changes to `pyobs/modules/camera/basevid
       sub-step — see design doc §3 for why the VFS-backed framenum step can't run per frame at
       video rate, and why the raw stream doesn't need any frame-sequence number at all (dropped
       from the wire format, not replaced with an in-memory counter either).
-- [ ] Implement the new raw-stream handler:
+- [x] Implement the new raw-stream handler:
       - multipart response, same `multipart/x-mixed-replace` mechanism as `video_handler`
       - per-frame: JSON meta header built from the split-out cheap header sub-step above (FITS
         keywords — `NAXIS1`/`NAXIS2`/`BITPIX`/`DATE-OBS`/etc., whatever it produces, plus `DTYPE`
@@ -60,16 +60,16 @@ on `BaseVideo`). Just the producer-side changes to `pyobs/modules/camera/basevid
       - clean up (deregister, let `_active_time` age out normally) on client disconnect
         (`aiohttp.client_exceptions.ClientConnectionResetError`, matching `video_handler`'s existing
         handling at `basevideo.py:248-251`)
-- [ ] Byte order: confirm outgoing arrays are serialized little-endian regardless of host order
+- [x] Byte order: confirm outgoing arrays are serialized little-endian regardless of host order
       (explicit dtype cast, not relying on `ndarray.tobytes()`'s native order).
-- [ ] Add a reconstruction helper (e.g. `Image` classmethod, name TBD) that builds a
+- [x] Add a reconstruction helper (e.g. `Image` classmethod, name TBD) that builds a
       `pyobs.images.Image` directly from `(ndarray, meta dict)` — decode via
       `numpy.dtype(meta["DTYPE"])`, build the `Header` from the FITS-named keys by direct
       assignment. Deliberately does **not** call `Image.from_bytes()`/go through actual FITS
       bytes, and does **not** touch `ImageFitsHeaderMixin`'s namespace-based cross-module enrichment
       — see design doc §3 for why. This is producer/wire-contract scope (`pyobs-core`), not a
       guiding consumer module.
-- [ ] Lower `sleep_time`'s default from 600s to **60s** (`basevideo.py`, param TBD exact location) —
+- [x] Lower `sleep_time`'s default from 600s to **60s** (`basevideo.py`, param TBD exact location) —
       a raw-only consumer session that dies previously left hardware streaming for up to 10 minutes
       with nothing consuming it. 60s is a starting point, not measured — flag in a code comment that
       it trades off against `_activate_camera()`/`_deactivate_camera()` cost (driver-specific,

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -62,7 +62,7 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-08-09-object-kwarg-validation.md](2026-08-09-object-kwarg-validation.md) — surface
   unrecognized kwargs in `Object.__init__`. **investigated, not started**
 - [2026-08-11-basevideo-raw-frame-streaming.md](2026-08-11-basevideo-raw-frame-streaming.md) —
-  raw-frame streaming endpoint in `BaseVideo`. **proposed**
+  raw-frame streaming endpoint in `BaseVideo`. **implemented**
 - [2026-08-11-camera-driver-gui-split.md](2026-08-11-camera-driver-gui-split.md) — driver/GUI split
   for all camera modules. **proposed** (Repos: qhyccd, fli, tis, asi, aravis, sbig, flipro, v4l)
 - [2026-08-11-core-tier-test-baseline-and-dependabot-automerge.md](2026-08-11-core-tier-test-baseline-and-dependabot-automerge.md) —

--- a/tests/images/test_image.py
+++ b/tests/images/test_image.py
@@ -130,6 +130,36 @@ def test_from_ccddata_non_values(mock_image):
     assert_equal_image_params(image, mock_image)
 
 
+def test_from_ndarray_builds_header_and_preserves_dtype():
+    data = np.arange(6, dtype="<u2").reshape(2, 3)
+    meta = {
+        "NAXIS1": 3,
+        "NAXIS2": 2,
+        "DTYPE": "<u2",
+        "DATE-OBS": "2026-08-11T22:04:11.123456",
+        "IMAGETYP": "object",
+    }
+
+    image = Image.from_ndarray(data, meta)
+
+    np.testing.assert_array_equal(image.data, data)
+    assert image.data.dtype == np.dtype("<u2")
+    assert image.header["DATE-OBS"] == "2026-08-11T22:04:11.123456"
+    assert image.header["IMAGETYP"] == "object"
+    assert image.header["NAXIS1"] == 3
+    assert image.header["NAXIS2"] == 2
+
+
+def test_from_ndarray_skips_dtype_key():
+    data = np.zeros((2, 2), dtype=np.float32)
+    meta = {"DTYPE": "<f4", "DATE-OBS": "2026-01-01T00:00:00"}
+
+    image = Image.from_ndarray(data, meta)
+
+    assert "DTYPE" not in image.header
+    assert image.header["DATE-OBS"] == "2026-01-01T00:00:00"
+
+
 def test__from_hdu_list_no_hdu():
     hdu = fits.PrimaryHDU(None)
     img_hdu = fits.ImageHDU(None)

--- a/tests/interfaces/test_ivideo.py
+++ b/tests/interfaces/test_ivideo.py
@@ -1,0 +1,27 @@
+"""Tests for the IVideo interface's VideoCapabilities dataclass."""
+
+from __future__ import annotations
+
+from pyobs.comm.xmpp.serializer import _dataclass_to_xml, _xml_to_dataclass
+from pyobs.interfaces import VideoCapabilities
+
+
+def test_video_capabilities_defaults() -> None:
+    caps = VideoCapabilities()
+    assert caps.mjpeg is None
+    assert caps.raw is None
+
+
+def test_video_capabilities_roundtrip() -> None:
+    caps = VideoCapabilities(mjpeg="/webcam/video.mjpg", raw="/webcam/video.raw")
+    xml = _dataclass_to_xml(caps, tag="capabilities")
+    restored = _xml_to_dataclass(xml, VideoCapabilities)
+    assert restored == caps
+
+
+def test_video_capabilities_roundtrip_none_field() -> None:
+    caps = VideoCapabilities(mjpeg="/webcam/video.mjpg", raw=None)
+    xml = _dataclass_to_xml(caps, tag="capabilities")
+    restored = _xml_to_dataclass(xml, VideoCapabilities)
+    assert restored.mjpeg == "/webcam/video.mjpg"
+    assert restored.raw is None

--- a/tests/mixins/test_fitsheader.py
+++ b/tests/mixins/test_fitsheader.py
@@ -203,6 +203,24 @@ async def test_add_fits_headers_skips_frame_number_when_disabled() -> None:
     assert "FRAMENUM" not in image.header
 
 
+def test_add_local_fits_headers_sets_headers_without_vfs_io() -> None:
+    m = make_module(frame_number=True)
+    m._vfs = MagicMock()
+    m._vfs.read_yaml = AsyncMock()
+    m._vfs.write_yaml = AsyncMock()
+    image = make_image(**{"DATE-OBS": "2024-01-01T03:00:00.000"})
+
+    m.add_local_fits_headers(image)
+
+    assert image.header["EXTNAME"] == "SCI"
+    assert image.header["OBSERVER"] == "pyobs"
+    assert image.header["MJD-OBS"] == pytest.approx(60310.125)
+    assert "FRAMENUM" not in image.header
+    # the whole point of the split: no VFS I/O on the local half
+    m._vfs.read_yaml.assert_not_called()
+    m._vfs.write_yaml.assert_not_called()
+
+
 # ── _fitsheadermixin_add_fits_headers (base) ────────────────────────────────
 
 

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -249,7 +249,9 @@ async def test_image_jpeg_returns_last_jpeg() -> None:
     bv = make_basevideo()
     bv.activate_camera = AsyncMock()
     bv._frame_num = 5
-    bv._last_image = LastImage(data=np.zeros((2, 2)), image=None, jpeg=b"jpeg-bytes", filename=None)
+    bv._last_image = LastImage(
+        data=np.zeros((2, 2)), image=None, jpeg=b"jpeg-bytes", filename=None, date_obs="2024-01-01T00:00:00.000000"
+    )
 
     num, jpeg = await bv.image_jpeg()
 
@@ -562,7 +564,7 @@ def test_raw_frame_meta_and_little_endian_bytes() -> None:
     bv = make_basevideo()
     data = np.arange(6, dtype=np.uint16).reshape(2, 3)
 
-    meta_bytes, frame = bv._raw_frame(data)
+    meta_bytes, frame = bv._raw_frame(data, "2024-01-01T00:00:00.000000")
 
     meta = json.loads(meta_bytes)
     assert meta["DTYPE"] == "<u2"
@@ -596,3 +598,38 @@ async def test_raw_handler_writes_once_per_wake_and_keeps_active(mocker) -> None
     assert response.write.await_count == 1
     assert bv.camera_active is True
     assert bv._active_time > 0
+
+
+@pytest.mark.asyncio
+async def test_raw_handler_touches_activity_without_new_frame(mocker) -> None:
+    # no frame has arrived yet -- the wait must time out and re-touch activity
+    # anyway, per design doc §5, instead of blocking indefinitely
+    bv = make_basevideo(sleep_time=0.02)
+
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    response.write = AsyncMock(side_effect=ClientConnectionResetError())
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+
+    real_activate = bv.activate_camera
+    activate_calls = 0
+
+    async def activate_side_effect() -> None:
+        nonlocal activate_calls
+        activate_calls += 1
+        await real_activate()
+        if activate_calls == 2:
+            # this is the timeout-triggered re-touch with no frame yet produced;
+            # now produce one so the next loop iteration can wake normally
+            await bv._set_image(np.zeros((2, 2), dtype=np.uint16))
+
+    bv.activate_camera = activate_side_effect  # type: ignore[method-assign]
+
+    await bv.raw_handler(make_request())
+
+    # call #1: on connect: call #2: timeout re-touch (no frame yet); call #3: after real wake
+    assert activate_calls >= 2
+    assert response.write.await_count == 1
+    assert bv.camera_active is True

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -34,21 +35,22 @@ def test_init_defaults() -> None:
     assert bv._port == 37077
     assert bv._interval == 0.5
     assert bv._video_path == "/webcam/video.mjpg"
+    assert bv._raw_path == "/webcam/video.raw"
     assert bv._frame_num == 0
-    assert bv._live_view is True
     assert bv._image_type == ImageType.OBJECT
     assert bv._active is False
     assert bv._flip is False
-    assert bv._sleep_time == 600
+    assert bv._sleep_time == 60
     assert bv._is_listening is False
     assert bv.opened is False
 
 
 def test_init_custom_values() -> None:
-    bv = make_basevideo(http_port=8000, interval=1.5, live_view=False, flip=True, sleep_time=30)
+    bv = make_basevideo(http_port=8000, interval=1.5, video_path=None, raw_path=None, flip=True, sleep_time=30)
     assert bv._port == 8000
     assert bv._interval == 1.5
-    assert bv._live_view is False
+    assert bv._video_path is None
+    assert bv._raw_path is None
     assert bv._flip is True
     assert bv._sleep_time == 30
 
@@ -76,7 +78,8 @@ async def test_open_starts_server_and_publishes_capabilities_and_state(mocker) -
     bv._comm.set_capabilities.assert_awaited_once()
     interface, caps = bv._comm.set_capabilities.await_args[0]
     assert interface is IVideo
-    assert caps.video == bv._video_path
+    assert caps.mjpeg == bv._video_path
+    assert caps.raw == bv._raw_path
 
     bv._comm.set_state.assert_awaited_once()
     state_interface, state = bv._comm.set_state.await_args[0]
@@ -274,7 +277,7 @@ def test_create_jpeg_handles_uint8() -> None:
 
 @pytest.mark.asyncio
 async def test_set_image_stores_last_image_and_increments_frame_num() -> None:
-    bv = make_basevideo(live_view=False)
+    bv = make_basevideo(video_path=None)
     data = np.zeros((4, 4))
 
     await bv._set_image(data)
@@ -282,12 +285,12 @@ async def test_set_image_stores_last_image_and_increments_frame_num() -> None:
     assert bv._frame_num == 1
     assert bv._last_image is not None
     assert bv._last_image.data is data
-    assert bv._last_image.jpeg is None  # live_view disabled
+    assert bv._last_image.jpeg is None  # video_path disabled
 
 
 @pytest.mark.asyncio
 async def test_set_image_flips_when_configured() -> None:
-    bv = make_basevideo(live_view=False, flip=True)
+    bv = make_basevideo(video_path=None, flip=True)
     data = np.arange(16).reshape(4, 4).astype(float)
 
     await bv._set_image(data)
@@ -296,8 +299,8 @@ async def test_set_image_flips_when_configured() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_image_generates_jpeg_when_live_view_enabled() -> None:
-    bv = make_basevideo(live_view=True, interval=0.0)
+async def test_set_image_generates_jpeg_when_video_enabled() -> None:
+    bv = make_basevideo(interval=0.0)
     data = np.zeros((4, 4), dtype=np.uint8)
 
     await bv._set_image(data)
@@ -308,7 +311,7 @@ async def test_set_image_generates_jpeg_when_live_view_enabled() -> None:
 
 @pytest.mark.asyncio
 async def test_set_image_throttles_jpeg_generation_by_interval() -> None:
-    bv = make_basevideo(live_view=True, interval=1000.0)
+    bv = make_basevideo(interval=1000.0)
     bv._last_time = __import__("time").time()  # just generated one
 
     await bv._set_image(np.zeros((4, 4)))
@@ -318,7 +321,7 @@ async def test_set_image_throttles_jpeg_generation_by_interval() -> None:
 
 @pytest.mark.asyncio
 async def test_set_image_creates_image_and_fulfills_pending_requests() -> None:
-    bv = make_basevideo(live_view=False)
+    bv = make_basevideo(video_path=None)
     bv.request_fits_headers = AsyncMock(return_value={})
     bv._create_image = AsyncMock(return_value=("the-image", "the-filename.fits"))
 
@@ -337,7 +340,7 @@ async def test_set_image_creates_image_and_fulfills_pending_requests() -> None:
 
 @pytest.mark.asyncio
 async def test_set_image_prepares_next_image_when_requests_pending() -> None:
-    bv = make_basevideo(live_view=False)
+    bv = make_basevideo(video_path=None)
     bv.request_fits_headers = AsyncMock(return_value={"h": "x"})
     bv._image_requests.append(ImageRequest(broadcast=True))
 
@@ -351,7 +354,7 @@ async def test_set_image_prepares_next_image_when_requests_pending() -> None:
 
 @pytest.mark.asyncio
 async def test_set_image_does_not_prepare_next_image_without_requests() -> None:
-    bv = make_basevideo(live_view=False)
+    bv = make_basevideo(video_path=None)
     bv.request_fits_headers = AsyncMock(return_value={})
 
     await bv._set_image(np.zeros((4, 4)))
@@ -489,3 +492,107 @@ async def test_set_image_type_updates_state_and_type() -> None:
     interface, state = bv._comm.set_state.await_args[0]
     assert interface is IImageType
     assert state.image_type == ImageType.DARK
+
+
+# ── route registration gating ───────────────────────────────────────────────
+
+
+def _route_paths(bv: BaseVideo) -> set[str]:
+    return {r.resource.canonical for r in bv._app.router.routes()}
+
+
+def test_routes_registered_by_default() -> None:
+    bv = make_basevideo()
+    paths = _route_paths(bv)
+    assert "/" in paths
+    assert "/video.mjpg" in paths
+    assert "/video.raw" in paths
+    assert "/ping" in paths
+    assert "/{filename}" in paths
+
+
+def test_routes_not_registered_when_video_disabled() -> None:
+    bv = make_basevideo(video_path=None)
+    paths = _route_paths(bv)
+    assert "/" not in paths
+    assert "/video.mjpg" not in paths
+    assert "/video.raw" in paths
+    assert "/ping" in paths
+    assert "/{filename}" in paths
+
+
+def test_routes_not_registered_when_raw_disabled() -> None:
+    bv = make_basevideo(raw_path=None)
+    paths = _route_paths(bv)
+    assert "/" in paths
+    assert "/video.mjpg" in paths
+    assert "/video.raw" not in paths
+    assert "/ping" in paths
+    assert "/{filename}" in paths
+
+
+# ── raw-frame streaming ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_image_sets_new_frame_event() -> None:
+    bv = make_basevideo(video_path=None)
+    bv._new_frame.clear()
+
+    await bv._set_image(np.zeros((4, 4)))
+
+    assert bv._new_frame.is_set()
+
+
+@pytest.mark.asyncio
+async def test_new_frame_event_coalesces_multiple_sets() -> None:
+    bv = make_basevideo(video_path=None)
+    bv._new_frame.clear()
+
+    for _ in range(5):
+        await bv._set_image(np.zeros((4, 4)))
+
+    # asyncio.Event is a boolean, not a counter: five sets collapse into one wake
+    assert bv._new_frame.is_set()
+    bv._new_frame.clear()
+    assert not bv._new_frame.is_set()
+
+
+def test_raw_frame_meta_and_little_endian_bytes() -> None:
+    bv = make_basevideo()
+    data = np.arange(6, dtype=np.uint16).reshape(2, 3)
+
+    meta_bytes, frame = bv._raw_frame(data)
+
+    meta = json.loads(meta_bytes)
+    assert meta["DTYPE"] == "<u2"
+    assert meta["NAXIS1"] == 3
+    assert meta["NAXIS2"] == 2
+    assert "DATE-OBS" in meta
+    assert "IMAGETYP" in meta
+    # little-endian: value 0 -> 00 00, value 1 -> 01 00
+    assert frame == data.astype("<u2").tobytes()
+    assert frame[:4] == b"\x00\x00\x01\x00"
+
+
+@pytest.mark.asyncio
+async def test_raw_handler_writes_once_per_wake_and_keeps_active(mocker) -> None:
+    bv = make_basevideo()
+
+    # several frames arriving before the handler starts coalesce into a single wake
+    for _ in range(3):
+        await bv._set_image(np.zeros((4, 4), dtype=np.uint16))
+
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    response.write = AsyncMock(side_effect=ClientConnectionResetError())
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+
+    await bv.raw_handler(make_request())
+
+    # one wake -> one write, despite three _set_image calls; connection is active
+    assert response.write.await_count == 1
+    assert bv.camera_active is True
+    assert bv._active_time > 0


### PR DESCRIPTION
Implements the `basevideo-raw-frame-streaming` plan/design.

## What

- New `/video.raw` multipart endpoint: JSON FITS-keyed meta header (`X-Pyobs-Frame-Meta`) + raw little-endian bytes, event-driven via a new `asyncio.Event` with latest-frame-wins backpressure (coalesces bursts into a single wake).
- `VideoCapabilities.video` renamed to `mjpeg`, plus a new `raw` field (both `str | None`). Collapsed `live_view` + `video_path` into a single `video_path: str | None`, added `raw_path: str | None`. `/`, `/video.mjpg`, and `/video.raw` routes are now registered only when their path is configured.
- Split `add_fits_headers()` into `add_local_fits_headers()` (no VFS I/O) plus the persistent FRAMENUM VFS step, so the raw path builds headers without per-frame VFS writes.
- Added `Image.from_ndarray()` reconstruction helper (consumer side of the wire contract).
- Fixed `video_handler`'s hardcoded 1 fps interval (now uses `self._interval`).
- Lowered `sleep_time` default 600s -> 60s.
- Also guarded the once-per-frame `DET-CPX` warning (it fired every frame when `centre` is unset).

## Breaking changes

- `VideoCapabilities.video` removed in favor of `mjpeg`/`raw`.
- `BaseVideo(live_view=...)` removed; use `video_path=None` to disable the MJPEG live view.

Both acceptable per the plan (project is `2.0.0.dev`).

## Tests

Added coverage for: capability round-trip (XML), route gating, `_new_frame` set + coalescing, raw meta/little-endian framing, raw handler wake/write + activity, `add_local_fits_headers` VFS-free, and `Image.from_ndarray`.