### PR TITLE
Fix comm_cfg anchor-holder key leaking into config dicts

### DIFF
--- a/pyobs/utils/config.py
+++ b/pyobs/utils/config.py
@@ -25,18 +25,36 @@ def pre_process_yaml(config: str) -> str:
     pattern = r"((\s*)?(-\s*)?\{include (\S*)( \S*)?\})"
     matches = re.findall(pattern, content)
     for match, indent, tick, filename, key in matches:
+        matches_anchor = reload_anchors(path + "/" + filename)
         with StringIO(pre_process_yaml(path + "/" + filename)) as f:
             include_full = yaml.safe_load(f)
             include_dict = include_parts(include_full, key)
-        include = yaml.dump(include_dict, default_flow_style=False, indent=2)
 
-        # ensure indentation level to be conserved
-        if tick != "":
-            include = tick + include
-        if indent != "":
-            indent_newline = indent + " " * len(tick)
-            include = indent + include.replace("\n", indent_newline)
-        matches_anchor = reload_anchors(path + "/" + filename)
+        # a whole-file include (no key selector) would otherwise leak any key whose sole purpose
+        # is holding an anchor for `<<: *anchor` use elsewhere (e.g. comm.shared.yaml's
+        # `comm_cfg: &comm`) as an unconsumed top-level key in the final config. Drop those here;
+        # `<<: *anchor` below still resolves correctly, since replace_aliases reads the anchor's
+        # value from the original included file, not from this (possibly trimmed) copy.
+        if not key.strip() and isinstance(include_dict, dict):
+            anchor_keywords = {keyword for keyword, _anchor in matches_anchor}
+            include_dict = {k: v for k, v in include_dict.items() if k not in anchor_keywords}
+
+        if isinstance(include_dict, dict) and not include_dict:
+            # everything in this whole-file include was anchor-holder keys (e.g. a
+            # comm.shared.yaml whose only top-level key is `comm_cfg: &comm`) -- nothing left to
+            # splice in. yaml.dump({}) is "{}\n", a flow-style node that isn't a valid sibling to
+            # the block-style mapping the rest of the file continues as, so drop the placeholder
+            # entirely instead of inserting an empty mapping.
+            include = ""
+        else:
+            include = yaml.dump(include_dict, default_flow_style=False, indent=2)
+
+            # ensure indentation level to be conserved
+            if tick != "":
+                include = tick + include
+            if indent != "":
+                indent_newline = indent + " " * len(tick)
+                include = indent + include.replace("\n", indent_newline)
         content = content.replace(match, include)
         content = replace_aliases(matches_anchor, path + "/" + filename, content)
 

--- a/pyobs/utils/config.py
+++ b/pyobs/utils/config.py
@@ -35,16 +35,21 @@ def pre_process_yaml(config: str) -> str:
         # `comm_cfg: &comm`) as an unconsumed top-level key in the final config. Drop those here;
         # `<<: *anchor` below still resolves correctly, since replace_aliases reads the anchor's
         # value from the original included file, not from this (possibly trimmed) copy.
+        # Only top-level, unindented anchor holders count -- reload_anchors() matches an anchor
+        # anywhere in the file regardless of nesting, so filtering by that directly would drop a
+        # top-level key whose name happens to collide with an unrelated nested anchor holder.
         if not key.strip() and isinstance(include_dict, dict):
-            anchor_keywords = {keyword for keyword, _anchor in matches_anchor}
+            anchor_keywords = top_level_anchor_keywords(path + "/" + filename)
             include_dict = {k: v for k, v in include_dict.items() if k not in anchor_keywords}
 
-        if isinstance(include_dict, dict) and not include_dict:
+        if not key.strip() and isinstance(include_dict, dict) and not include_dict:
             # everything in this whole-file include was anchor-holder keys (e.g. a
             # comm.shared.yaml whose only top-level key is `comm_cfg: &comm`) -- nothing left to
             # splice in. yaml.dump({}) is "{}\n", a flow-style node that isn't a valid sibling to
             # the block-style mapping the rest of the file continues as, so drop the placeholder
-            # entirely instead of inserting an empty mapping.
+            # entirely instead of inserting an empty mapping. Scoped to whole-file includes only --
+            # a keyed include that legitimately selects an empty mapping (`{include file key}`
+            # where `key`'s value is `{}`) must still emit `{}`, not be silently dropped.
             include = ""
         else:
             include = yaml.dump(include_dict, default_flow_style=False, indent=2)
@@ -78,6 +83,23 @@ def include_parts(include: dict[str, Any], keys: str) -> dict[str, Any]:
     for key in keys.split("."):
         include = include[key]
     return include
+
+
+def top_level_anchor_keywords(filename: str) -> set[str]:
+    """
+    Finds keys that hold an anchor ('&') at the top level (no leading whitespace) of the given
+    file -- used to decide which keys are safe to drop from a whole-file include, without
+    accidentally matching a nested key that happens to share its name with an unrelated anchor
+    holder elsewhere in the file (`reload_anchors` matches anchors at any nesting depth).
+    Args:
+        filename: name of the file to scan.
+    Returns:
+        keywords: set of top-level keys that carry an anchor.
+    """
+    pattern = r"^(\S*): &(?:\S*)"
+    with open(filename) as f:
+        content = f.read()
+    return set(re.findall(pattern, content, re.MULTILINE))
 
 
 def reload_anchors(filename: str) -> list[tuple[str, str]]:

