### PR TITLE
Make pyobs-core's mixin composition cooperative (step 1/10, cooperative-mixin-init plan)

### DIFF
--- a/pyobs/mixins/camerasettings.py
+++ b/pyobs/mixins/camerasettings.py
@@ -35,6 +35,8 @@ class CameraSettingsMixin:
         self.__camerasettings_filter = filter_name
         self.__camerasettings_binning = binning
 
+        super().__init__(**kwargs)
+
     async def _do_camera_settings(self, camera: Module | IData | IFilters | IBinning | IWindow) -> None:
         """Do camera settings for given camera."""
 

--- a/pyobs/mixins/fitsheader.py
+++ b/pyobs/mixins/fitsheader.py
@@ -46,8 +46,6 @@ class FitsHeaderMixin:
                 them. A peer that never answers (e.g. a laptop put to sleep without closing its
                 client) would otherwise stall the frame for the full XMPP IQ timeout.
         """
-        module = cast(Module, self)
-
         # store
         self._fitsheadermixin_fits_namespaces = fits_namespaces
         self._fitsheadermixin_filename_pattern = filenames
@@ -58,9 +56,18 @@ class FitsHeaderMixin:
         self._fitsheadermixin_night_obs = night_obs
 
         # night exposure number
-        self._fitsheadermixin_cache = f"/pyobs/modules/{module.name}/cache.yaml"
         self._fitsheadermixin_enable_frame_number = frame_number
         self._fitsheadermixin_frame_number = 0
+
+        super().__init__(**kwargs)
+
+    @property
+    def _fitsheadermixin_cache(self) -> str:
+        # computed lazily (not cached at __init__ time) since it depends on module.name, which in
+        # turn depends on comm having been set up by Object.__init__ -- in a cooperative super()
+        # chain, this mixin's __init__ can run before Module has finished its own setup
+        module = cast(Module, self)
+        return f"/pyobs/modules/{module.name}/cache.yaml"
 
     async def request_fits_headers(self, before: bool = True) -> dict[str, Task[Any]]:
         """Request FITS headers from other modules.
@@ -309,7 +316,7 @@ class ImageFitsHeaderMixin(FitsHeaderMixin):
             rotation: Rotation east of north.
             filename: Filename pattern for FITS images.
         """
-        FitsHeaderMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         # store
         self._fitsheadermixin_centre = centre

--- a/pyobs/mixins/fitsnamespace.py
+++ b/pyobs/mixins/fitsnamespace.py
@@ -15,6 +15,7 @@ class FitsNamespaceMixin:
 
     def __init__(self, fits_namespaces: dict[str, list[str]] | None = None, **kwargs: Any):
         self.__namespaces = {} if fits_namespaces is None else fits_namespaces
+        super().__init__(**kwargs)
 
     def _filter_fits_namespace(
         self, hdr: dict[str, FitsHeaderEntry], sender: str, namespaces: list[str] | None = None, **kwargs: Any

--- a/pyobs/mixins/follow.py
+++ b/pyobs/mixins/follow.py
@@ -125,6 +125,8 @@ class FollowMixin:
         if not isinstance(self, self.__follow_mode):
             raise ValueError(f"This module is not of given mode {mode}.")
 
+        super().__init__(*args, **kwargs)
+
     @property
     def is_following(self) -> bool:
         """Returns True, if we're following another device."""

--- a/pyobs/mixins/motionstatus.py
+++ b/pyobs/mixins/motionstatus.py
@@ -26,6 +26,8 @@ class MotionStatusMixin:
         self.__motion_status = MotionStatus.UNKNOWN
         self.__motion_status_single = {i: MotionStatus.UNKNOWN for i in self.__motion_status_interfaces}
 
+        super().__init__(**kwargs)
+
     async def open(self) -> None:
         # subscribe to events
         if isinstance(self, Module) and self._comm:

--- a/pyobs/mixins/pipeline.py
+++ b/pyobs/mixins/pipeline.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any
 
 from pyobs.images import Image, ImageProcessor
-from pyobs.object import Object
+from pyobs.object import Object, get_class_from_string
 from pyobs.utils.exceptions import ImageError
 
 if TYPE_CHECKING:
@@ -31,9 +32,10 @@ class PipelineMixin:
             archive: Default archive config/object for steps that accept one (e.g.
                 Calibration) and don't already specify their own -- lets a pipeline's
                 steps share the archive it was itself given, instead of repeating the
-                same archive config in every step that needs one. Steps that don't
-                declare an archive parameter just absorb and drop it via their own
-                **kwargs, the same as any other unrecognized Object kwarg.
+                same archive config in every step that needs one. Only injected into a
+                step's config if that step's class actually declares an `archive`
+                parameter (checked via signature inspection); steps that don't declare
+                one never receive it, rather than receiving-then-silently-dropping it.
         """
 
         # store
@@ -46,11 +48,38 @@ class PipelineMixin:
         else:
             raise ValueError("This class is no Object.")
 
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _accepts_archive(class_name: str) -> bool:
+        """Whether the given class declares an `archive` parameter anywhere in its `__init__` MRO."""
+        try:
+            klass = get_class_from_string(class_name)
+        except Exception:
+            return False
+        for cls in klass.__mro__:
+            init = cls.__dict__.get("__init__")
+            if init is None:
+                continue
+            try:
+                sig = inspect.signature(init)
+            except (TypeError, ValueError):
+                continue
+            if "archive" in sig.parameters:
+                return True
+        return False
+
     @staticmethod
     def _with_default_archive(
         step: dict[str, Any] | ImageProcessor, archive: dict[str, Any] | Archive | None
     ) -> dict[str, Any] | ImageProcessor:
-        if archive is not None and isinstance(step, dict) and "archive" not in step:
+        if (
+            archive is not None
+            and isinstance(step, dict)
+            and "archive" not in step
+            and "class" in step
+            and PipelineMixin._accepts_archive(step["class"])
+        ):
             return {**step, "archive": archive}
         return step
 

--- a/pyobs/mixins/waitformotion.py
+++ b/pyobs/mixins/waitformotion.py
@@ -42,6 +42,8 @@ class WaitForMotionMixin:
         )
         self.__wait_for_timeout = wait_for_timeout
 
+        super().__init__(**kwargs)
+
     async def _wait_for_motion(self, abort: Event) -> None:
         """Wait until all devices are in one of the given motion states.
 

--- a/pyobs/mixins/weatheraware.py
+++ b/pyobs/mixins/weatheraware.py
@@ -33,6 +33,8 @@ class WeatherAwareMixin:
         else:
             raise ValueError("This is not a module.")
 
+        super().__init__(**kwargs)
+
     async def open(self) -> None:
         """Open mixin."""
         # subscribe to events

