### PR TITLE
fix: add `public` flag to Project model (robotic backend ingestion)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 v2.0.0.dev78 (unreleased)
 *************************
+* ``Project`` gained a ``public`` flag (default ``False``), matching the field the robotic backend
+  (pyobs-robotic-backend#79) will start returning from ``GET /api/projects/``. Without it, the
+  strict ``Project`` model rejected the new key and ``BackendTaskArchive`` silently kept running on
+  stale or empty task/project data. Fixes #786.
 * ``BaseVideo`` gained a raw-frame streaming endpoint (``/video.raw``) alongside the existing MJPEG
   stream: a multipart, event-driven feed of a JSON FITS-keyed meta header plus raw little-endian
   frame bytes, with latest-frame-wins backpressure (a slow client drops stale frames instead of

--- a/pyobs/robotic/task.py
+++ b/pyobs/robotic/task.py
@@ -150,6 +150,7 @@ class Project(BaseModel):
     name: str = ""
     priority: float | None = Field(ge=0.0, le=9999.0, default=1.0)
     users: list[str] = Field(default_factory=list)
+    public: bool = False  # ingest backend `public` flag; default keeps old backends valid
 
 
 __all__ = ["Task", "TaskData", "Project"]

--- a/tests/robotic/storage/backend/test_backend_archives.py
+++ b/tests/robotic/storage/backend/test_backend_archives.py
@@ -115,6 +115,27 @@ async def test_task_get_projects_from_backend(mocker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_task_get_projects_from_backend_accepts_public(mocker) -> None:
+    """Projects with the backend `public` flag ingest without a strict-model ValidationError."""
+    archive = make_task_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(
+            return_value=[
+                {"code": "public", "name": "Public", "priority": 1.0, "public": True},
+                {"code": "private", "name": "Private", "priority": 1.0, "public": False},
+            ]
+        ),
+    )
+    result = await archive._get_projects()
+    assert len(result) == 2
+    assert result[0].code == "public"
+    assert result[0].public is True
+    assert result[1].code == "private"
+    assert result[1].public is False
+
+
+@pytest.mark.asyncio
 async def test_task_get_tasks_from_backend(mocker) -> None:
     archive = make_task_archive()
     mocker.patch(


### PR DESCRIPTION
## Summary

Fixes #786. [pyobs/pyobs-robotic-backend#79](https://github.com/pyobs/pyobs-robotic-backend/issues/79) adds a `public` flag to the backend's `Project` model and REST serializer, so `GET /api/projects/` will start returning a `public` key per project. Our strict `Project` model (`extra="forbid"`) rejected that key, so `BackendTaskArchive._get_projects()` raised `ValidationError` on every refresh; the broad `except Exception` in `_check_for_changes()` swallowed it, logged every 5 s, and the scheduler silently kept running on stale/empty task/project data.

## Changes

- `pyobs/robotic/task.py` — add `public: bool = False` to `Project`. Default `False` keeps old backends (payloads without the flag) valid.
- `tests/robotic/storage/backend/test_backend_archives.py` — regression test: `_get_projects()` accepts payloads carrying `public` (both `True` and `False`) and round-trips the value.
- `CHANGELOG.rst` — unreleased entry.

## Verification

- `tests/robotic` → 341 passed (incl. 23 in `test_backend_archives.py`)
- `ruff check` + `ruff format --check` → clean
- `black --check` → clean on changed Python files
- `pyrefly check` → 0 errors

## Not affected

- `BackendObservationArchive` — observations carry a task id, not project data.
- `LcoTaskArchive` — builds `Project(...)` directly from LCO proposals.
- FileSystem/Memory task archives and schedulers — only read `project.code` / `project.priority`.

## Coordination note

If robotic-backend#79 ships access filtering on `GET /api/projects/` (non-superusers see only public projects + their memberships), the token user `BackendTaskArchive` authenticates with must be a member/superuser of every private project it must schedule, or those projects silently drop out of ingestion. Decide together with the backend change.