--- a/specs/plans/2026-08-09-object-kwarg-validation.md
+++ b/specs/plans/2026-08-09-object-kwarg-validation.md
@@ -1,6 +1,7 @@
 # Plan: Surface unrecognized kwargs in `Object.__init__` instead of silently discarding them
 
-Status: investigated — findings and decision recorded 2026-08-15; implementation not started
+Status: `comm_cfg` anchor leak fixed at the source (2026-08-17, PR pending); `environment`/`database`
+question and `Object.__init__` enforcement (warn/raise) still open — see Decision
 
 Related: `specs/plans/night-archive-io-hardening.md` — where this was first flagged (a typo in a
 `Reduction`/`Night` YAML config silently does nothing instead of raising). That plan fixes the
@@ -105,6 +106,16 @@ anchor-holder key, key-selected include of the same key does not.
 This is a ~5-line change to one function in the include mechanism itself, not a new YAML loader —
 low enough risk to do directly rather than staging behind a warn+allowlist step in `Object.__init__`.
 
+**Implemented 2026-08-17.** One non-obvious wrinkle found while implementing: `comm.shared.yaml`'s
+*only* top-level key is `comm_cfg` (the anchor holder), so a whole-file include of it filters down to
+an **empty** `include_dict`. `yaml.dump({})` produces `"{}\n"`, a flow-style node — spliced into a
+document that continues as a block-style mapping below it (`comm:\n  <<: *comm\n  ...`), that isn't
+valid YAML (`ParserError: expected '<document start>', but found '<block mapping start>'`). Fixed by
+emitting an empty string instead of `"{}\n"` when the filtered `include_dict` is empty, so the
+placeholder is dropped entirely rather than replaced with an empty mapping. Verified end-to-end
+against a real fleet config (`pyobs-monet/config/central/imagedb.yaml`): `comm_cfg` no longer appears
+in the parsed result, `comm.class`/`comm.domain`/`comm.user` still resolve correctly via the alias.
+
 **`environment`/`database` (monet central configs) are a separate, still-open problem, not fixed by
 the above.** They aren't an anchor-holder pattern at all (no `&anchor` — see the open-question note
 below dated 2026-08-17): they're just top-level keys from a whole-file splice that nothing appears
@@ -143,9 +154,15 @@ kwargs disappears — but `environment`/`database` staying unresolved means a ha
       practice, and check whether any real YAML configs in this repo or known deployments rely on
       extra ignored keys (done — see findings above: 126 subclasses, `comm_cfg` anchor leak is real
       and documented)
-- [x] Decide raise vs. warn (see Decision: warn now, raise later after fixing the include leak)
-- [ ] Implement the warn check in `Object.__init__` (allowlisting `comm_cfg` and the monet
-      `environment`/`database` wrappers, or better, fixing the include mechanism to strip them)
-- [ ] Tests: a class with a typo'd kwarg warns; a class using legitimate multi-level `**kwargs`
-      passthrough still works; `comm_cfg` does not warn
-- [ ] Update this doc's `Status:` to `implemented` once landed
+- [x] Decide raise vs. warn (superseded 2026-08-17 — see Decision: fix the `comm_cfg` leak at its
+      source instead of allowlisting it in `Object.__init__`)
+- [x] Fix the `comm_cfg` anchor-holder leak at its source in `pre_process_yaml`
+      (`pyobs/utils/config.py`): whole-file includes (no key selector) now drop any key
+      `reload_anchors()` identifies as an anchor holder for that file before splicing, and an
+      empty resulting splice is dropped entirely rather than emitting `"{}\n"`. Regression tests
+      added in `tests/utils/test_config.py`; verified against a real `pyobs-monet` config.
+- [ ] `environment`/`database` (monet central configs) still unresolved — see the 2026-08-17
+      open-question note above; not fixed by the `comm_cfg` change and not safe to allowlist yet.
+- [ ] Decide and implement warn vs. raise for any remaining leftover kwargs at `Object.__init__`,
+      once the `environment`/`database` question is closed.
+- [ ] Update this doc's `Status:` to fully `implemented, closed` once the above lands.

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -211,3 +211,44 @@ def test_pre_process_yaml_whole_file_include_does_not_leak_anchor_holder_key(tmp
         "comm_cfg leaked into the top-level config dict from a whole-file include -- "
         "see specs/plans/2026-08-09-object-kwarg-validation.md"
     )
