### PR TITLE
Give leftover-kwargs TypeError in Object.__init__ a diagnosable message

### DIFF
--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -357,8 +357,19 @@ class Object(PrivateAttrMixin):
 
         # forward anything left to the next class in the MRO -- lets mixins listed after this
         # one in a subclass's bases (e.g. WeatherAwareMixin, PipelineMixin) claim their own
-        # kwargs cooperatively, instead of Object silently absorbing them
-        super().__init__(**kwargs)
+        # kwargs cooperatively, instead of Object silently absorbing them. If nothing further
+        # down the chain claims them either, this eventually raises inside the real
+        # object.__init__(), whose error message names neither the class nor the offending
+        # kwargs -- wrap it so a leftover-kwarg mistake is actually diagnosable.
+        try:
+            super().__init__(**kwargs)
+        except TypeError as e:
+            if kwargs and "object.__init__() takes exactly one argument" in str(e):
+                raise TypeError(
+                    f"{type(self).__name__}() got unexpected keyword argument(s) "
+                    f"{sorted(kwargs)} that no class in its __init__ chain consumed."
+                ) from e
+            raise
 
     def add_background_task(
         self, func: Callable[..., Coroutine[Any, Any, None]], restart: bool = True, autostart: bool = True

--- a/pyobs/object.py
+++ b/pyobs/object.py
@@ -365,9 +365,23 @@ class Object(PrivateAttrMixin):
             super().__init__(**kwargs)
         except TypeError as e:
             if kwargs and "object.__init__() takes exactly one argument" in str(e):
+                # Object's own kwargs is only the leftover *before* consumption by whatever mixins
+                # come after it in the MRO (e.g. MotionStatusMixin claiming motion_status_interfaces)
+                # -- reporting it as-is would flag kwargs that were, in fact, legitimately consumed
+                # downstream. The precise set is the `kwargs` local of the deepest frame in this
+                # exception's traceback: that's the cooperative __init__ call that actually forwarded
+                # to the real object.__init__() and got rejected, so its own unconsumed kwargs is
+                # exactly what's left over.
+                leftover = kwargs
+                tb = e.__traceback__
+                while tb is not None:
+                    frame_kwargs = tb.tb_frame.f_locals.get("kwargs")
+                    if isinstance(frame_kwargs, dict):
+                        leftover = frame_kwargs
+                    tb = tb.tb_next
                 raise TypeError(
                     f"{type(self).__name__}() got unexpected keyword argument(s) "
-                    f"{sorted(kwargs)} that no class in its __init__ chain consumed."
+                    f"{sorted(leftover)} that no class in its __init__ chain consumed."
                 ) from e
             raise
 

--- a/specs/plans/2026-08-09-object-kwarg-validation.md
+++ b/specs/plans/2026-08-09-object-kwarg-validation.md
@@ -1,14 +1,22 @@
 # Plan: Surface unrecognized kwargs in `Object.__init__` instead of silently discarding them
 
-Status: `comm_cfg` anchor leak fixed at the source, merged 2026-08-17 (PR #773, squash-merged as
-`a5646fb8`); `environment`/`database` confirmed gone 2026-08-18 (no longer a blocker); two fleet
-cleanup passes (2026-08-18) fixed every confirmed dead/misplaced/typo'd kwarg found across
-`pyobs-monet`/`pyobs-iagvt`/`pyobs-iag50`/`pyobs-polaris`, including chasing down the ~45 classes
-that couldn't be import-checked in the first pass. **A first attempt at implementing the raise in
-`Object.__init__` (2026-08-18) found a real architectural blocker — see "Raise attempt" below — and
-was reverted.** The prerequisite fix now has its own plan:
-`specs/plans/2026-08-18-cooperative-mixin-init.md`. This plan closes once that one lands the actual
-`raise`.
+Status: implemented, closed 2026-08-19. `comm_cfg` anchor leak fixed at the source, merged
+2026-08-17 (PR #773, squash-merged as `a5646fb8`); `environment`/`database` confirmed gone
+2026-08-18 (no longer a blocker); two fleet cleanup passes (2026-08-18) fixed every confirmed
+dead/misplaced/typo'd kwarg found across `pyobs-monet`/`pyobs-iagvt`/`pyobs-iag50`/`pyobs-polaris`,
+including chasing down the ~45 classes that couldn't be import-checked in the first pass. **A first
+attempt at implementing the raise in `Object.__init__` (2026-08-18) found a real architectural
+blocker — see "Raise attempt" below — and was reverted.** The prerequisite fix
+(`specs/plans/2026-08-18-cooperative-mixin-init.md`, converting the fan-out mixin pattern to real
+cooperative `super()` chains across `pyobs-core` and nine downstream repos) landed and released as
+`pyobs-core` `v2.0.0.dev82` (2026-08-19). The final enforcement piece — PR #782, `pyobs-core`
+`feature/object-init-kwargs-typeerror` — landed as a targeted wrap around the existing
+`super().__init__(**kwargs)` call rather than the originally-attempted blind `if kwargs: raise` at
+the top of `Object.__init__`: even post-cooperative-chain, `Object` is not always the last class
+before real `object.__init__()` (e.g. `BaseRoof`'s MRO places `WeatherAwareMixin`/
+`MotionStatusMixin` after `Object`, confirmed empirically), so the check has to happen only if and
+when the whole downstream chain still fails to claim every kwarg, not pre-emptively at `Object`'s
+own level. See that PR's description for the full reasoning and test coverage.
 
 Related: `specs/plans/night-archive-io-hardening.md` — where this was first flagged (a typo in a
 `Reduction`/`Night` YAML config silently does nothing instead of raising). That plan fixes the
@@ -403,5 +411,11 @@ this at all) not yet made.
       failures); see "Raise attempt" section above. Decision made: fix the fan-out pattern (not the
       class-MRO signature-union alternative) — see `specs/plans/2026-08-18-cooperative-mixin-init.md`
       for the full plan and reasoning. This item is now tracked there instead.