--- a/pyobs/modules/camera/basecamera.py
+++ b/pyobs/modules/camera/basecamera.py
@@ -76,15 +76,14 @@ class BaseCamera(
             fits_namespaces: List of namespaces for FITS headers that this camera should request
             fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping them.
         """
-        Module.__init__(self, **kwargs)
-        ImageFitsHeaderMixin.__init__(
-            self,
+        super().__init__(
             fits_namespaces=fits_namespaces,
             fits_headers=fits_headers,
             centre=centre,
             rotation=rotation,
             filenames=filenames,
             fits_header_timeout=fits_header_timeout,
+            **kwargs,
         )
 
         # check

--- a/pyobs/modules/camera/basespectrograph.py
+++ b/pyobs/modules/camera/basespectrograph.py
@@ -44,10 +44,7 @@ class BaseSpectrograph(Module, SpectrumFitsHeaderMixin, ISpectrograph, IExposure
             filenames: Template for file naming.
             fits_namespaces: List of namespaces for FITS headers that this camera should request
         """
-        Module.__init__(self, **kwargs)
-        SpectrumFitsHeaderMixin.__init__(
-            self, fits_namespaces=fits_namespaces, fits_headers=fits_headers, filenames=filenames, **kwargs
-        )
+        super().__init__(fits_namespaces=fits_namespaces, fits_headers=fits_headers, filenames=filenames, **kwargs)
 
         # init camera
         self._exposure: ExposureInfo | None = None

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -113,15 +113,14 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             sleep_time: Time in s with inactivity after which the camera should go to sleep.
             fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping them.
         """
-        Module.__init__(self, **kwargs)
-        ImageFitsHeaderMixin.__init__(
-            self,
+        super().__init__(
             fits_namespaces=fits_namespaces,
             fits_headers=fits_headers,
             centre=centre,
             rotation=rotation,
             filenames=filenames,
             fits_header_timeout=fits_header_timeout,
+            **kwargs,
         )
 
         # store

--- a/pyobs/modules/camera/pipelinecamera.py
+++ b/pyobs/modules/camera/pipelinecamera.py
@@ -20,9 +20,7 @@ class PipelineCamera(Module, ICamera, ImageFitsHeaderMixin, PipelineMixin):
 
     def __init__(self, **kwargs: Any):
         """Creates a new pipeline cammera."""
-        Module.__init__(self, **kwargs)
-        PipelineMixin.__init__(self, **kwargs)
-        ImageFitsHeaderMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     async def grab_data(self, broadcast: bool = True, **kwargs: Any) -> str:
         """Grabs an image and returns reference.

--- a/pyobs/modules/focus/focusseries.py
+++ b/pyobs/modules/focus/focusseries.py
@@ -58,7 +58,7 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
             broadcast: Whether to broadcast focus series images.
             final_image: Whether to take final image with optimal focus, which is always broadcasted.
         """
-        Module.__init__(self, **kwargs)
+        super().__init__(filters=filters, filter_name=filter_name, binning=binning, **kwargs)
 
         # store focuser and camera
         self._focuser = focuser
@@ -73,9 +73,6 @@ class AutoFocusSeries(Module, CameraSettingsMixin, IAutoFocus):
 
         # create focus series
         self._series: FocusSeries = get_object(series, FocusSeries)
-
-        # init camera settings mixin
-        CameraSettingsMixin.__init__(self, filters=filters, filter_name=filter_name, binning=binning, **kwargs)
 
         # register exceptions
         if isinstance(camera, str):

--- a/pyobs/modules/image/pipeline.py
+++ b/pyobs/modules/image/pipeline.py
@@ -29,8 +29,7 @@ class Pipeline(Module, PipelineMixin):
             sources: List of sources to process images from.
             interval: Interval in seconds for automatic run of pipeline.
         """
-        Module.__init__(self, **kwargs)
-        PipelineMixin.__init__(self, pipeline)
+        super().__init__(steps=pipeline, **kwargs)
 
         # only allow one option!
         if (sources is not None and interval is not None) or (sources is None and interval is None):

--- a/pyobs/modules/pointing/_base.py
+++ b/pyobs/modules/pointing/_base.py
@@ -34,11 +34,8 @@ class BasePointing(Module, PipelineMixin, metaclass=ABCMeta):
             telescope: Telescope to use.
             pipeline: Pipeline steps to run on new image. MUST include a step calculating offsets!
             apply: Object that handles applying offsets to telescope.
-            log_file: Name of file to write log to.
-            log_absolute: Log absolute offsets instead of relative ones to last one.
         """
-        Module.__init__(self, **kwargs)
-        PipelineMixin.__init__(self, pipeline)
+        super().__init__(steps=pipeline, **kwargs)
 
         # store
         self._camera = camera

--- a/pyobs/modules/pointing/acquisition.py
+++ b/pyobs/modules/pointing/acquisition.py
@@ -75,7 +75,7 @@ class Acquisition(BasePointing, CameraSettingsMixin, IAcquisition):
                      successful or not.
             broadcast: Whether to broadcast acquisition images.
         """
-        BasePointing.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         # store
         self._default_exposure_time = exposure_time
@@ -91,9 +91,6 @@ class Acquisition(BasePointing, CameraSettingsMixin, IAcquisition):
 
         # init log file
         self._publisher = CsvPublisher(log_file) if log_file is not None else None
-
-        # init camera settings mixin
-        CameraSettingsMixin.__init__(self, **kwargs)
 
     async def open(self) -> None:
         """Open module"""

--- a/pyobs/modules/pointing/autoguiding.py
+++ b/pyobs/modules/pointing/autoguiding.py
@@ -27,16 +27,13 @@ class AutoGuiding(BaseGuiding, CameraSettingsMixin):
             exposure_time: Initial exposure time in seconds.
             broadcast: Whether to broadcast new images.
         """
-        BaseGuiding.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         # store
         self._default_exposure_time = exposure_time
         self._exposure_time: float | None = None
         self._broadcast = broadcast
         self._source_detection = SepSourceDetection()
-
-        # init camera settings mixin
-        CameraSettingsMixin.__init__(self, **kwargs)
 
         # add thread func
         self.add_background_task(self._auto_guiding)

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -34,19 +34,25 @@ from pyobs.utils.time import Time
 log = logging.getLogger(__name__)
 
 
-def _scheduler_accepts_observation_archive(scheduler: dict[str, Any] | TaskScheduler) -> bool:
-    """Whether the configured scheduler class declares an `observation_archive` parameter.
+def _class_accepts_param(config: dict[str, Any] | Any, param_name: str) -> bool:
+    """Whether the class configured in `config` (a dict with a "class" key, or an already-built
+    object) declares `param_name` somewhere in its __init__ MRO.
 
-    Only `OnDemandScheduler` uses it; other TaskScheduler implementations (e.g.
-    AstroplanScheduler) don't declare it at all, so it must not be injected unconditionally --
-    that was silently absorbed by Object.__init__'s **kwargs before, with no effect.
+    Used to decide whether a kwarg can be injected into a child object's config -- injecting
+    unconditionally relies on the target silently absorbing it if unwanted, which no longer
+    happens now that Object.__init__ forwards leftover kwargs on to object.__init__().
     """
-    if not isinstance(scheduler, dict) or "class" not in scheduler:
-        return False
-    try:
-        klass = get_class_from_string(scheduler["class"])
-    except Exception:
-        return False
+    if isinstance(config, dict):
+        if "class" not in config:
+            return False
+        try:
+            klass = get_class_from_string(config["class"])
+        except Exception:
+            return False
+    elif isinstance(config, type):
+        klass = config
+    else:
+        klass = type(config)
     for cls in klass.__mro__:
         init = cls.__dict__.get("__init__")
         if init is None:
@@ -55,7 +61,7 @@ def _scheduler_accepts_observation_archive(scheduler: dict[str, Any] | TaskSched
             sig = inspect.signature(init)
         except (TypeError, ValueError):
             continue
-        if "observation_archive" in sig.parameters:
+        if param_name in sig.parameters:
             return True
     return False
 
@@ -96,11 +102,16 @@ class Scheduler(Module, IStartStop, IRunnable):
 
         # get scheduler
         self._task_archive = self.add_child_object(tasks, TaskArchive, on_tasks_changed=self._update_schedule)
-        # auto_update was never declared by ObservationArchive/LcoObservationArchive -- silently
-        # dropped, no effect, for this class's entire history
-        self._schedule = self.add_child_object(schedule, ObservationArchive)
+        # BackendObservationArchive declares auto_update and gates its own polling loop on it --
+        # since we already drive updates via on_tasks_changed above, that poller must stay off.
+        # Other ObservationArchive implementations (e.g. LcoObservationArchive) don't declare it at
+        # all, so it must not be injected unconditionally.
+        extra_schedule_kwargs: dict[str, Any] = {}
+        if _class_accepts_param(schedule, "auto_update"):
+            extra_schedule_kwargs["auto_update"] = False
+        self._schedule = self.add_child_object(schedule, ObservationArchive, **extra_schedule_kwargs)
         extra_scheduler_kwargs: dict[str, Any] = {}
-        if _scheduler_accepts_observation_archive(scheduler):
+        if _class_accepts_param(scheduler, "observation_archive"):
             extra_scheduler_kwargs["observation_archive"] = self._schedule
         self._scheduler = self.add_child_object(scheduler, TaskScheduler, **extra_scheduler_kwargs)
 

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import time
@@ -19,6 +20,7 @@ from pyobs.events import (
 from pyobs.interfaces import IRunnable, IRunning, IStartStop
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
+from pyobs.object import get_class_from_string
 from pyobs.robotic import (
     ObservationArchive,
     ObservationList,
@@ -30,6 +32,32 @@ from pyobs.robotic.scheduler import TaskScheduler
 from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
+
+
+def _scheduler_accepts_observation_archive(scheduler: dict[str, Any] | TaskScheduler) -> bool:
+    """Whether the configured scheduler class declares an `observation_archive` parameter.
+
+    Only `OnDemandScheduler` uses it; other TaskScheduler implementations (e.g.
+    AstroplanScheduler) don't declare it at all, so it must not be injected unconditionally --
+    that was silently absorbed by Object.__init__'s **kwargs before, with no effect.
+    """
+    if not isinstance(scheduler, dict) or "class" not in scheduler:
+        return False
+    try:
+        klass = get_class_from_string(scheduler["class"])
+    except Exception:
+        return False
+    for cls in klass.__mro__:
+        init = cls.__dict__.get("__init__")
+        if init is None:
+            continue
+        try:
+            sig = inspect.signature(init)
+        except (TypeError, ValueError):
+            continue
+        if "observation_archive" in sig.parameters:
+            return True
+    return False
 
 
 class Scheduler(Module, IStartStop, IRunnable):
@@ -68,8 +96,13 @@ class Scheduler(Module, IStartStop, IRunnable):
 
         # get scheduler
         self._task_archive = self.add_child_object(tasks, TaskArchive, on_tasks_changed=self._update_schedule)
-        self._schedule = self.add_child_object(schedule, ObservationArchive, auto_update=False)
-        self._scheduler = self.add_child_object(scheduler, TaskScheduler, observation_archive=self._schedule)
+        # auto_update was never declared by ObservationArchive/LcoObservationArchive -- silently
+        # dropped, no effect, for this class's entire history
+        self._schedule = self.add_child_object(schedule, ObservationArchive)
+        extra_scheduler_kwargs: dict[str, Any] = {}
+        if _scheduler_accepts_observation_archive(scheduler):
+            extra_scheduler_kwargs["observation_archive"] = self._schedule
+        self._scheduler = self.add_child_object(scheduler, TaskScheduler, **extra_scheduler_kwargs)
 
         # store
         self._running = True

--- a/pyobs/modules/roof/baseroof.py
+++ b/pyobs/modules/roof/baseroof.py
@@ -12,17 +12,14 @@ from pyobs.utils.enums import MotionStatus
 log = logging.getLogger(__name__)
 
 
-class BaseRoof(WeatherAwareMixin, MotionStatusMixin, IRoof, IFitsHeaderBefore, Module, metaclass=ABCMeta):
+class BaseRoof(Module, WeatherAwareMixin, MotionStatusMixin, IRoof, IFitsHeaderBefore, metaclass=ABCMeta):
     """Base class for roofs."""
 
     __module__ = "pyobs.modules.roof"
 
     def __init__(self, **kwargs: Any):
         """Initialize a new base roof."""
-        Module.__init__(self, **kwargs)
-
-        WeatherAwareMixin.__init__(self, **kwargs)
-        MotionStatusMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     async def open(self) -> None:
         """Open module."""

--- a/pyobs/modules/telescope/_dummytelescopebase.py
+++ b/pyobs/modules/telescope/_dummytelescopebase.py
@@ -94,8 +94,7 @@ class _DummyTelescopeBase(
             focal_length: Focal length in mm.
             wait_secs: Wait time between slew checks in seconds.
         """
-        BaseTelescope.__init__(self, **kwargs, motion_status_interfaces=["ITelescope", "IFocuser", "IFilters"])
-        FitsNamespaceMixin.__init__(self, **kwargs)
+        super().__init__(motion_status_interfaces=["ITelescope", "IFocuser", "IFilters"], **kwargs)
 
         # telescope state
         self._position = (

--- a/pyobs/modules/telescope/basetelescope.py
+++ b/pyobs/modules/telescope/basetelescope.py
@@ -221,7 +221,7 @@ def _ra_rate_on_sky(ra1_deg: float, ra2_deg: float, dec_deg: float, dt_seconds: 
 
 
 class BaseTelescope(
-    WeatherAwareMixin, MotionStatusMixin, WaitForMotionMixin, ITelescope, IFitsHeaderBefore, Module, metaclass=ABCMeta
+    Module, WeatherAwareMixin, MotionStatusMixin, WaitForMotionMixin, ITelescope, IFitsHeaderBefore, metaclass=ABCMeta
 ):
     """Base class for telescopes."""
 
@@ -241,7 +241,16 @@ class BaseTelescope(
             min_altitude: Minimal altitude for telescope.
             wait_for_dome: Name of dome module to wait for.
         """
-        Module.__init__(self, **kwargs)
+        # wait_for_dome is BaseTelescope's own param, but WaitForMotionMixin (further down the
+        # cooperative chain) needs it translated into its own wait_for_modules/wait_for_timeout/
+        # wait_for_states shape -- computed here and threaded through the single super() call,
+        # since WaitForMotionMixin has no way to see wait_for_dome itself.
+        super().__init__(
+            wait_for_modules=None if wait_for_dome is None else [wait_for_dome],
+            wait_for_timeout=60000,
+            wait_for_states=[MotionStatus.POSITIONED, MotionStatus.TRACKING],
+            **kwargs,
+        )
 
         # store
         self._fits_headers = fits_headers if fits_headers is not None else {}
@@ -264,16 +273,6 @@ class BaseTelescope(
         # add thread func
         self.add_background_task(self._celestial, True)
         self.add_background_task(self._track_refresh, True)
-
-        # init mixins
-        WeatherAwareMixin.__init__(self, **kwargs)
-        MotionStatusMixin.__init__(self, **kwargs)
-        WaitForMotionMixin.__init__(
-            self,
-            wait_for_modules=None if wait_for_dome is None else [wait_for_dome],
-            wait_for_timeout=60000,
-            wait_for_states=[MotionStatus.POSITIONED, MotionStatus.TRACKING],
-        )
 
         # register exception
         self._register_exception(exc.MotionError, 3, timespan=600, callback=self._default_remote_error_callback)

--- a/pyobs/modules/utils/dummymode.py
+++ b/pyobs/modules/utils/dummymode.py
@@ -14,15 +14,14 @@ from pyobs.utils.enums import MotionStatus
 log = logging.getLogger(__name__)
 
 
-class DummyMode(MotionStatusMixin, Module, IMode, IMotion):
+class DummyMode(Module, MotionStatusMixin, IMode, IMotion):
     """A dummy module for mode switching."""
 
     __module__ = "pyobs.modules.utils"
 
     def __init__(self, **kwargs: Any):
         """Initialize a new dummy module."""
-        Module.__init__(self, **kwargs)
-        MotionStatusMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         # modes
         self._mode_options = {

--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -355,6 +355,11 @@ class Object(PrivateAttrMixin):
         # background tasks
         self._background_tasks: list[tuple[BackgroundTask, bool]] = []
 
+        # forward anything left to the next class in the MRO -- lets mixins listed after this
+        # one in a subclass's bases (e.g. WeatherAwareMixin, PipelineMixin) claim their own
+        # kwargs cooperatively, instead of Object silently absorbing them
+        super().__init__(**kwargs)
+
     def add_background_task(
         self, func: Callable[..., Coroutine[Any, Any, None]], restart: bool = True, autostart: bool = True
     ) -> BackgroundTask:

--- a/pyobs/utils/pipeline/pipeline.py
+++ b/pyobs/utils/pipeline/pipeline.py
@@ -36,8 +36,7 @@ class Pipeline(Object, PipelineMixin):
                 Calibration) and don't already specify their own. See
                 PipelineMixin.__init__.
         """
-        Object.__init__(self, **kwargs)
-        PipelineMixin.__init__(self, steps, archive=archive)
+        super().__init__(steps=steps, archive=archive, **kwargs)
 
     @staticmethod
     def _combine_calib_images(

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -115,6 +115,71 @@ knowledge)
 10. **`pyobs-brot`** (1) — highest stakes: telescope/dome/roof control at multiple active sites
     (`monet` north+south, `iag50`) — last, most critical, most to lose if something's missed.
 
+## Critical finding (2026-08-18): PR #776's blast radius isn't scoped by rollout order
+
+The "safest repo first" ordering above assumes each repo's own risk is independent — that
+converting `pyobs-monet` before `pyobs-fli` only matters for `pyobs-monet`'s *own* classes. That's
+wrong. The moment `Object`/`Module`/`BaseCamera` in `pyobs-core` became cooperative (PR #776), any
+**unconverted** fan-out class *anywhere downstream* that threads a foreign (sibling-only) kwarg
+through the same `**kwargs` dict to one of those now-cooperative bases breaks — regardless of
+whether that repo's own conversion PR has landed yet. Order of the fan-out's own explicit calls
+doesn't matter either: every sibling call receives the *same* unfiltered dict, so whichever one
+reaches `Module`/`Object` first carries the foreign key all the way to `object.__init__()`, which
+raises. Confirmed with a minimal repro (`BaseCamera.__init__(self, **kwargs)` called before a
+`FliBaseMixin`-shaped stub that owns a `port` kwarg → `TypeError: object.__init__() takes exactly
+one argument`).
+
+Re-ran the original AST fan-out scan fresh (found the same 14 non-core classes as before, across
+`pyobs-alpaca`(3)/`pyobs-brot`(1)/`pyobs-fli`(2)/`pyobs-gemini`(1)/`pyobs-monet`(2)/`pyobs-monti`(1)/
+`pyobs-sbig`(1)/`pyobs-zwoeaf`(1)/`pyobs-iagvt`(2)) and cross-referenced every one against real
+configs in `pyobs-monet`, `pyobs-iagvt`, `pyobs-iag50`, `pyobs-polaris`. **8 of 14 are live** today:
+`FliFilterWheel`, `FliCamera`, `GeminiFocuserRotator`, `SbigFilterCamera`, `EAFFocuser`, `LDP`, `LED`
+(`FrontendCameraSouth` remains commented-out/dead, confirmed again). Of those 8, checking each
+live config's actual keys against which sibling declares them found **two that will concretely
+crash on the next `pyobs-core` bump, not just carry latent risk**:
+
+- `pyobs_fli.FliFilterWheel` at `pyobs-monet/config/{north/fli,south/frontend}/filterwheel.yaml` —
+  both set `dev_path`, a `FliBaseMixin`-only kwarg; `Module.__init__` (called first) leaks it to
+  `object.__init__()` before `FliBaseMixin.__init__` (called second) ever sees it.
+- `pyobs_gemini.GeminiFocuserRotator` at `pyobs-monet/config/south/piggyback/gemini.yaml` — sets
+  `fits_namespaces`, a `FitsNamespaceMixin`-only kwarg; same shape, `Module.__init__` at line 53 runs
+  long before `FitsNamespaceMixin.__init__` at line 114.
+
+The other 6 live classes' *current* configs happen not to set any sibling-only kwarg, so they
+won't break today, but carry the identical latent risk on the next config change.
+
+**Action taken:** pulled `pyobs-fli` and `pyobs-gemini` forward, ahead of their step 9/5 slots —
+see their sections below. Holding off on merging PR #776 until this is resolved was considered but
+not required, since `pyobs-core`'s `develop` doesn't auto-propagate to fleet installs; the real
+gate is "don't bump a live repo's `pyobs-core` pin past PR #776 until that repo's own fan-out
+classes are converted," which now applies to `pyobs-fli`/`pyobs-gemini` (done) and still applies to
+`pyobs-alpaca`/`pyobs-brot`/`pyobs-monti`/`pyobs-sbig`/`pyobs-zwoeaf`/`pyobs-iagvt` (not done yet;
+none of their *current* configs concretely break, but don't treat that as a guarantee — re-check
+before any of those repos' `pyobs-core` pin gets bumped past #776).
+
+## Step 2 (`pyobs-fli`) — implemented
+
+Reordered bases in `FliCamera` (`BaseCamera` first, was `FliBaseMixin` first) and `FliFilterWheel`
+(`Module` first, was `FliBaseMixin` first) — both need `Object`/`Module` to run before
+`FliBaseMixin.__init__`'s `self.add_background_task(...)` call. Added
+`super().__init__(**kwargs)` to the end of `FliBaseMixin.__init__` (it never forwarded before).
+Collapsed both classes' fan-out to a single `super().__init__(dev_type=..., **kwargs)` call
+(`FliFilterWheel` also threads `motion_status_interfaces=["IFilters"]`, a derived value like
+`BaseTelescope`'s `WaitForMotionMixin` case). Verified: 20/20 tests pass, ruff/black/pyrefly clean,
+and both previously-crashing live configs (`filterwheel.yaml` x2) plus `morisot.yaml` (`FliCamera`)
+and `pyobs-monet`'s `FliBonnShutter` (subclass of `FliCamera`, live at `fli230.yaml`) all construct
+correctly against the fixed `pyobs-core` branch.
+
+## Step 3 (`pyobs-gemini`) — implemented
+
+Reordered `GeminiFocuserRotator`'s bases to put `Module` first (was `FitsNamespaceMixin` first).
+Moved the single `super().__init__(*args, motion_status_interfaces=["IFocuser", "IRotation"],
+**kwargs)` call to the top of `__init__`, ahead of this class's own attribute setup (matches the
+`BaseTelescope` precedent from step 1) — removed the two now-redundant trailing
+`FitsNamespaceMixin.__init__`/`MotionStatusMixin.__init__` calls. Verified: 17/17 tests pass,
+ruff/black/pyrefly clean, and the live `gemini.yaml` config constructs correctly with
+`fits_namespaces` and `motion_status_interfaces` both landing on the right attributes.
+
 ## Non-goals
 
 - Not converting every explicit `ClassName.__init__(self, **kwargs)` call in these codebases — a
@@ -175,14 +240,19 @@ construction check against real configs where fleet configs exist to check again
 - [x] `pyobs-core`: convert the 14 production fan-out classes + 5 tests to cooperative `super()`
       chains; full test suite green (`pytest -m "not integration and not xmpp" --extra full`).
       PR #776 (open, not yet merged).
-- [ ] `pyobs-monet` (2 classes)
+- [x] `pyobs-fli` (2 classes) — pulled forward, live-breaking (see critical finding above); tests +
+      lint + real-config checks green, not yet committed/pushed/PR'd.
+- [x] `pyobs-gemini` (1 class) — pulled forward, live-breaking (see critical finding above); tests +
+      lint + real-config checks green, not yet committed/pushed/PR'd.
+- [ ] `pyobs-monet` (2 classes) — dead code (`FrontendCameraSouth`/`FrontendSouth` unreferenced),
+      zero urgency, not yet started.
 - [ ] `pyobs-monti` (1 class)
 - [ ] `pyobs-alpaca` (3 classes)
-- [ ] `pyobs-gemini` (1 class)
 - [ ] `pyobs-zwoeaf` (1 class)
-- [ ] `pyobs-iagvt` (2 classes)
-- [ ] `pyobs-sbig` (1 class)
-- [ ] `pyobs-fli` (2 classes)
+- [ ] `pyobs-iagvt` (2 classes) — `LDP`/`LED` are live but current configs don't trigger the bug;
+      re-check before this repo's `pyobs-core` pin moves past #776.
+- [ ] `pyobs-sbig` (1 class) — `SbigFilterCamera` is live but current configs don't trigger the bug;
+      re-check before this repo's `pyobs-core` pin moves past #776.
 - [ ] `pyobs-brot` (1 class)
 - [ ] Implement `if kwargs: raise TypeError(...)` in `Object.__init__` (`pyobs-core`), now that
       every consuming class threads kwargs cooperatively.

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -391,33 +391,55 @@ construction check against real configs where fleet configs exist to check again
       PR #776 (open, reviewed — one real regression found and fixed, see review thread — not yet
       merged; merging this is what unblocks pyobs-fli #84 and pyobs-gemini #19 below).
 - [ ] `pyobs-fli` (2 classes) — pulled forward, live-breaking (see critical finding above); PR #84
-      open, reviewed, regression test added and independently re-verified by reviewer. Blocked on
-      pyobs-core #776 merging + bumping this repo's `pyobs-core` pin to a release containing it.
+      — reviewed and **approved**, regression test added and independently re-verified by
+      reviewer. Blocked on pyobs-core #776 merging + bumping this repo's `pyobs-core` pin to a
+      release containing it.
 - [ ] `pyobs-gemini` (1 class) — pulled forward, live-breaking (see critical finding above); PR #19
-      open, reviewed, regression test added. Same block as pyobs-fli: needs #776 merged + this
-      repo's `pyobs-core` pin bumped.
+      — reviewed and **approved**, regression test added. Same block as pyobs-fli: needs #776
+      merged + this repo's `pyobs-core` pin bumped.
 - [ ] `pyobs-monet` (2 classes) — dead code (`FrontendCameraSouth`/`FrontendSouth` unreferenced),
-      zero urgency; MR !54 (GitLab) open and reviewed — correct, blocked on pyobs-core #776 +
-      pyobs-fli #84 merging first (this class chain depends on `FliBonnShutter`/`FliCamera`).
+      zero urgency; MR !54 (GitLab) — reviewed and **approved** — correct, blocked on pyobs-core
+      #776 + pyobs-fli #84 merging first (this class chain depends on `FliBonnShutter`/`FliCamera`).
 - [ ] `pyobs-monti` (1 class) — live (`config/telescope.yaml`); fixed, regression test added, MR !1
-      (GitLab, `gitlab.gwdg.de/monet/pyobs-monti`) open and reviewed — approved, blocked purely on
+      (GitLab, `gitlab.gwdg.de/monet/pyobs-monti`) — reviewed and **approved**, blocked purely on
       pyobs-core #776 merging first (same as pyobs-fli/pyobs-gemini). `_set_tracking_rate`
       abstract-method gap and stale `pyobs-core==1.32.1` pin are pre-existing, out of scope here.
 - [ ] `pyobs-alpaca` (3 classes) — `AlpacaDome`/`AlpacaFocuser`/`AlpacaTelescope` fixed, plus a
-      related child-object kwarg-leak bug (see Step 6); regression test added. PR #34, open,
-      blocked on pyobs-core #776 merging first.
-- [ ] `pyobs-zwoeaf` (1 class) — `EAFFocuser` fixed; currently harmless (no crash reproduced) but
-      converted for consistency, see Step 7. PR #21, open, blocked on pyobs-core #776.
+      related child-object kwarg-leak bug (see Step 6); regression test added, plus a follow-up
+      test locking `DEVICE_INIT_KWARGS`/`OBJECT_SHARED_KWARGS` against the real constructor
+      signatures. PR #34 — reviewed and **approved**, blocked purely on pyobs-core #776 merging
+      first.
+- [ ] `pyobs-zwoeaf` (1 class) — `EAFFocuser` fixed; confirmed harmless even pre-fix (bases were
+      already correctly ordered, so the redundant second call was a genuine no-op, not a latent
+      crash — verified with the reviewer's suggested kwargs via `git stash`), converted for
+      consistency, see Step 7. PR #21 — reviewed and **approved**, blocked on pyobs-core #776.
 - [ ] `pyobs-iagvt` (2 classes) — `LDP`/`LED` fixed; live configs don't trigger the bug but a
-      sibling-mixin kwarg does (see Step 8), regression test added. MR !61
-      (`gitlab.gwdg.de/iagvt/pyobs-iagvt`), open, blocked on pyobs-core #776.
-- [ ] `pyobs-sbig` (1 class) — `SbigFilterCamera` fixed; not reproducibly crashing (see Step 9),
-      converted for consistency. PR #72, open, blocked on pyobs-core #776.
+      sibling-mixin kwarg does (see Step 8), regression test added (using `motion_status_interfaces:
+      ["IMotion"]`, matching what these classes actually implement). MR !61
+      (`gitlab.gwdg.de/iagvt/pyobs-iagvt`) — reviewed and **approved**, blocked on pyobs-core #776.
+- [ ] `pyobs-sbig` (1 class) — `SbigFilterCamera` fixed; not reproducibly crashing (see Step 9,
+      `motion_status_interfaces` is hardcoded at the call site so it collides rather than leaks),
+      converted for consistency; construction-locking test added. PR #72 — reviewed and
+      **approved**; base branch retargeted from `main` to `develop` mid-review since `main` didn't
+      yet have a prior unrelated PR (#71) merged, which was bundling unrelated diffs into this PR.
+      Blocked on pyobs-core #776.
 - [ ] `pyobs-brot` (1 class) — `BrotBaseTelescope` fixed; **live production crash**, confirmed via
-      the deployed telescope configs (see Step 10), regression test added. PR #56, open, blocked
-      on pyobs-core #776. Resolves this plan's earlier open question about `pyobs-brot`'s liveness.
+      the deployed telescope configs (see Step 10), regression test added. PR #56 — reviewed and
+      **approved**, blocked on pyobs-core #776. Resolves this plan's earlier open question about
+      `pyobs-brot`'s liveness. Reviewer flagged a separate, pre-existing bug in the same file
+      (`get_fits_header_before` missing the required `sender` arg, same issue as `pyobs-monti`) —
+      filed as [pyobs-brot#57](https://github.com/pyobs/pyobs-brot/issues/57), out of scope here.
+- [ ] **All nine downstream PRs/MRs above are reviewed and approved**, contingent on pyobs-core
+      #776 landing first — that's the sole remaining blocker for this whole rollout. Once #776
+      merges: merge `pyobs-fli`/`pyobs-gemini`/`pyobs-monti`/`pyobs-alpaca`/`pyobs-zwoeaf`/
+      `pyobs-iagvt`/`pyobs-sbig`/`pyobs-brot` (any order), then `pyobs-monet` (needs `pyobs-fli`
+      merged too), then bump each repo's `pyobs-core` pin to a release containing #776.
 - [ ] Implement `if kwargs: raise TypeError(...)` in `Object.__init__` (`pyobs-core`), now that
-      every consuming class threads kwargs cooperatively.
+      every consuming class threads kwargs cooperatively. Worth confirming this is still additive
+      work and not already covered: this session's testing repeatedly showed leftover kwargs
+      already reaching real `object.__init__()` and raising `TypeError` via `Object.__init__`'s
+      existing `super().__init__(**kwargs)` call (see PR #776's `object.py` change) — so this item
+      may now just be about a clearer, `pyobs`-specific error message rather than new enforcement.
 - [ ] Roll out / restart affected fleet modules; watch for anything this session's checks missed
       (the ~45-class import-failure bucket in `object-kwarg-validation.md` was never fully cleared
       — `pyobs_gui.GUI`, `pyobs-pilar`, `pyobs-dashboard-utils` remain genuinely unverified).

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -1,7 +1,8 @@
 # Plan: Make mixin `__init__` composition cooperative, then enforce unrecognized kwargs at `Object.__init__`
 
-Status: proposed (Repos: pyobs-core, pyobs-alpaca, pyobs-brot, pyobs-fli, pyobs-gemini, pyobs-iagvt,
-pyobs-monet, pyobs-monti, pyobs-sbig, pyobs-zwoeaf)
+Status: step 1/10 (`pyobs-core`) implemented, PR #776 open (not yet merged). (Repos: pyobs-core,
+pyobs-alpaca, pyobs-brot, pyobs-fli, pyobs-gemini, pyobs-iagvt, pyobs-monet, pyobs-monti, pyobs-sbig,
+pyobs-zwoeaf)
 
 Related: `specs/plans/2026-08-09-object-kwarg-validation.md` — where this was discovered. That
 plan's last open item ("implement warn/raise enforcement at `Object.__init__`") is superseded by
@@ -123,10 +124,57 @@ knowledge)
   `object-kwarg-validation.md`'s fleet cleanup pass (`pilar` is archived; `dashboard-utils` wasn't
   cloned/investigated).
 
+## Step 1 (`pyobs-core`) — implemented, PR #776
+
+Converted all 14 production classes + 3 test doubles (the other 2 flagged test files,
+`test_pipeline_archive.py`/`test_pipeline_on_error.py`, turned out already-passing despite the old
+pattern — not touched). Reordered bases in `BaseRoof`, `BaseTelescope`, `DummyMode` (`Module` first).
+
+**Two extra fixes needed beyond the mechanical conversion, found via actually running things, not
+just reading code:**
+
+- `FitsHeaderMixin`'s cache-path attribute was computed eagerly at `__init__` time from
+  `module.name` — but `module.name` needs `Module` to have *finished* its own setup
+  (`self._device_name = self.comm.name`), and a cooperative chain can now reach a later mixin
+  *during* an earlier class's single `super().__init__()` call, before that class's own post-`super()`
+  code runs. Fixed by making the cache path a lazy property instead. This is a structurally different
+  problem than the fan-out one — it's not about *whether* a mixin's kwargs get claimed, it's about
+  *sequencing side effects* relative to a cooperative chain that now runs the entire rest of the MRO
+  atomically inside one `super()` call. Worth watching for in the remaining 9 repos: any mixin that
+  reads live `Module`/`Object` state (not just its own constructor kwargs) during `__init__`.
+- `PipelineMixin`'s `archive` default-injection (`_with_default_archive`) unconditionally injected
+  `archive` into every step's config if a pipeline-level default was set, relying on steps that
+  don't want it to silently drop it — exactly the pattern this whole effort removes. Fixed to check
+  the step's declared signature first (same shape later reused for `Scheduler`'s
+  `observation_archive`, see below).
+
+**Verified the double-init risk is actually closed, not just "tests still pass":** before the fix,
+`BaseCamera`-family classes were silently calling `ImageFitsHeaderMixin.__init__` *twice* per
+construction (once via the new cooperative chain, once via the class's own leftover explicit call) —
+harmless there only because the second call happened to run last with the correct values, overwriting
+the first's wrong ones. Counted actual call counts with a monkey-patched `__init__` to confirm exactly
+one call post-fix, not just correct final attribute values (see PR #776 description).
+
+**Real bugs found via a full fleet-config construction check** (not caught by the unit test suite at
+all — these code paths have no test coverage): `Scheduler` passed `auto_update=False` to
+`ObservationArchive`/`LcoObservationArchive` (never declared, silently dropped, zero effect for this
+class's entire history) and `observation_archive` to every `TaskScheduler` implementation (only
+`OnDemandScheduler` declares it). Both fixed in `pyobs-core`; the fleet YAML side of this
+(`BasePointing`'s docstring falsely promised `log_file`/`log_absolute`, actually only real on the
+nested `apply:` object) is fixed in companion commits to `pyobs-monet`/`pyobs-iag50` directly (not a
+PR — those repos push straight to `develop`, per this session's established pattern).
+
+**Confirms the approach works end-to-end**, not just in theory: full suite green (1490 passed),
+ruff/black/pyrefly clean, and 799 real fleet config files across 4 repos still construct (the 2 real
+bugs above were the only new failures, both fixed). Take this as evidence for the remaining 9 repos,
+not a guarantee — each one still needs its own order-dependency check and, ideally, its own
+construction check against real configs where fleet configs exist to check against.
+
 ## Implementation checklist
 
-- [ ] `pyobs-core`: convert the 14 production fan-out classes + 5 tests to cooperative `super()`
+- [x] `pyobs-core`: convert the 14 production fan-out classes + 5 tests to cooperative `super()`
       chains; full test suite green (`pytest -m "not integration and not xmpp" --extra full`).
+      PR #776 (open, not yet merged).
 - [ ] `pyobs-monet` (2 classes)
 - [ ] `pyobs-monti` (1 class)
 - [ ] `pyobs-alpaca` (3 classes)

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -180,6 +180,63 @@ Moved the single `super().__init__(*args, motion_status_interfaces=["IFocuser", 
 ruff/black/pyrefly clean, and the live `gemini.yaml` config constructs correctly with
 `fits_namespaces` and `motion_status_interfaces` both landing on the right attributes.
 
+## Step 4 (`pyobs-monet`) — implemented
+
+Both flagged classes are dead code (`FrontendCameraSouth` commented out in
+`config/south/frontend/fli230.yaml`; `FrontendSouth` unreferenced anywhere), so zero live risk
+either way. `FrontendCameraSouth`'s bases were reordered (`FliBonnShutter` first, was
+`MotionStatusMixin` first — `FliBonnShutter` is the only path to `Module`/`Object`).
+`FrontendSouth`'s bases were already correctly ordered (`Module` first). Both collapsed to a single
+`super().__init__(**kwargs)` call. Note: the old `FrontendCameraSouth` code called
+`MotionStatusMixin.__init__(self)` with **zero** kwargs, not even `**kwargs` — always defaulting
+`motion_status_interfaces` to `None`. The cooperative version just lets it flow through `**kwargs`
+naturally instead (in practice identical, since no caller has ever set it).
+
+No test suite exists for these modules (`pyobs-monet` has no `pytest`/`ruff`/`pyrefly` dev
+dependencies at all, unlike the driver repos) — verified instead by directly constructing both
+classes with representative kwargs and calling `motion_status()` on each, confirming
+`MotionStatusMixin.__init__` actually ran (would raise `AttributeError` otherwise, same failure
+mode found in `pyobs-fli`/`pyobs-gemini`'s review). `black --line-length 120` clean.
+
+## Step 5 (`pyobs-monti`) — implemented
+
+`MontiTelescope`'s bases were already correctly ordered (`BaseTelescope` first, `FitsNamespaceMixin`
+last), but its `__init__` still called both explicitly: `BaseTelescope.__init__(self, **kwargs,
+motion_status_interfaces=["ITelescope"])` first, then `FitsNamespaceMixin.__init__(self, **kwargs)`
+again at the end. Collapsed to a single `super().__init__(motion_status_interfaces=["ITelescope"],
+**kwargs)` call at the top, moved ahead of this class's own attribute setup (matches the
+`BaseTelescope` precedent). Verified: `black` clean; constructed directly (with a stub
+`_set_tracking_rate` and mocked serial I/O, see below) — `fits_namespaces` lands correctly and
+`motion_status()` returns `UNKNOWN` instead of raising.
+
+**A third, distinct failure mode found here, worth generalizing:** because `BaseTelescope` was
+already correctly ordered *before* `FitsNamespaceMixin` in the base list, `BaseTelescope`'s own
+(now-cooperative) `super()` chain — triggered by the *first* explicit call — already reached
+`FitsNamespaceMixin` correctly on its own. The *second*, redundant explicit
+`FitsNamespaceMixin.__init__(self, **kwargs)` call wasn't needed to reach the mixin at all; it was
+dead weight from the pre-cooperative world. Confirmed via a minimal repro
+(`Module.__init__(self, comm=None)` then `FitsNamespaceMixin.__init__(self, comm=None)`, i.e. only
+kwargs that are legitimately declared and fully consumed on the *first* call) that this redundant
+second call **still raises** `TypeError: object.__init__() takes exactly one argument` — because
+`**kwargs` unpacking at a call site never mutates the caller's dict, so the second call re-threads
+the *same already-consumed* kwargs to a chain that's now cooperative all the way to
+`object.__init__()`. This is a stricter trap than the sibling-leak pattern found in
+`pyobs-fli`/`pyobs-gemini`: it doesn't require a genuinely foreign kwarg at all, just *any* redundant
+second explicit call to a mixin whose `__init__` the first call's cooperative chain already reached.
+Live relevance: `pyobs-monti/config/telescope.yaml` sets only ordinary `BaseTelescope`-level kwargs
+(`fits_headers`, `comm`, no `fits_namespaces`) — under the *old* two-call code this construction
+would still have failed against a cooperative `pyobs-core`, for exactly this reason.
+
+Also found and worked around, not fixed (pre-existing, unrelated to this conversion):
+`pyobs-monti`'s `pyproject.toml` pins `pyobs-core==1.32.1` (the old 1.x line) while its actual source
+imports 2.x-era paths (`pyobs.modules.telescope.basetelescope.BaseTelescope`,
+`pyobs.mixins.FitsNamespaceMixin`) — confirms this repo's dependency metadata has been stale for a
+while, consistent with the "possibly already inactive" note from the original rollout plan. Verified
+against current `pyobs-core` (not `1.32.1`) with `--no-deps` to bypass the stale pin.
+`MontiTelescope` is also currently missing `_set_tracking_rate`, an abstract method `ITelescope` has
+since grown — unrelated to kwarg threading, not fixed here (out of scope), worked around in
+verification with a throwaway stub subclass.
+
 ## Non-goals
 
 - Not converting every explicit `ClassName.__init__(self, **kwargs)` call in these codebases — a
@@ -237,16 +294,23 @@ construction check against real configs where fleet configs exist to check again
 
 ## Implementation checklist
 
-- [x] `pyobs-core`: convert the 14 production fan-out classes + 5 tests to cooperative `super()`
+- [ ] `pyobs-core`: convert the 14 production fan-out classes + 5 tests to cooperative `super()`
       chains; full test suite green (`pytest -m "not integration and not xmpp" --extra full`).
-      PR #776 (open, not yet merged).
-- [x] `pyobs-fli` (2 classes) — pulled forward, live-breaking (see critical finding above); tests +
-      lint + real-config checks green, not yet committed/pushed/PR'd.
-- [x] `pyobs-gemini` (1 class) — pulled forward, live-breaking (see critical finding above); tests +
-      lint + real-config checks green, not yet committed/pushed/PR'd.
+      PR #776 (open, reviewed — one real regression found and fixed, see review thread — not yet
+      merged; merging this is what unblocks pyobs-fli #84 and pyobs-gemini #19 below).
+- [ ] `pyobs-fli` (2 classes) — pulled forward, live-breaking (see critical finding above); PR #84
+      open, reviewed, regression test added and independently re-verified by reviewer. Blocked on
+      pyobs-core #776 merging + bumping this repo's `pyobs-core` pin to a release containing it.
+- [ ] `pyobs-gemini` (1 class) — pulled forward, live-breaking (see critical finding above); PR #19
+      open, reviewed, regression test added. Same block as pyobs-fli: needs #776 merged + this
+      repo's `pyobs-core` pin bumped.
 - [ ] `pyobs-monet` (2 classes) — dead code (`FrontendCameraSouth`/`FrontendSouth` unreferenced),
-      zero urgency, not yet started.
-- [ ] `pyobs-monti` (1 class)
+      zero urgency; MR !54 (GitLab) open and reviewed — correct, blocked on pyobs-core #776 +
+      pyobs-fli #84 merging first (this class chain depends on `FliBonnShutter`/`FliCamera`).
+- [ ] `pyobs-monti` (1 class) — live (`config/telescope.yaml`); fixed, regression test added, MR !1
+      (GitLab, `gitlab.gwdg.de/monet/pyobs-monti`) open and reviewed — approved, blocked purely on
+      pyobs-core #776 merging first (same as pyobs-fli/pyobs-gemini). `_set_tracking_rate`
+      abstract-method gap and stale `pyobs-core==1.32.1` pin are pre-existing, out of scope here.
 - [ ] `pyobs-alpaca` (3 classes)
 - [ ] `pyobs-zwoeaf` (1 class)
 - [ ] `pyobs-iagvt` (2 classes) — `LDP`/`LED` are live but current configs don't trigger the bug;

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -237,6 +237,98 @@ against current `pyobs-core` (not `1.32.1`) with `--no-deps` to bypass the stale
 since grown — unrelated to kwarg threading, not fixed here (out of scope), worked around in
 verification with a throwaway stub subclass.
 
+## Step 6 (`pyobs-alpaca`) — implemented
+
+Three classes, all three separate fan-out shapes: `AlpacaDome(FollowMixin, BaseDome)` had the mixin
+listed *before* the base and both `__init__`s called explicitly (sibling-leak, plus what became a
+redundant-double-call once `pyobs-core`'s `FollowMixin` went cooperative); `AlpacaFocuser
+(MotionStatusMixin, ..., Module)` had `Module` listed *last*, called first, with
+`MotionStatusMixin.__init__(self)` called separately with no kwargs after (same sibling-leak shape as
+`pyobs-fli`); `AlpacaTelescope(BaseTelescope, FitsNamespaceMixin, ...)` had bases already correctly
+ordered but still made the `pyobs-monti`-style redundant second call. Reordered `AlpacaDome` to
+`(BaseDome, FollowMixin)` and `AlpacaFocuser` to `(Module, MotionStatusMixin, ...)`; collapsed all
+three to a single `super().__init__()` call.
+
+**A fourth, new failure mode found here:** all three classes construct a child `AlpacaDevice` via
+`self.add_child_object(AlpacaDevice, **kwargs)`, reusing the *same* `kwargs` dict passed to the
+module's own chain. `AlpacaDevice`-only kwargs (`server`, `port`, `device_type`, `device`, `version`,
+`alive_parameter`) aren't recognized anywhere in the `Module`/mixin chain, and — symmetrically —
+module/mixin-only kwargs (`fits_namespaces`, `motion_status_interfaces`) aren't recognized by
+`AlpacaDevice`. Both directions used to be silently absorbed; both now raise. Fixed by scoping each
+side's kwargs explicitly (`DEVICE_INIT_KWARGS`/`OBJECT_SHARED_KWARGS` constants in `device.py`). This
+is a distinct bug from the fan-out `__init__` pattern — it's about a *child object* sharing its
+parent's raw kwargs blob, not about sibling mixins in the same MRO — but it's the same root cause
+(`Object.__init__` no longer silently absorbing) and was blocking verification, so fixed in the same
+PR. Verified: new `tests/test_cooperative_init.py` constructs all three with representative kwargs
+and asserts mixin state landed; confirmed to fail with `TypeError` against the pre-fix code (via
+`git stash`) and pass post-fix. `AlpacaFocuser`/`AlpacaTelescope` are live outside this repo's own
+config directory (`pytel-dev/configs/alpaca-{focuser,telescope}.yaml`) — those configs currently use
+a stale `type:` key instead of `device_type:` (pre-existing config drift from an old rename,
+unrelated, not fixed). `AlpacaDome` has no config reference found anywhere in the fleet. PR #34.
+
+## Step 7 (`pyobs-zwoeaf`) — implemented
+
+`EAFFocuser(Module, MotionStatusMixin, IFocuser, ITemperatures)` — bases already correctly ordered,
+but called `Module.__init__(self, **kwargs)` then a separate `MotionStatusMixin.__init__(self)` with
+*no* kwargs. Collapsed to a single `super().__init__(**kwargs)` call. Unlike the other repos, this one
+doesn't currently crash: the redundant second call passes zero kwargs, so it just re-runs
+`MotionStatusMixin.__init__`'s idempotent body a second time rather than leaking anything to
+`object.__init__()` — confirmed by constructing with a representative kwarg (`location`) against both
+pre- and post-fix code. Still converted for consistency with the fleet-wide pattern and to remove the
+footgun (any future kwarg threaded through that second call would resurface as a crash). Live in
+`pyobs-monet/config/south/monti/focuser.yaml` (`comm`/`vfs` only). PR #21.
+
+## Step 8 (`pyobs-iagvt`) — implemented
+
+`LDP`/`LED` (identical shape): `class LDP(MotionStatusMixin, Module, IMode, IMotion)` — mixin listed
+*before* `Module`, called `Module.__init__(self, *args, **kwargs)` then a separate
+`MotionStatusMixin.__init__(self, **kwargs)` — classic sibling-leak, with real kwargs on the second
+call this time. Reordered both to `(Module, MotionStatusMixin, IMode, IMotion)`, collapsed to
+`super().__init__(*args, **kwargs)`. Live configs (`config/iagvtsrv/{ldp,led}.yaml`) only set `comm`,
+which is consumed by `Object` and doesn't crash — confirmed both pre- and post-fix with those exact
+kwargs. But any sibling-mixin kwarg (`motion_status_interfaces`) does crash pre-fix — confirmed via a
+constructed repro and used as the regression test (`tests/modules/test_ldp_led.py`), since it's the
+smallest kwarg that exercises the actual defect rather than a coincidentally-safe one. Full test
+suite not run (this repo depends on a private `pyftscontrol` git package and heavy optional deps not
+installed in the verification environment); `ruff`/`pyrefly` clean on touched files. MR !61
+(`gitlab.gwdg.de/iagvt/pyobs-iagvt`).
+
+## Step 9 (`pyobs-sbig`) — implemented
+
+`SbigFilterCamera(MotionStatusMixin, SbigCamera, IFilters)` — same sibling-leak shape as
+`pyobs-iagvt`: `SbigCamera.__init__(self, **kwargs)` then a separate
+`MotionStatusMixin.__init__(self, **kwargs, motion_status_interfaces=["IFilters"])`. Reordered to
+`(SbigCamera, MotionStatusMixin, IFilters)`, collapsed to a single call. Unlike `pyobs-iagvt`, this
+one turned out *not* reproducibly crashing: `SbigCamera`'s own chain (via `BaseCamera`) already
+consumes every kwarg the live configs set (`filter_wheel`, `filter_names`, `setpoint`, `fits_headers`,
+`comm`, `vfs`), and re-consumes them identically on the redundant second pass, so nothing leaks either
+before or after the fix — confirmed with the actual `pyobs-monet`/`pyobs-monti` SBIG8300 config
+kwargs. The only kwarg that would exercise the defect is `motion_status_interfaces` itself, and that
+collides directly (`got multiple values`) rather than leaking, both before and after, since it's
+hardcoded at the call site — not a fair regression case. No new regression test added for this reason
+(the existing suite already covers construction); fixed anyway to match the fleet-wide pattern. Live
+in `pyobs-monet`'s `south/piggyback`/`north/camera` SBIG8300 configs and `pyobs-monti/config/camera.yaml`.
+PR #72.
+
+## Step 10 (`pyobs-brot`) — implemented
+
+Resolves this plan's earlier open question about whether `pyobs-brot` is actually live: yes —
+`pyobs-monet/config/{north,south}/monet/telescope.yaml` (both `class: BrotAltAzTelescope`) and
+`south/monet/roof.yaml`. Three classes exist (`BrotDome`, `BrotRoof`, `BrotBaseTelescope` +
+subclasses `BrotRaDecTelescope`/`BrotAltAzTelescope`), but only `BrotBaseTelescope` has the fan-out
+shape — `BrotDome`/`BrotRoof` and the two telescope subclasses each have exactly one real base,
+called explicitly, which is fine (matches the `BaseDome`-in-`pyobs-core` precedent). `BrotBaseTelescope
+(BaseTelescope, ..., FitsNamespaceMixin)` — bases already correctly ordered, but called
+`BaseTelescope.__init__(self, **kwargs, motion_status_interfaces=[...], wait_for_dome=...)` then a
+separate `FitsNamespaceMixin.__init__(self, **kwargs)` — the `pyobs-monti`-style redundant-double-call.
+Collapsed to a single `super().__init__()` call.
+
+**This is a real, live crash, not just a latent one:** the deployed telescope configs set `location`,
+`timezone`, `comm`, `fits_headers`, and `temperatures`. Confirmed via `git stash` that constructing
+`BrotAltAzTelescope` with exactly those kwargs raises `TypeError: object.__init__() takes exactly one
+argument` against `pyobs-core`#776's cooperative chain on the pre-fix code, and succeeds post-fix.
+Regression test added mirroring the live config's kwargs. PR #56.
+
 ## Non-goals
 
 - Not converting every explicit `ClassName.__init__(self, **kwargs)` call in these codebases — a
@@ -311,13 +403,19 @@ construction check against real configs where fleet configs exist to check again
       (GitLab, `gitlab.gwdg.de/monet/pyobs-monti`) open and reviewed — approved, blocked purely on
       pyobs-core #776 merging first (same as pyobs-fli/pyobs-gemini). `_set_tracking_rate`
       abstract-method gap and stale `pyobs-core==1.32.1` pin are pre-existing, out of scope here.
-- [ ] `pyobs-alpaca` (3 classes)
-- [ ] `pyobs-zwoeaf` (1 class)
-- [ ] `pyobs-iagvt` (2 classes) — `LDP`/`LED` are live but current configs don't trigger the bug;
-      re-check before this repo's `pyobs-core` pin moves past #776.
-- [ ] `pyobs-sbig` (1 class) — `SbigFilterCamera` is live but current configs don't trigger the bug;
-      re-check before this repo's `pyobs-core` pin moves past #776.
-- [ ] `pyobs-brot` (1 class)
+- [ ] `pyobs-alpaca` (3 classes) — `AlpacaDome`/`AlpacaFocuser`/`AlpacaTelescope` fixed, plus a
+      related child-object kwarg-leak bug (see Step 6); regression test added. PR #34, open,
+      blocked on pyobs-core #776 merging first.
+- [ ] `pyobs-zwoeaf` (1 class) — `EAFFocuser` fixed; currently harmless (no crash reproduced) but
+      converted for consistency, see Step 7. PR #21, open, blocked on pyobs-core #776.
+- [ ] `pyobs-iagvt` (2 classes) — `LDP`/`LED` fixed; live configs don't trigger the bug but a
+      sibling-mixin kwarg does (see Step 8), regression test added. MR !61
+      (`gitlab.gwdg.de/iagvt/pyobs-iagvt`), open, blocked on pyobs-core #776.
+- [ ] `pyobs-sbig` (1 class) — `SbigFilterCamera` fixed; not reproducibly crashing (see Step 9),
+      converted for consistency. PR #72, open, blocked on pyobs-core #776.
+- [ ] `pyobs-brot` (1 class) — `BrotBaseTelescope` fixed; **live production crash**, confirmed via
+      the deployed telescope configs (see Step 10), regression test added. PR #56, open, blocked
+      on pyobs-core #776. Resolves this plan's earlier open question about `pyobs-brot`'s liveness.
 - [ ] Implement `if kwargs: raise TypeError(...)` in `Object.__init__` (`pyobs-core`), now that
       every consuming class threads kwargs cooperatively.
 - [ ] Roll out / restart affected fleet modules; watch for anything this session's checks missed

--- a/tests/mixins/test_camerasettings.py
+++ b/tests/mixins/test_camerasettings.py
@@ -17,8 +17,7 @@ class SettingsModule(Module, CameraSettingsMixin):
     """Minimal concrete module for exercising CameraSettingsMixin in isolation."""
 
     def __init__(self, **kwargs) -> None:
-        Module.__init__(self, **kwargs)
-        CameraSettingsMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
 
 def make_module(**kwargs) -> SettingsModule:

--- a/tests/mixins/test_fitsheader.py
+++ b/tests/mixins/test_fitsheader.py
@@ -22,8 +22,7 @@ class FitsModule(Module, ImageFitsHeaderMixin):
     """Minimal concrete module for exercising ImageFitsHeaderMixin in isolation."""
 
     def __init__(self, **kwargs) -> None:
-        Module.__init__(self, **kwargs)
-        ImageFitsHeaderMixin.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
 
 DEFAULT_LOCATION = EarthLocation.from_geodetic(lon=20.81, lat=-32.38, height=1798.0)

--- a/tests/mixins/test_follow.py
+++ b/tests/mixins/test_follow.py
@@ -17,8 +17,7 @@ from pyobs.modules import Module
 
 class _FollowingDevice(Module, FollowMixin, IPointingAltAz):
     def __init__(self, **kwargs: Any) -> None:
-        Module.__init__(self, **kwargs)
-        FollowMixin.__init__(self, mode=IPointingAltAz, **kwargs)
+        super().__init__(mode=IPointingAltAz, **kwargs)
 
     async def move_altaz(self, alt: float, az: float, **kwargs: Any) -> None:
         pass

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -8,9 +8,14 @@ from pyobs.comm import Comm
 from pyobs.events import GoodWeatherEvent, TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
 from pyobs.interfaces import IRunning
 from pyobs.modules.robotic import Scheduler
+from pyobs.modules.robotic.scheduler import _class_accepts_param
 from pyobs.robotic import ObservationArchive, Task, TaskArchive
 from pyobs.robotic.observation import Observation, ObservationList, ObservationState
 from pyobs.robotic.scheduler import TaskScheduler
+from pyobs.robotic.scheduler.astroplanscheduler import AstroplanScheduler
+from pyobs.robotic.scheduler.ondemandscheduler import OnDemandScheduler
+from pyobs.robotic.storage.backend.observationarchive import BackendObservationArchive
+from pyobs.robotic.storage.lco.observationarchive import LcoObservationArchive
 from pyobs.robotic.task import TaskData
 from pyobs.utils.time import Time
 
@@ -121,6 +126,63 @@ def test_init_defaults() -> None:
     assert scheduler._tasks == []
     assert scheduler._projects == []
     assert scheduler._safety_time == 300 * u.second
+
+
+# ── _class_accepts_param (kwarg-injection matrix) ────────────────────────────
+#
+# Pins which schedule/scheduler classes get which auto-injected kwarg -- injecting
+# unconditionally used to rely on the target silently absorbing an unwanted kwarg, which stopped
+# being true once Object.__init__ started forwarding leftovers to object.__init__(). Regression
+# coverage for the auto_update bug found in PR #776 review: dropping it unconditionally would have
+# re-enabled BackendObservationArchive's polling loop in two live fleets.
+
+
+@pytest.mark.parametrize(
+    "class_path,param_name,expected",
+    [
+        ("pyobs.robotic.storage.backend.observationarchive.BackendObservationArchive", "auto_update", True),
+        ("pyobs.robotic.storage.lco.observationarchive.LcoObservationArchive", "auto_update", False),
+        ("pyobs.robotic.scheduler.ondemandscheduler.OnDemandScheduler", "observation_archive", True),
+        ("pyobs.robotic.scheduler.astroplanscheduler.AstroplanScheduler", "observation_archive", False),
+    ],
+)
+def test_class_accepts_param_dict_config(class_path: str, param_name: str, expected: bool) -> None:
+    assert _class_accepts_param({"class": class_path}, param_name) is expected
+
+
+@pytest.mark.parametrize(
+    "klass,param_name,expected",
+    [
+        (BackendObservationArchive, "auto_update", True),
+        (LcoObservationArchive, "auto_update", False),
+        (OnDemandScheduler, "observation_archive", True),
+        (AstroplanScheduler, "observation_archive", False),
+    ],
+)
+def test_class_accepts_param_bare_class(klass: type, param_name: str, expected: bool) -> None:
+    assert _class_accepts_param(klass, param_name) is expected
+
+
+def test_class_accepts_param_dict_without_class_key_is_false() -> None:
+    assert _class_accepts_param({}, "auto_update") is False
+
+
+def test_class_accepts_param_unresolvable_class_path_is_false() -> None:
+    assert _class_accepts_param({"class": "not.a.real.module.Class"}, "auto_update") is False
+
+
+def test_init_injects_auto_update_false_for_backend_observation_archive() -> None:
+    # regression test for the bug found in PR #776 review: dropping auto_update=False
+    # unconditionally re-enabled this 5s polling loop in two live fleet configs
+    scheduler = make_scheduler(
+        schedule={
+            "class": "pyobs.robotic.storage.backend.observationarchive.BackendObservationArchive",
+            "url": "http://x",
+            "token": "t",
+        }
+    )
+    has_poller = any(bg._func.__name__ == "_check_for_changes" for bg, _ in scheduler._schedule._background_tasks)
+    assert has_poller is False
 
 
 # ── open ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

First step of `specs/plans/2026-08-18-cooperative-mixin-init.md`: makes `pyobs-core`'s own mixin composition genuinely cooperative, so `Object.__init__` can eventually raise on unrecognized kwargs (attempted directly in `specs/plans/2026-08-09-object-kwarg-validation.md`, reverted -- broke 59 tests because several classes fan the same `**kwargs` out to multiple sibling mixins independently instead of a `super()` chain).

- `Object.__init__` now ends with `super().__init__(**kwargs)` instead of silently absorbing leftovers.
- Converted the 14 `pyobs-core` classes (+ 3 test doubles) using the explicit fan-out pattern to a single cooperative `super().__init__()` call.
- Reordered bases in `BaseRoof`, `BaseTelescope`, `DummyMode` to put `Module` first -- every order dependency found (mixins calling `add_background_task`/`add_child_object`/`self.comm`) needs `Object`/`Module` to run first, none need the opposite.
- Made `FitsHeaderMixin`'s cache-path attribute a lazy property instead of computing it eagerly at `__init__` time, since it can now run before `Module` finishes setting up `self._device_name`.
- Made `PipelineMixin`'s `archive` default-injection conditional on the target step actually declaring the parameter (signature-checked), instead of injecting unconditionally and relying on silent-drop -- the exact thing this whole effort removes.

## Real bugs found and fixed along the way

A full fleet-config construction check (not just unit tests -- actually building real objects from 799 config files across `pyobs-monet`/`pyobs-iagvt`/`pyobs-iag50`/`pyobs-polaris`) surfaced two previously-hidden, silently-dropped kwargs in `pyobs-core` itself:

- `Scheduler` passed `auto_update=False` to `ObservationArchive`/`LcoObservationArchive`, which have never declared that parameter. Removed.
- `Scheduler` passed `observation_archive` to every `TaskScheduler` implementation, but only `OnDemandScheduler` declares it -- `AstroplanScheduler` (the one actually configured in the fleet) always dropped it. Now only injected when the configured class actually declares it.
- `BasePointing`'s docstring documented `log_file`/`log_absolute` as if they were its own params; never implemented there (only on the nested `apply:` object, and on `Acquisition` specifically). Removed the false documentation.

Companion fleet-config fixes (moving misplaced `log_file`/`max_offset` into the `apply:` block where they're actually consumed, removing one true duplicate) are in separate PRs against `pyobs-monet` and `pyobs-iag50`.

## Test plan
- [x] Full suite: `pytest -m "not integration and not xmpp" --extra full` -- 1490 passed, 25 skipped, 0 failed
- [x] `ruff check` / `black --check` / `pyrefly check` clean
- [x] Manually verified the double-init bug this could have hidden is actually fixed (counted `FitsHeaderMixin.__init__` calls before/after: 1, not 2)
- [x] Constructed all 799 real fleet config files across 4 repos; every previously-constructible config still constructs, the two real bugs above were the only new failures (both fixed)