+
+
+def test_pre_process_yaml_keyed_empty_dict_include_is_not_dropped(tmp_path) -> None:
+    """A keyed include that legitimately selects an empty mapping must still emit `{}`.
+
+    Regression test for a bug found in PR review: the whole-file "drop the placeholder" special
+    case (for when anchor-holder trimming empties a splice, see the test above) must not fire for
+    keyed includes too -- a keyed include of a value that is simply `{}` in the source file is
+    real, deliberate content, not an anchor-trimming leftover, and must not silently become `null`.
+    """
+    included = tmp_path / "inc.yaml"
+    included.write_text("somekey: {}\n")
+
+    main = tmp_path / "config.yaml"
+    main.write_text("outer:\n  {include inc.yaml somekey}\n")
+
+    result = pre_process_yaml(str(main))
+    parsed = yaml.safe_load(result)
+    assert parsed["outer"] == {}
+
+
+def test_pre_process_yaml_whole_file_include_keeps_top_level_key_matching_nested_anchor_name(
+    tmp_path,
+) -> None:
+    """A top-level key must not be dropped just because a nested key elsewhere shares its name.
+
+    Regression test for a bug found in PR review: `reload_anchors()` matches `keyword: &anchor` at
+    any nesting depth, not just top-level. The anchor-holder drop in `pre_process_yaml` must only
+    remove keys that are themselves top-level anchor holders -- not any top-level key whose name
+    happens to collide with an unrelated nested anchor holder's key name.
+    """
+    included = tmp_path / "inc.yaml"
+    included.write_text("type: Foo\ncamera:\n  type: &cam\n    model: X\n")
+
+    main = tmp_path / "config.yaml"
+    main.write_text("{include inc.yaml}\n")
+
+    result = pre_process_yaml(str(main))
+    parsed = yaml.safe_load(result)
+    assert parsed["type"] == "Foo"
+    assert parsed["camera"]["type"]["model"] == "X"

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -190,19 +190,14 @@ def test_pre_process_yaml_keyed_include_of_anchor_holder_is_kept(tmp_path) -> No
     assert parsed["direct"]["class"] == "pyobs.comm.xmpp.XmppComm"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="comm_cfg leak, tracked in specs/plans/2026-08-09-object-kwarg-validation.md; "
-    "remove this marker once pre_process_yaml drops anchor-holder keys from whole-file splices",
-)
 def test_pre_process_yaml_whole_file_include_does_not_leak_anchor_holder_key(tmp_path) -> None:
     """A whole-file include must not leave the anchor-holder key as a top-level leftover.
 
-    This is the documented `comm_cfg` bug from `specs/plans/2026-08-09-object-kwarg-validation.md`:
-    `{include comm.shared.yaml}` (no key selector) currently splices the *entire* file, including
-    `comm_cfg` itself, even though its only purpose is to be aliased via `<<: *comm` elsewhere.
-    `comm_cfg` then survives as an unconsumed top-level key that reaches `Object.__init__`'s
-    `**kwargs` and is silently dropped there.
+    Regression test for the `comm_cfg` leak documented in
+    `specs/plans/2026-08-09-object-kwarg-validation.md`: `{include comm.shared.yaml}` (no key
+    selector) used to splice the *entire* file, including `comm_cfg` itself, even though its only
+    purpose is to be aliased via `<<: *comm` elsewhere. `comm_cfg` then survived as an unconsumed
+    top-level key that reached `Object.__init__`'s `**kwargs` and was silently dropped there.
     """
     shared = tmp_path / "comm.shared.yaml"
     shared.write_text("comm_cfg: &comm\n  class: pyobs.comm.xmpp.XmppComm\n  domain: example.com\n")


### PR DESCRIPTION
## Summary
- `pre_process_yaml`'s whole-file `{include file}` spliced the entire included file in, including keys whose sole purpose is holding a YAML anchor for `<<: *anchor` use elsewhere -- e.g. `comm.shared.yaml`'s `comm_cfg: &comm`, used across every monti/monet/iagvt/polaris config. That leaked `comm_cfg` reached `Object.__init__`'s `**kwargs` and was silently dropped, indistinguishable from a real config typo.
- Whole-file includes now drop any key `reload_anchors()` identifies as an anchor holder for that file before splicing; keyed includes of the same key (`{include file key}`) are untouched.
- Handles the resulting edge case where the entire include is anchor-only keys (`comm.shared.yaml`'s only top-level key), by dropping the splice placeholder instead of emitting an empty `{}` mapping, which broke YAML parsing when followed by block-style content.
- Verified against a real `pyobs-monet` config (`config/central/imagedb.yaml`): `comm_cfg` no longer leaks, `comm: <<: *comm` still resolves correctly.

Implements the `comm_cfg` portion of `specs/plans/2026-08-09-object-kwarg-validation.md`. The `environment`/`database` wrapper-key question and `Object.__init__`'s warn/raise enforcement are intentionally left open -- see that plan's Decision section for why.

## Test plan
- [x] `tests/utils/test_config.py`: 3 new tests -- alias resolution (previously uncovered), keyed-include-of-anchor-holder is kept, whole-file-include no longer leaks the anchor holder
- [x] Full suite: `pytest -m "not integration and not xmpp"` -- 1488 passed, 25 skipped, 0 failed
- [x] `ruff check` / `black --check` / `pyrefly check` clean on changed files
- [x] Manual check against `pyobs-monet/config/central/imagedb.yaml`