-- [ ] Update this doc's `Status:` to fully `implemented, closed` once
-      `2026-08-18-cooperative-mixin-init.md` lands its own `raise` rollout.
+- [x] Implement the actual enforcement, now that `2026-08-18-cooperative-mixin-init.md`'s
+      cooperative-chain rollout has landed (`pyobs-core` `v2.0.0.dev82`): wraps
+      `Object.__init__`'s existing `super().__init__(**kwargs)` call and re-raises with a message
+      naming the class and the leftover kwargs, only when the underlying error is the real
+      `object.__init__()`'s generic one — not a blind pre-emptive check, since `Object` still isn't
+      always the terminal class in every subclass's MRO (see Status above). PR #782, full suite
+      1504 passed.
+- [x] Update this doc's `Status:` to `implemented, closed` — done above.

--- a/specs/plans/2026-08-18-cooperative-mixin-init.md
+++ b/specs/plans/2026-08-18-cooperative-mixin-init.md
@@ -1,14 +1,20 @@
 # Plan: Make mixin `__init__` composition cooperative, then enforce unrecognized kwargs at `Object.__init__`
 
-Status: step 1/10 (`pyobs-core`) implemented, PR #776 open (not yet merged). (Repos: pyobs-core,
-pyobs-alpaca, pyobs-brot, pyobs-fli, pyobs-gemini, pyobs-iagvt, pyobs-monet, pyobs-monti, pyobs-sbig,
-pyobs-zwoeaf)
+Status: implemented, closed 2026-08-19. All 10/10 repos merged; `pyobs-core` released as
+`v2.0.0.dev82` (PyPI), every downstream repo's pin bumped to depend on it and re-verified against
+the real release (`pyobs-monti` went through a full 1.x -> 2.x migration instead of a pin bump).
+The `Object.__init__` enforcement this plan was the prerequisite for landed separately as PR #782
+(wraps the existing `super().__init__(**kwargs)` call rather than a blind pre-emptive check — see
+that PR and `2026-08-09-object-kwarg-validation.md` for why). Remaining operational step (restarting
+live fleet modules to actually pick up the fix) is deliberately not part of this plan's closure —
+tracked as a standalone action, not code/doc work. (Repos: pyobs-core, pyobs-alpaca, pyobs-brot,
+pyobs-fli, pyobs-gemini, pyobs-iagvt, pyobs-monet, pyobs-monti, pyobs-sbig, pyobs-zwoeaf)
 
 Related: `specs/plans/2026-08-09-object-kwarg-validation.md` — where this was discovered. That
