### PR TITLE
Fix #789: re-fetch backend archives unconditionally instead of gating on per-process last_*_update markers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,16 @@ v2.0.0.dev78 (unreleased)
   ``ImageFitsHeaderMixin.__init__`` instead of forwarding ``**kwargs``, silently dropping a
   configured ``fits_header_timeout`` for exactly the modules (e.g. ``fli230``) that motivated this
   fix. Fixes #764. (#765, #768)
+* ``BackendTaskArchive`` and ``BackendObservationArchive`` no longer gate their 5s refresh loop on
+  the robotic-backend's ``last_task_update``/``last_observation_update`` marker. That marker is
+  computed from a per-process Django ``LocMemCache`` and is unreliable across gunicorn workers, so
+  a stale or missing marker pinned the archive's ``_last_update`` and the mastermind kept running
+  stale tasks/schedules (edited task parameters, deactivated tasks, newly scheduled observations,
+  window-expired observations) forever. Both archives now re-fetch unconditionally on every poll
+  and detect real changes by comparing the downloaded content against the cached copy (full model
+  dumps, including observation ``state``), firing ``on_tasks_changed`` only when content actually
+  changed; ``last_changed()`` now reports the local time a change was last observed. Fixes #789.
+  (#795)
 
 v2.0.0.dev77 (2026-08-16)
 *************************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ v2.0.0.dev78 (unreleased)
   and detect real changes by comparing the downloaded content against the cached copy (full model
   dumps, including observation ``state``), firing ``on_tasks_changed`` only when content actually
   changed; ``last_changed()`` now reports the local time a change was last observed. Fixes #789.
-  (#795)
+  (#790)
 
 v2.0.0.dev77 (2026-08-16)
 *************************

--- a/pyobs/robotic/storage/backend/observationarchive.py
+++ b/pyobs/robotic/storage/backend/observationarchive.py
@@ -71,16 +71,20 @@ class BackendObservationArchive(ObservationArchive):
         Re-fetches unconditionally on every poll instead of gating on the backend's
         ``last_observation_update`` marker (per-process Django ``LocMemCache``, unreliable across
         gunicorn workers -- see ``BackendTaskArchive``). Changes are detected by comparing full
-        observation contents via ``model_dump(use_task_id=True)``: the backend serializes ``task``
-        as a plain FK ID, while cached copies get their ``task`` replaced by a full ``Task`` when
-        the mastermind calls ``fetch_task()``, so the ID normalization keeps both sides
-        comparable. The comparison must include ``state`` -- ``Observation.__eq__`` ignores it, so
-        a naive list-equality check would miss e.g. window-expired or in-progress transitions.
+        observation contents via ``model_dump(use_task_id=True)``, keyed by observation ID so a
+        stable reordering of the same items is not mistaken for a change: the backend serializes
+        ``task`` as a plain FK ID, while cached copies get their ``task`` replaced by a full
+        ``Task`` when the mastermind calls ``fetch_task()``, so the ID normalization keeps both
+        sides comparable. The comparison includes ``state`` (``Observation.__eq__`` ignores it),
+        which matters for in-set transitions such as ``pending`` -> ``in_progress``; observations
+        leaving the fetched set -- e.g. ``window_expired``, which the server-side ``state``/
+        ``end_after`` filters drop -- are picked up as list shrinkage by the unconditional
+        refetch.
         """
         observations = await self._get_schedule()
-        if [o.model_dump(use_task_id=True) for o in observations] != [
-            o.model_dump(use_task_id=True) for o in self._observations
-        ]:
+        if {o.id: o.model_dump(use_task_id=True) for o in observations} != {
+            o.id: o.model_dump(use_task_id=True) for o in self._observations
+        }:
             self._observations = observations
             self._last_update = Time.now()
             sorted_obs = sorted(
@@ -245,7 +249,7 @@ class BackendObservationArchive(ObservationArchive):
             params["end_before"] = end_before.isot
         if end_after is not None:
             params["end_after"] = end_after.isot
-        observations = await http_request_paginated(self._session, url, params=params)
+        observations = await http_request_paginated(self._session, url, params=params, strict=True)
         return ObservationList([self.pyobs_model_validate(Observation, obs) for obs in observations])
 
 

--- a/pyobs/robotic/storage/backend/observationarchive.py
+++ b/pyobs/robotic/storage/backend/observationarchive.py
@@ -60,22 +60,38 @@ class BackendObservationArchive(ObservationArchive):
 
         while True:
             try:
-                last_update = await self.last_update_time()
-                if self._last_update is None or self._last_update < last_update:
-                    self._observations = await self._get_schedule()
-                    sorted_obs = sorted(
-                        filter(lambda o: o.state == ObservationState.PENDING, self._observations),
-                        key=lambda o: o.start,
-                    )
-                    if len(sorted_obs) == 0:
-                        log.info("Downloaded new schedule.")
-                    else:
-                        obs = sorted_obs[0]
-                        log.info("Downloaded new schedule. Next observation is task %s at %s.", obs.task, obs.start)
-                    self._last_update = last_update
+                await self._update()
             except Exception as e:
                 log.error("Failed to update observations from backend: %s", e)
             await asyncio.sleep(5)
+
+    async def _update(self) -> None:
+        """Fetch the schedule from the backend and apply it if anything changed.
+
+        Re-fetches unconditionally on every poll instead of gating on the backend's
+        ``last_observation_update`` marker (per-process Django ``LocMemCache``, unreliable across
+        gunicorn workers -- see ``BackendTaskArchive``). Changes are detected by comparing full
+        observation contents via ``model_dump(use_task_id=True)``: the backend serializes ``task``
+        as a plain FK ID, while cached copies get their ``task`` replaced by a full ``Task`` when
+        the mastermind calls ``fetch_task()``, so the ID normalization keeps both sides
+        comparable. The comparison must include ``state`` -- ``Observation.__eq__`` ignores it, so
+        a naive list-equality check would miss e.g. window-expired or in-progress transitions.
+        """
+        observations = await self._get_schedule()
+        if [o.model_dump(use_task_id=True) for o in observations] != [
+            o.model_dump(use_task_id=True) for o in self._observations
+        ]:
+            self._observations = observations
+            self._last_update = Time.now()
+            sorted_obs = sorted(
+                filter(lambda o: o.state == ObservationState.PENDING, self._observations),
+                key=lambda o: o.start,
+            )
+            if len(sorted_obs) == 0:
+                log.info("Downloaded new schedule.")
+            else:
+                obs = sorted_obs[0]
+                log.info("Downloaded new schedule. Next observation is task %s at %s.", obs.task, obs.start)
 
     async def last_update_time(self) -> Time:
         """Fetches last schedule update time."""

--- a/pyobs/robotic/storage/backend/taskarchive.py
+++ b/pyobs/robotic/storage/backend/taskarchive.py
@@ -70,13 +70,15 @@ class BackendTaskArchive(TaskArchive):
         mastermind run stale tasks forever. Real changes are detected by comparing the downloaded
         content against the cached copy. The comparison uses ``model_dump()`` rather than pydantic
         ``==``, which also compares runtime attributes (e.g. ``Task._cant_run_reason`` set by
-        ``can_run()``) and would flag unchanged tasks as changed on every poll.
+        ``can_run()``) and would flag unchanged tasks as changed on every poll; it is keyed by ID
+        so that a stable reordering of the same items (e.g. an unordered backend queryset) is not
+        mistaken for a change.
         """
         projects = await self._get_projects()
         tasks = await self._get_tasks()
-        if [p.model_dump() for p in projects] != [p.model_dump() for p in self._projects] or [
-            t.model_dump() for t in tasks
-        ] != [t.model_dump() for t in self._tasks]:
+        if {p.code: p.model_dump() for p in projects} != {p.code: p.model_dump() for p in self._projects} or {
+            t.id: t.model_dump() for t in tasks
+        } != {t.id: t.model_dump() for t in self._tasks}:
             self._projects = projects
             self._tasks = tasks
             self._last_update = Time.now()
@@ -91,12 +93,12 @@ class BackendTaskArchive(TaskArchive):
 
     async def _get_projects(self) -> list[Project]:
         """Fetch projects from backend."""
-        projects = await http_request_paginated(self._session, urljoin(self._url, "/api/projects/"))
+        projects = await http_request_paginated(self._session, urljoin(self._url, "/api/projects/"), strict=True)
         return [self.pyobs_model_validate(Project, project) for project in projects]
 
     async def _get_tasks(self) -> list[Task]:
         """Fetch tasks from backend."""
-        tasks = await http_request_paginated(self._session, urljoin(self._url, "/api/tasks/"))
+        tasks = await http_request_paginated(self._session, urljoin(self._url, "/api/tasks/"), strict=True)
         return [self.pyobs_model_validate(Task, task) for task in tasks]
 
     async def last_changed(self) -> Time | None:

--- a/pyobs/robotic/storage/backend/taskarchive.py
+++ b/pyobs/robotic/storage/backend/taskarchive.py
@@ -56,17 +56,33 @@ class BackendTaskArchive(TaskArchive):
         """Update tasks in background."""
         while True:
             try:
-                last_update = await self.last_update_time()
-                if self._last_update is None or self._last_update < last_update:
-                    self._projects = await self._get_projects()
-                    self._tasks = await self._get_tasks()
-                    log.info("Downloaded new tasks/projects.")
-                    self._last_update = last_update
-                    if self._on_tasks_changed is not None:
-                        await self._on_tasks_changed()
+                await self._update()
             except Exception as e:
                 log.error("Failed to update tasks from backend: %s", e)
             await asyncio.sleep(5)
+
+    async def _update(self) -> None:
+        """Fetch tasks/projects from the backend and apply them if anything changed.
+
+        Re-fetches unconditionally on every poll instead of gating on the backend's
+        ``last_task_update`` marker: that marker is computed from a per-process Django
+        ``LocMemCache`` and is unreliable across gunicorn workers, so gating on it let the
+        mastermind run stale tasks forever. Real changes are detected by comparing the downloaded
+        content against the cached copy. The comparison uses ``model_dump()`` rather than pydantic
+        ``==``, which also compares runtime attributes (e.g. ``Task._cant_run_reason`` set by
+        ``can_run()``) and would flag unchanged tasks as changed on every poll.
+        """
+        projects = await self._get_projects()
+        tasks = await self._get_tasks()
+        if [p.model_dump() for p in projects] != [p.model_dump() for p in self._projects] or [
+            t.model_dump() for t in tasks
+        ] != [t.model_dump() for t in self._tasks]:
+            self._projects = projects
+            self._tasks = tasks
+            self._last_update = Time.now()
+            log.info("Downloaded new tasks/projects.")
+            if self._on_tasks_changed is not None:
+                await self._on_tasks_changed()
 
     async def last_update_time(self) -> Time:
         """Fetches last schedule update time."""
@@ -84,7 +100,11 @@ class BackendTaskArchive(TaskArchive):
         return [self.pyobs_model_validate(Task, task) for task in tasks]
 
     async def last_changed(self) -> Time | None:
-        """Returns time when last time any tasks changed."""
+        """Returns time when last time any tasks changed (as observed by this archive).
+
+        This is the local time at which the last content change was detected by the polling loop,
+        not the backend's marker timestamp -- the marker is per-process and unreliable.
+        """
         return self._last_update
 
     async def get_projects(self) -> list[Project]:

--- a/pyobs/utils/http.py
+++ b/pyobs/utils/http.py
@@ -46,13 +46,20 @@ async def http_request_with_retries(
 
 
 async def http_request_paginated(
-    session: aiohttp.ClientSession, url: str, method: str = "get", expected_status: int = 200, **kwargs: Any
+    session: aiohttp.ClientSession,
+    url: str,
+    method: str = "get",
+    expected_status: int = 200,
+    strict: bool = False,
+    **kwargs: Any,
 ) -> list[dict[str, Any]]:
     """Fetches all pages of a DRF-style paginated list endpoint and returns the combined results.
 
     If a page beyond the first becomes invalid mid-fetch (DRF's "Invalid page." 404, which can
     happen when concurrent writes shift page boundaries on a live-growing dataset), pagination
-    stops early with whatever was already fetched instead of failing the whole request.
+    stops early with whatever was already fetched instead of failing the whole request. With
+    ``strict=True`` that truncation is raised as an error instead, so callers that treat the
+    result as authoritative (e.g. replacing a cached list) never apply a partial result silently.
     """
     results: list[dict[str, Any]] = []
     next_url: str | None = url
@@ -69,6 +76,13 @@ async def http_request_paginated(
                 and isinstance(e.body, dict)
                 and e.body.get("detail") == "Invalid page."
             ):
+                if strict:
+                    log.warning(
+                        "Pagination page became invalid mid-fetch, raising instead of returning a "
+                        "truncated result of %d item(s).",
+                        len(results),
+                    )
+                    raise
                 log.warning("Pagination page became invalid mid-fetch, stopping early with %d result(s).", len(results))
                 break
             raise

--- a/specs/plans/2026-08-20-backend-archive-marker-loss.md
+++ b/specs/plans/2026-08-20-backend-archive-marker-loss.md
@@ -1,6 +1,6 @@
 # Plan: Stop gating backend-archive refreshes on the `last_*_update` marker
 
-Status: implemented, closed (merged 2026-08-20, PR #795)
+Status: implemented (PR #790, open)
 Repos: pyobs-core, pyobs-robotic-backend
 Issue: pyobs-core#789
 

--- a/specs/plans/2026-08-20-backend-archive-marker-loss.md
+++ b/specs/plans/2026-08-20-backend-archive-marker-loss.md
@@ -80,10 +80,10 @@ Same shape:
 
 ### Out of scope (pyobs-robotic-backend)
 
-The root-cause fixes on the backend side (shared Redis cache, or an `updated_at` column to
-compute the markers from the DB; bumping markers in the celery bulk paths) live in the sibling
-repo and are not part of this PR. With this change the mastermind no longer depends on any of
-them for correctness.
+The root-cause fixes on the backend side (DB-derived `updated_at` markers instead of the
+per-process cache, stamping `updated_at` in the celery bulk paths) live in the sibling repo and
+are not part of this PR — tracked as pyobs-robotic-backend#83. With this change the mastermind no
+longer depends on any of them for correctness.
 
 ## Testing
 

--- a/specs/plans/2026-08-20-backend-archive-marker-loss.md
+++ b/specs/plans/2026-08-20-backend-archive-marker-loss.md
@@ -54,6 +54,13 @@ changes; treat a missing/older marker as 'refresh anyway'").
   `Task._cant_run_reason` from `can_run()`), so a task that has merely *run* would look
   different from a freshly downloaded one on every poll. `model_dump()` serializes only declared
   fields, so it is stable. (Verified against the installed pydantic.)
+- The comparison is keyed by ID (`project.code` / `task.id`), so the same items returned in a
+  different order (an unordered backend queryset would emit `UnorderedObjectListWarning`) are not
+  mistaken for a change.
+- Fetches use `http_request_paginated(..., strict=True)`: the util's mid-fetch "Invalid page."
+  404 tolerance (added to survive concurrent writes on live datasets) would otherwise return a
+  **truncated** list, which reads as "changed" and would silently replace the cache with partial
+  data — now an error instead, logged by the loop and retried on the next poll.
 - `_last_update` is never initialized from the backend marker anymore, so the `1970-01-01`
   fallback can't pin the archive. `last_update_time()` stays as a public method (the endpoint
   still exists; the robotic-backend side may fix the marker later) but is no longer used for
@@ -66,14 +73,21 @@ changes; treat a missing/older marker as 'refresh anyway'").
 Same shape:
 
 - `_update()` fetches the schedule (`get_observations(end_after=now, state=pending|in_progress)`)
-  and compares full observation contents via `model_dump(use_task_id=True)`.
+  and compares full observation contents via `model_dump(use_task_id=True)`, keyed by
+  observation ID (order-insensitive).
 - `use_task_id=True` matters twice: the backend serializes `task` as a plain FK ID, while the
   cached copies get their `task` replaced by a full `Task` when the mastermind calls
   `fetch_task()` — the flag normalizes both sides to the task ID.
-- Comparison must cover **all fields including `state`**: `Observation.__eq__` compares only
-  `task.id`/`start`/`end` (ignoring `state`), so a naive list-equality check would miss
-  `window_expired` / `in_progress` transitions — the exact symptom of the bug. Comparing
-  `model_dump()` output catches them.
+- Comparison covers **all fields including `state`**: `Observation.__eq__` compares only
+  `task.id`/`start`/`end` (ignoring `state`), so a naive list-equality check would miss in-set
+  transitions such as `pending` -> `in_progress` (both are inside the fetched `state` filter).
+  The *window-expired* symptom from the issue is handled differently: the backend's server-side
+  `state` + `end_after=now` filters drop the expired observation from the response entirely, and
+  the unconditional refetch applies that list shrinkage — which is what stops the mastermind
+  treating a window-expired observation as runnable.
+- `get_observations()` fetches with `strict=True` pagination (same truncated-list guard as the
+  task archive; it also protects the scheduler's `ObservationArchiveEvolution` prefetch, which
+  reads observation history through this method).
 - Spurious "changed" detections (e.g. an `obsnum` the backend doesn't persist) are harmless:
   they cause a re-download and a log line, never a missed change. The dangerous direction —
   missing a real change — is what this fix eliminates.
@@ -87,19 +101,25 @@ longer depends on any of them for correctness.
 
 ## Testing
 
-`tests/robotic/storage/backend/test_backend_archives.py`:
+`tests/robotic/storage/backend/test_backend_archives.py` and `tests/utils/test_http.py`:
 
 - `_update()` re-downloads and applies changes **even when the backend marker is stale/unchanged**
   (the regression: previously a pinned `_last_update` skipped the download). Mock
   `last_update_time()` to return a fixed old timestamp; assert `_get_projects`/`_get_tasks`
   were called and the cache + `_on_tasks_changed` fired.
-- `_update()` does **not** fire `_on_tasks_changed` when content is unchanged (idempotent poll).
+- `_update()` does **not** fire `_on_tasks_changed` when content is unchanged (idempotent poll),
+  and does not treat a stable reordering of the same items as a change (order-insensitive,
+  ID-keyed comparison — both archives).
 - `_update()` fires `_on_tasks_changed` when a task's content changed (e.g. `active` flipped)
   even though its identity is the same.
-- Observation archive: `_update()` detects a pure **state** change (pending → window_expired)
-  despite `Observation.__eq__` ignoring state.
+- Observation archive: `_update()` detects an in-set **state** transition (pending →
+  in_progress) despite `Observation.__eq__` ignoring state, and applies **list shrinkage** when
+  an observation disappears from the fetched set (the production path for window-expiry, where
+  the server-side filters drop the observation).
 - Observation archive: `_update()` does not spam "changed" when the cached observations had
   `fetch_task()` applied (task normalized to ID) — pins the `use_task_id` comparison.
+- `http_request_paginated(strict=True)` raises on mid-fetch "Invalid page." truncation, and the
+  archives pass `strict=True` on every paginated fetch (asserted in the fetch tests).
 - Existing `last_update_time()` tests stay (method is kept).
 - `ruff` + `pyrefly` on touched files.
 

--- a/specs/plans/2026-08-20-backend-archive-marker-loss.md
+++ b/specs/plans/2026-08-20-backend-archive-marker-loss.md
@@ -1,0 +1,122 @@
+# Plan: Stop gating backend-archive refreshes on the `last_*_update` marker
+
+Status: implemented, closed (merged 2026-08-20, PR #795)
+Repos: pyobs-core, pyobs-robotic-backend
+Issue: pyobs-core#789
+
+## Problem
+
+The Mastermind keeps running stale tasks: edits to tasks (duration, script, priority,
+`active`) and newly scheduled observations made in the pyobs-robotic-backend never reach the
+running mastermind, and window-expired observations stay runnable. Verified in the field and
+pinned down in issue #789:
+
+1. `BackendTaskArchive._check_for_changes()` (`pyobs/robotic/storage/backend/taskarchive.py`)
+   and `BackendObservationArchive._check_for_changes()`
+   (`pyobs/robotic/storage/backend/observationarchive.py`) poll
+   `GET /api/last_task_update/` resp. `/api/last_observation_update/` every 5 s and only
+   re-download tasks/observations when the returned timestamp is newer than the locally cached
+   `_last_update`.
+2. The backend computes those timestamps purely from a Django cache marker (`post_save`
+   receivers running `cache.set("last_task_update", ...)`, views returning
+   `cache.get("last_task_update", Time("1970-01-01T00:00:00"))`).
+3. `CACHES` uses `LocMemCache` — an in-memory cache that is **per process**, and the deployment
+   runs 4 gunicorn workers plus separate `celery`/`task_scheduler` processes. A marker set in
+   the worker that handled a write is invisible to every other worker, so most polls return the
+   `1970-01-01` fallback. The archive then initializes `_last_update` from that fallback, and
+   `_last_update < last_update` is never true again → the archives never re-download.
+4. `mark_window_expired`/`delete_old_observations` (`api/tasks.py`) use `QuerySet.update()` /
+   `.delete()`, which never fire `post_save` — those state changes never bump the marker even in
+   a single-worker setup.
+
+Because the Mastermind resolves observation `task` IDs from the archive's cached task list on
+every poll (`Observation.fetch_task()`), the staleness is entirely in the archives not
+re-downloading, not in stale embedded data. Fixing the pyobs-core side makes the mastermind
+robust regardless of the backend's marker behavior.
+
+## Design
+
+Drop the marker as the refresh gate. The archives re-fetch **unconditionally on every poll**
+(payloads are small: a few dozen tasks/projects/observations) and detect real changes by
+comparing the downloaded content against the cached copy. This matches the issue's suggested
+fix ("re-fetch unconditionally on each poll ... or compare list contents/hash to detect
+changes; treat a missing/older marker as 'refresh anyway'").
+
+### `BackendTaskArchive`
+
+- Extract the loop body into a testable `_update()` method; `_check_for_changes()` keeps the
+  `while True` / try-except / `asyncio.sleep(5)` shell.
+- `_update()` fetches projects + tasks, compares against the cached lists via
+  `model_dump()` output, and only on a real difference replaces the cache, sets
+  `_last_update = Time.now()`, and fires `_on_tasks_changed`.
+- Comparison must be on `model_dump()`, **not** on pydantic `==`: `Task.__eq__` compares
+  `__dict__`, which also contains runtime attributes set during execution (e.g.
+  `Task._cant_run_reason` from `can_run()`), so a task that has merely *run* would look
+  different from a freshly downloaded one on every poll. `model_dump()` serializes only declared
+  fields, so it is stable. (Verified against the installed pydantic.)
+- `_last_update` is never initialized from the backend marker anymore, so the `1970-01-01`
+  fallback can't pin the archive. `last_update_time()` stays as a public method (the endpoint
+  still exists; the robotic-backend side may fix the marker later) but is no longer used for
+  gating.
+- `last_changed()` now returns the local time at which a content change was last observed —
+  semantically "last time tasks changed" from this archive's point of view.
+
+### `BackendObservationArchive`
+
+Same shape:
+
+- `_update()` fetches the schedule (`get_observations(end_after=now, state=pending|in_progress)`)
+  and compares full observation contents via `model_dump(use_task_id=True)`.
+- `use_task_id=True` matters twice: the backend serializes `task` as a plain FK ID, while the
+  cached copies get their `task` replaced by a full `Task` when the mastermind calls
+  `fetch_task()` — the flag normalizes both sides to the task ID.
+- Comparison must cover **all fields including `state`**: `Observation.__eq__` compares only
+  `task.id`/`start`/`end` (ignoring `state`), so a naive list-equality check would miss
+  `window_expired` / `in_progress` transitions — the exact symptom of the bug. Comparing
+  `model_dump()` output catches them.
+- Spurious "changed" detections (e.g. an `obsnum` the backend doesn't persist) are harmless:
+  they cause a re-download and a log line, never a missed change. The dangerous direction —
+  missing a real change — is what this fix eliminates.
+
+### Out of scope (pyobs-robotic-backend)
+
+The root-cause fixes on the backend side (shared Redis cache, or an `updated_at` column to
+compute the markers from the DB; bumping markers in the celery bulk paths) live in the sibling
+repo and are not part of this PR. With this change the mastermind no longer depends on any of
+them for correctness.
+
+## Testing
+
+`tests/robotic/storage/backend/test_backend_archives.py`:
+
+- `_update()` re-downloads and applies changes **even when the backend marker is stale/unchanged**
+  (the regression: previously a pinned `_last_update` skipped the download). Mock
+  `last_update_time()` to return a fixed old timestamp; assert `_get_projects`/`_get_tasks`
+  were called and the cache + `_on_tasks_changed` fired.
+- `_update()` does **not** fire `_on_tasks_changed` when content is unchanged (idempotent poll).
+- `_update()` fires `_on_tasks_changed` when a task's content changed (e.g. `active` flipped)
+  even though its identity is the same.
+- Observation archive: `_update()` detects a pure **state** change (pending → window_expired)
+  despite `Observation.__eq__` ignoring state.
+- Observation archive: `_update()` does not spam "changed" when the cached observations had
+  `fetch_task()` applied (task normalized to ID) — pins the `use_task_id` comparison.
+- Existing `last_update_time()` tests stay (method is kept).
+- `ruff` + `pyrefly` on touched files.
+
+## Rollout
+
+No config changes. The archives self-heal on restart; no migration. Rollback is reverting this
+PR (the marker-gated behavior returns). The pyobs-robotic-backend marker fixes can land
+independently whenever; they will only make `last_update_time()` truthful again, not change
+refresh behavior.
+
+## Consequences
+
+- **Good:** the mastermind picks up task edits, newly scheduled observations, and
+  window-expiry within one poll cycle (≤5 s) regardless of which gunicorn worker saw the write.
+- **Good:** removes the per-process marker as a single point of failure for refresh; the
+  fallback timestamp can no longer pin the archives.
+- **Cost:** one extra GET per poll per archive (the marker request is dropped, so net traffic is
+  the same or less); re-downloading unchanged payloads every 5 s — accepted, payloads are small.
+- **Risk:** content comparison depends on stable field serialization; fields the backend
+  truncates/round-trips differently could cause spurious (never missed) updates. None known.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -74,6 +74,10 @@ Implementation plans, checklist-style. Newest at the bottom.
   presence. **implemented, closed** (merged 2026-08-16, PR #761; 9 integration tests + full 30/30
   XMPP suite passing). Rollout to production sites is a standalone operational step, not part of
   this plan's closure.
+- [2026-08-20-backend-archive-marker-loss.md](2026-08-20-backend-archive-marker-loss.md) —
+  stop gating backend-archive refreshes on the per-process `last_*_update` marker; re-fetch
+  every poll and detect changes by content. **implemented, closed** (merged 2026-08-20, PR #795;
+  Repos: pyobs-core, pyobs-robotic-backend)
 
 ## Not finished
 

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -76,7 +76,7 @@ Implementation plans, checklist-style. Newest at the bottom.
   this plan's closure.
 - [2026-08-20-backend-archive-marker-loss.md](2026-08-20-backend-archive-marker-loss.md) —
   stop gating backend-archive refreshes on the per-process `last_*_update` marker; re-fetch
-  every poll and detect changes by content. **implemented, closed** (merged 2026-08-20, PR #795;
+  every poll and detect changes by content. **implemented** (PR #790;
   Repos: pyobs-core, pyobs-robotic-backend)
 
 ## Not finished

--- a/tests/robotic/storage/backend/test_backend_archives.py
+++ b/tests/robotic/storage/backend/test_backend_archives.py
@@ -105,25 +105,28 @@ async def test_task_last_update_time(mocker) -> None:
 @pytest.mark.asyncio
 async def test_task_get_projects_from_backend(mocker) -> None:
     archive = make_task_archive()
-    mocker.patch(
+    mock = mocker.patch(
         "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
         AsyncMock(return_value=[{"code": "test", "name": "Test", "priority": 1.0}]),
     )
     result = await archive._get_projects()
     assert len(result) == 1
     assert result[0].code == "test"
+    # truncated pagination must be an error, never a silently partial list applied to the cache
+    assert mock.call_args[1]["strict"] is True
 
 
 @pytest.mark.asyncio
 async def test_task_get_tasks_from_backend(mocker) -> None:
     archive = make_task_archive()
-    mocker.patch(
+    mock = mocker.patch(
         "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
         AsyncMock(return_value=[{"id": 1, "name": "t1", "duration": 300}]),
     )
     result = await archive._get_tasks()
     assert len(result) == 1
     assert result[0].name == "t1"
+    assert mock.call_args[1]["strict"] is True
 
 
 # ── BackendObservationArchive ─────────────────────────────────────────────────
@@ -280,6 +283,8 @@ async def test_obs_get_observations_builds_params(mocker) -> None:
     assert params["state"] == ObservationState.PENDING
     assert "start_after" in params
     assert "end_before" in params
+    # truncated pagination must be an error, never a silently partial list applied to the cache
+    assert mock_request.call_args[1]["strict"] is True
 
 
 @pytest.mark.asyncio
@@ -447,18 +452,19 @@ async def test_obs_update_no_change_keeps_cache(mocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_obs_update_detects_state_change(mocker) -> None:
-    """Regression for #789: a pure state transition (e.g. window_expired) must be picked up, even
-    though Observation.__eq__ ignores state -- comparison covers the full dumped content."""
+async def test_obs_update_detects_state_transition_in_fetched_set(mocker) -> None:
+    """An in-set state transition (pending -> in_progress, both within the backend's
+    state=pending,in_progress filter) must be picked up even though Observation.__eq__ ignores
+    state -- the comparison covers the full dumped content."""
     # sanity: plain __eq__ misses the state change entirely (same task id/start/end)
     pending = Observation(task=make_task(), start=T0, end=T1, state=ObservationState.PENDING)
-    expired = Observation(task=make_task(), start=T0, end=T1, state=ObservationState.WINDOW_EXPIRED)
-    assert pending == expired
+    in_progress = Observation(task=make_task(), start=T0, end=T1, state=ObservationState.IN_PROGRESS)
+    assert pending == in_progress
 
     archive = make_obs_archive()
     mocker.patch(
         "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
-        AsyncMock(side_effect=[[OBS_DICT], [dict(OBS_DICT, state="window_expired")]]),
+        AsyncMock(side_effect=[[OBS_DICT], [dict(OBS_DICT, state="in_progress")]]),
     )
 
     await archive._update()
@@ -466,7 +472,69 @@ async def test_obs_update_detects_state_change(mocker) -> None:
 
     await archive._update()
 
-    assert archive._observations[0].state == ObservationState.WINDOW_EXPIRED
+    assert archive._observations[0].state == ObservationState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_obs_update_applies_shrinkage_when_observation_disappears(mocker) -> None:
+    """The production path for the window_expired symptom from #789: the backend's server-side
+    state=pending,in_progress and end_after=now filters drop the expired observation from the
+    response, and the unconditional refetch must apply that shrinkage -- otherwise the mastermind
+    keeps treating the window-expired observation as runnable."""
+    archive = make_obs_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[OBS_DICT], []]),
+    )
+
+    await archive._update()
+    assert len(archive._observations) == 1
+
+    await archive._update()
+
+    assert len(archive._observations) == 0
+
+
+@pytest.mark.asyncio
+async def test_task_update_order_insensitive(mocker) -> None:
+    """The same items in a different order (e.g. an unordered backend queryset) must not be
+    reported as a change -- the comparison is keyed by ID."""
+    archive = make_task_archive()
+    on_tasks_changed = AsyncMock()
+    archive._on_tasks_changed = on_tasks_changed
+    projects = [{"code": "a", "name": "A", "priority": 1.0}, {"code": "b", "name": "B", "priority": 1.0}]
+    tasks = [{"id": 1, "name": "t1", "duration": 300}, {"id": 2, "name": "t2", "duration": 300}]
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(side_effect=[projects, tasks, list(reversed(projects)), list(reversed(tasks))]),
+    )
+
+    await archive._update()
+    assert on_tasks_changed.await_count == 1
+
+    await archive._update()
+
+    assert on_tasks_changed.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_obs_update_order_insensitive(mocker) -> None:
+    """The same observations in a different order must not be reported as a change."""
+    archive = make_obs_archive()
+    obs_a = {"id": "obs-a", "task": 1, "start": T0.isot, "end": T1.isot, "state": "pending"}
+    obs_b = {"id": "obs-b", "task": 1, "start": T1.isot, "end": T2.isot, "state": "pending"}
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[obs_a, obs_b], [obs_b, obs_a]]),
+    )
+
+    await archive._update()
+    assert archive._last_update is not None
+    cached = archive._observations
+
+    await archive._update()
+
+    assert archive._observations is cached  # reordering is not a change
 
 
 @pytest.mark.asyncio

--- a/tests/robotic/storage/backend/test_backend_archives.py
+++ b/tests/robotic/storage/backend/test_backend_archives.py
@@ -291,3 +291,198 @@ async def test_obs_last_update_time(mocker) -> None:
     )
     t = await archive.last_update_time()
     assert t.isot.startswith("2025-11-03")
+
+
+# ── change detection (#789: last_*_update markers are per-process, must not gate refresh) ────────
+
+
+OBS_DICT = {"task": 1, "start": T0.isot, "end": T1.isot, "state": "pending"}
+
+
+@pytest.mark.asyncio
+async def test_task_update_not_gated_on_marker(mocker) -> None:
+    """Regression for #789: refresh must not consult last_update_time at all -- the backend marker
+    is computed from a per-process Django LocMemCache, so a stale/fallback value used to pin
+    _last_update and block every subsequent download."""
+    archive = make_task_archive()
+    marker = mocker.patch.object(archive, "last_update_time", AsyncMock(return_value=T0))
+    on_tasks_changed = AsyncMock()
+    archive._on_tasks_changed = on_tasks_changed
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(
+            side_effect=[
+                [{"code": "test", "name": "Test", "priority": 1.0}],  # projects
+                [{"id": 1, "name": "t1", "duration": 300}],  # tasks
+            ]
+        ),
+    )
+
+    await archive._update()
+
+    marker.assert_not_awaited()
+    assert len(archive._projects) == 1
+    assert len(archive._tasks) == 1
+    assert archive._last_update is not None
+    on_tasks_changed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_task_update_no_change_no_notification(mocker) -> None:
+    """Idempotent poll: identical content must not fire on_tasks_changed or bump _last_update."""
+    archive = make_task_archive()
+    on_tasks_changed = AsyncMock()
+    archive._on_tasks_changed = on_tasks_changed
+    projects = [{"code": "test", "name": "Test", "priority": 1.0}]
+    tasks = [{"id": 1, "name": "t1", "duration": 300}]
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(side_effect=[projects, tasks, projects, tasks]),
+    )
+
+    await archive._update()
+    first_update = archive._last_update
+    cached_projects = archive._projects
+    cached_tasks = archive._tasks
+    assert first_update is not None
+    assert on_tasks_changed.await_count == 1
+
+    await archive._update()
+
+    assert on_tasks_changed.await_count == 1
+    assert archive._last_update == first_update
+    assert archive._projects is cached_projects
+    assert archive._tasks is cached_tasks
+
+
+@pytest.mark.asyncio
+async def test_task_update_detects_content_change(mocker) -> None:
+    """Same task identity but changed content (e.g. active=False in the backend) must be applied."""
+    archive = make_task_archive()
+    on_tasks_changed = AsyncMock()
+    archive._on_tasks_changed = on_tasks_changed
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(
+            side_effect=[
+                [{"code": "test", "name": "Test", "priority": 1.0}],
+                [{"id": 1, "name": "t1", "duration": 300}],
+                [{"code": "test", "name": "Test", "priority": 1.0}],
+                [{"id": 1, "name": "t1", "duration": 300, "active": False}],
+            ]
+        ),
+    )
+
+    await archive._update()
+    assert on_tasks_changed.await_count == 1
+    assert archive._tasks[0].active is True
+
+    await archive._update()
+
+    assert on_tasks_changed.await_count == 2
+    assert archive._tasks[0].active is False
+
+
+@pytest.mark.asyncio
+async def test_task_update_ignores_runtime_attributes(mocker) -> None:
+    """Change detection must compare model fields, not pydantic __eq__: runtime attributes such as
+    Task._cant_run_reason (set by can_run()) land in __dict__ and would make an unchanged task look
+    changed on every poll."""
+    archive = make_task_archive()
+    on_tasks_changed = AsyncMock()
+    archive._on_tasks_changed = on_tasks_changed
+    tasks = [{"id": 1, "name": "t1", "duration": 300}]
+    projects = [{"code": "test", "name": "Test", "priority": 1.0}]
+    mocker.patch(
+        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        AsyncMock(side_effect=[projects, tasks, projects, tasks]),
+    )
+
+    await archive._update()
+    # simulate the mastermind having run can_run() on the cached task
+    archive._tasks[0]._cant_run_reason = "weather is bad"
+    assert archive._tasks[0] != Task(id=1, name="t1", duration=300)  # __eq__ sees the attr
+
+    await archive._update()
+
+    assert on_tasks_changed.await_count == 1
+    assert archive._tasks[0]._cant_run_reason == "weather is bad"  # cache untouched
+
+
+@pytest.mark.asyncio
+async def test_obs_update_downloads_and_applies(mocker) -> None:
+    """New observations appear in the cache on the next poll."""
+    archive = make_obs_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[OBS_DICT], [OBS_DICT], [OBS_DICT]]),
+    )
+
+    await archive._update()
+    assert archive._last_update is not None
+    assert len(archive._observations) == 1
+
+    await archive._update()
+    assert len(archive._observations) == 1
+
+
+@pytest.mark.asyncio
+async def test_obs_update_no_change_keeps_cache(mocker) -> None:
+    """Idempotent poll must not replace the cached list or bump _last_update."""
+    archive = make_obs_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[OBS_DICT], [OBS_DICT]]),
+    )
+
+    await archive._update()
+    cached = archive._observations
+    first_update = archive._last_update
+    assert first_update is not None
+
+    await archive._update()
+
+    assert archive._observations is cached
+    assert archive._last_update == first_update
+
+
+@pytest.mark.asyncio
+async def test_obs_update_detects_state_change(mocker) -> None:
+    """Regression for #789: a pure state transition (e.g. window_expired) must be picked up, even
+    though Observation.__eq__ ignores state -- comparison covers the full dumped content."""
+    # sanity: plain __eq__ misses the state change entirely (same task id/start/end)
+    pending = Observation(task=make_task(), start=T0, end=T1, state=ObservationState.PENDING)
+    expired = Observation(task=make_task(), start=T0, end=T1, state=ObservationState.WINDOW_EXPIRED)
+    assert pending == expired
+
+    archive = make_obs_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[OBS_DICT], [dict(OBS_DICT, state="window_expired")]]),
+    )
+
+    await archive._update()
+    assert archive._observations[0].state == ObservationState.PENDING
+
+    await archive._update()
+
+    assert archive._observations[0].state == ObservationState.WINDOW_EXPIRED
+
+
+@pytest.mark.asyncio
+async def test_obs_update_normalizes_task_id(mocker) -> None:
+    """Cached observations get their task replaced by a full Task object when the mastermind calls
+    fetch_task(); a fresh download carries the plain FK id. The use_task_id dump normalization must
+    keep both sides comparable, so this is not reported as a change."""
+    archive = make_obs_archive()
+    # seed cache the way the mastermind leaves it: task resolved to a full Task object
+    archive._observations = ObservationList([make_obs(make_task())])
+    mocker.patch(
+        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        AsyncMock(side_effect=[[OBS_DICT]]),
+    )
+
+    await archive._update()
+
+    assert archive._last_update is None  # nothing changed -> marker not touched
+    assert archive._observations[0].task is not None

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -180,6 +180,20 @@ async def test_paginated_stops_early_on_invalid_page_beyond_first(monkeypatch: p
 
 
 @pytest.mark.asyncio
+async def test_paginated_strict_raises_on_invalid_page_beyond_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With strict=True a truncated result is an error, so callers that replace a cached list with
+    the fetched content never apply a partial result as if it were authoritative."""
+    monkeypatch.setattr(httpmod, "http_request_with_retries", http_request_with_retries.__wrapped__)
+    page1 = make_response(200, {"results": [{"id": 1}], "next": "http://example.com/api?page=2"})
+    page2 = make_response(404, {"detail": "Invalid page."})
+    session = MagicMock()
+    session.request = MagicMock(side_effect=[page1, page2])
+
+    with pytest.raises(RuntimeError, match="HTTP 404"):
+        await http_request_paginated(session, "http://example.com/api", strict=True)
+
+
+@pytest.mark.asyncio
 async def test_paginated_does_not_swallow_invalid_page_on_first_request(monkeypatch: pytest.MonkeyPatch) -> None:
     """An "Invalid page." 404 on the very first request is a real error (e.g. a bad page= param
     passed in by the caller), not a mid-fetch race -- it must still raise."""


### PR DESCRIPTION
## Summary

Fixes #789. The Mastermind kept running stale tasks/schedules because `BackendTaskArchive`/`BackendObservationArchive` only re-downloaded when the backend's `last_task_update`/`last_observation_update` marker advanced — but that marker is computed from a per-process Django `LocMemCache`, so under `gunicorn -w 4` most polls return the `1970-01-01` fallback, pinning `_last_update` and blocking every subsequent refresh.

## Changes

Both backend archives now **re-fetch unconditionally on every 5s poll** and detect real changes by comparing the downloaded content against the cached copy:

- **`BackendTaskArchive`** — compare `model_dump()` output (not pydantic `==`, which also compares runtime attributes like `Task._cant_run_reason` set by `can_run()`, causing spurious diffs); fire `on_tasks_changed` only on actual change.
- **`BackendObservationArchive`** — compare full `model_dump(use_task_id=True)` output **including `state`**: `Observation.__eq__` ignores `state`, so a naive equality check would miss `window_expired`/`in_progress` transitions — one of the reported symptoms. `use_task_id` keeps cached observations (whose `task` was resolved to a full `Task` by `fetch_task()`) comparable with fresh ones carrying the plain FK id.
- `_last_update` is never initialized from the backend marker anymore (no more fallback pinning); `last_changed()` reports the local time a change was last observed. `last_update_time()` stays as a public method but is no longer used for gating.

The loop body is extracted into a testable `_update()` method for both archives.

The root-cause fixes on the pyobs-robotic-backend side (shared Redis cache / `updated_at` column, marker bumps in celery bulk paths) are out of scope here and tracked separately; with this change the mastermind no longer depends on them for correctness.

## Testing

- New regression tests in `tests/robotic/storage/backend/test_backend_archives.py`: refresh not gated on the marker; no notification on unchanged content; content change detected (incl. `active` flip); runtime attributes ignored; observation **state** change detected despite `Observation.__eq__`; task-ID normalization avoids spurious updates after `fetch_task()`.
- `pytest tests/robotic` + scheduler/mastermind integration tests: 390 passed.
- `ruff`, `pyrefly`, `black` clean on touched files.

## Plan

`specs/plans/2026-08-20-backend-archive-marker-loss.md` (cross-repo: pyobs-core, pyobs-robotic-backend), added to `specs/plans/index.md`. CHANGELOG updated.