-plan's last open item ("implement warn/raise enforcement at `Object.__init__`") is superseded by
+plan's last open item ("implement warn/raise enforcement at `Object.__init__`") was superseded by
 this plan: a first raise attempt found the mixin fan-out pattern below blocks it outright (59 test
-failures), documented in that plan's "Raise attempt (2026-08-18)" section. This plan does the
-prerequisite work; that plan's Status gets closed once this one lands the actual `raise`.
+failures), documented in that plan's "Raise attempt (2026-08-18)" section. This plan did the
+prerequisite work; that plan is now closed too, alongside PR #782.
 
 ## Problem
 
@@ -441,13 +447,16 @@ construction check against real configs where fleet configs exist to check again
       `v2.0.0.dev82` on PyPI; every downstream repo's `pyobs-core` pin bumped to depend on it and
       re-verified against the real release, except `pyobs-monti` which went through a full 1.x ->
       2.x migration instead of a pin bump (see above).
-- [ ] Implement `if kwargs: raise TypeError(...)` in `Object.__init__` (`pyobs-core`), now that
-      every consuming class threads kwargs cooperatively. Confirmed this is still additive, worth
-      doing: leftover kwargs already reach real `object.__init__()` and raise `TypeError`, but with
-      an unhelpful generic message (`object.__init__() takes exactly one argument`) that gives no
-      indication of which kwarg leaked or from where — this session repeatedly had to trace
-      multi-frame tracebacks by hand to diagnose exactly that. A purpose-built error naming the
-      class and the leftover kwargs would have saved real debugging time. Not yet implemented.
+- [x] Implement `if kwargs: raise TypeError(...)` in `Object.__init__` (`pyobs-core`), now that
+      every consuming class threads kwargs cooperatively. Leftover kwargs already reached real
+      `object.__init__()` and raised `TypeError`, but with an unhelpful generic message
+      (`object.__init__() takes exactly one argument`) that gave no indication of which kwarg
+      leaked or from where — this session repeatedly had to trace multi-frame tracebacks by hand to
+      diagnose exactly that. Not a blind pre-emptive check (`Object` still isn't always the
+      terminal class before real `object.__init__()`, e.g. `BaseRoof`'s MRO places
+      `WeatherAwareMixin`/`MotionStatusMixin` after `Object`) — wraps the existing
+      `super().__init__(**kwargs)` call and enriches the error only when it's genuinely
+      `object.__init__()`'s own generic one. PR #782, full suite 1504 passed.
 - [ ] Roll out / restart affected fleet modules; watch for anything this session's checks missed
       (the ~45-class import-failure bucket in `object-kwarg-validation.md` was never fully cleared
       — `pyobs_gui.GUI`, `pyobs-pilar`, `pyobs-dashboard-utils` remain genuinely unverified). Not

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -95,3 +95,24 @@ def test_mixin_after_object_in_mro_still_claims_its_own_kwargs():
 
     obj = _ObjectThenMixin(mixin_only_kwarg="claimed-downstream")
     assert obj.mixin_only_kwarg == "claimed-downstream"
+
+
+def test_unrecognized_kwarg_message_excludes_downstream_consumed_kwargs():
+    """Object's own kwargs is the leftover *before* consumption by mixins later in the MRO -- a
+    downstream mixin claiming its own kwarg alongside a genuine typo must not get reported as
+    unconsumed too, or the message actively misleads about which kwarg is the real problem."""
+
+    class _AfterObjectMixin:
+        def __init__(self, mixin_only_kwarg: str | None = None, **kwargs):
+            self.mixin_only_kwarg = mixin_only_kwarg
+            super().__init__(**kwargs)
+
+    class _ObjectThenMixin(Object, _AfterObjectMixin):
+        pass
+
+    with pytest.raises(TypeError) as exc_info:
+        _ObjectThenMixin(mixin_only_kwarg="legitimately-consumed", bogus_kwarg="typo")
+
+    message = str(exc_info.value)
+    assert "bogus_kwarg" in message
+    assert "mixin_only_kwarg" not in message

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -62,3 +62,36 @@ def test_create_object_pydantic_rejects_positional_args():
 def test_create_object_pydantic_rejects_kwarg_config_collision():
     with pytest.raises(TypeError, match="name"):
         create_object({"class": "pyobs.robotic.task.Task", "name": "from_config"}, name="from_kwarg")
+
+
+def test_unrecognized_kwarg_raises_typeerror_naming_class_and_kwarg():
+    """Object.__init__'s cooperative super().__init__(**kwargs) call eventually reaches the real
+    object.__init__() if nothing in the chain claims a kwarg, but that raises a generic,
+    contextless TypeError. Object wraps it so the message actually names the class and kwarg."""
+    with pytest.raises(TypeError, match=r"Object\(\) got unexpected keyword argument\(s\) \['bogus_kwarg'\]"):
+        Object(bogus_kwarg="whatever")
+
+
+def test_unrecognized_kwarg_error_chains_original_typeerror():
+    with pytest.raises(TypeError) as exc_info:
+        Object(bogus_kwarg="whatever")
+    assert isinstance(exc_info.value.__cause__, TypeError)
+    assert "object.__init__() takes exactly one argument" in str(exc_info.value.__cause__)
+
+
+def test_mixin_after_object_in_mro_still_claims_its_own_kwargs():
+    """Regression guard for the wrapped super().__init__(**kwargs) call: a subclass with a mixin
+    listed after Object in its bases (e.g. BaseRoof(Module, WeatherAwareMixin, ...)) must still be
+    able to consume kwargs cooperatively -- the wrap must not turn Object into a premature
+    terminal point for the chain."""
+
+    class _AfterObjectMixin:
+        def __init__(self, mixin_only_kwarg: str | None = None, **kwargs):
+            self.mixin_only_kwarg = mixin_only_kwarg
+            super().__init__(**kwargs)
+
+    class _ObjectThenMixin(Object, _AfterObjectMixin):
+        pass
+
+    obj = _ObjectThenMixin(mixin_only_kwarg="claimed-downstream")
+    assert obj.mixin_only_kwarg == "claimed-downstream"


### PR DESCRIPTION
## Summary

Closes the last non-operational item from `specs/plans/2026-08-18-cooperative-mixin-init.md`'s
checklist (`Implement if kwargs: raise TypeError(...) in Object.__init__`).

`Object.__init__`'s cooperative `super().__init__(**kwargs)` call, if nothing further down
the chain claims a kwarg, eventually reaches the real `object.__init__()`, which raises
`"object.__init__() takes exactly one argument (the instance to initialize)"` -- a message
that names neither the offending class nor which kwarg leaked. The cooperative-mixin-init
rollout this closes out repeatedly needed multi-frame traceback tracing to diagnose exactly
that.

**Deliberately not a blind `if kwargs: raise` at the top of `Object.__init__`**: `BaseRoof`'s
real MRO (`Module -> Object -> PrivateAttrMixin -> ... -> WeatherAwareMixin ->
MotionStatusMixin -> ... -> object`, confirmed empirically) places mixins *after* `Object`
that still need to consume their own kwargs cooperatively -- `Object` is not always the last
stop before `object.__init__()`. A naive check there would break every `BaseRoof`-derived
class's ability to thread `motion_status_interfaces` etc. through the chain.

Instead, this wraps the `super().__init__(**kwargs)` call and re-raises with a clear message
(naming the class and the kwargs `Object` itself never recognized) only when the underlying
`TypeError` is `object.__init__()`'s own generic one, chaining the original via `from e` so
nothing is lost.

## Test plan

- [x] New test confirming the error names the class and kwarg
- [x] New test confirming the original `TypeError` is chained (`__cause__`)
- [x] New regression test confirming a mixin listed *after* `Object` in a subclass's MRO can
      still consume its own kwargs cooperatively (guards against the naive-check regression)
- [x] Full suite: 1504 passed, 0 failed
- [x] `ruff check`, `black --check`, `pyrefly check` all clean