### PR TITLE
Add OBSNUM filter to Archive.list_frames()/list_options()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,11 @@ v2.0.0.dev78 (unreleased)
   dumps, including observation ``state``), firing ``on_tasks_changed`` only when content actually
   changed; ``last_changed()`` now reports the local time a change was last observed. Fixes #789.
   (#790)
+* ``PyobsArchive`` and ``LocalArchive`` gained an ``obsnum`` filter on ``list_frames()`` and
+  ``list_options()``: ``PyobsArchive`` now emits the ``OBSNUM`` query parameter (exact match on
+  ``Frame.OBSNUM``), and ``LocalArchive`` filters its local index on the ``OBSNUM`` FITS header, so
+  observations can be matched to their archived frames via ``list_frames(obsnum=...)``. Needed by
+  pyobs-robotic-backend#82. (#791)
 
 v2.0.0.dev77 (2026-08-16)
 *************************

--- a/pyobs/robotic/utils/archive/archive.py
+++ b/pyobs/robotic/utils/archive/archive.py
@@ -42,6 +42,7 @@ class Archive(PolymorphicBaseModel, metaclass=ABCMeta):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> dict[str, list[Any]]: ...
 
     @abstractmethod
@@ -57,6 +58,7 @@ class Archive(PolymorphicBaseModel, metaclass=ABCMeta):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> list[FrameInfo]: ...
 
     @abstractmethod

--- a/pyobs/robotic/utils/archive/local_archive.py
+++ b/pyobs/robotic/utils/archive/local_archive.py
@@ -48,6 +48,7 @@ class LocalArchive(Archive):
                 "site",
                 "telescope",
                 "rlevel",
+                "obsnum",
             ]
         }
         for filename in filenames:
@@ -61,6 +62,7 @@ class LocalArchive(Archive):
             columns["site"].append(hdr["SITEID"] if "SITEID" in hdr else None)
             columns["telescope"].append(hdr["TELID"] if "TELID" in hdr else None)
             columns["rlevel"].append(hdr["RLEVEL"] if "RLEVEL" in hdr else None)
+            columns["obsnum"].append(str(hdr["OBSNUM"]) if "OBSNUM" in hdr else None)
         columns["filename"] = filenames
         self._data = pd.DataFrame(columns)
 
@@ -76,6 +78,7 @@ class LocalArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> pd.DataFrame:
         data = self._data
         if start is not None:
@@ -98,6 +101,8 @@ class LocalArchive(Archive):
             data = data[data["filter"] == filter_name]
         if rlevel is not None:
             data = data[data["rlevel"] == rlevel]
+        if obsnum is not None:
+            data = data[data["obsnum"] == obsnum]
         return data
 
     async def list_options(
@@ -112,9 +117,10 @@ class LocalArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> dict[str, list[Any]]:
         data = self._filter_data(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel
+            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
         )
         return {
             "binnings": list(data["binning"].unique()),
@@ -137,9 +143,10 @@ class LocalArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> list[FrameInfo]:
         data = self._filter_data(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel
+            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
         )
         infos: list[FrameInfo] = []
         for _, row in data.iterrows():

--- a/pyobs/robotic/utils/archive/pyobs_archive.py
+++ b/pyobs/robotic/utils/archive/pyobs_archive.py
@@ -68,10 +68,11 @@ class PyobsArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> dict[str, list[Any]]:
         url = urllib.parse.urljoin(self.url, "frames/aggregate/")
         params = self._build_query(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel
+            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
         )
         async with aiohttp.ClientSession() as session:
             async with session.get(url, params=params, headers=self._headers, timeout=self._timeout) as response:
@@ -91,10 +92,11 @@ class PyobsArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> list[FrameInfo]:
         url = urllib.parse.urljoin(self.url, "frames/")
         params = self._build_query(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel
+            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
         )
         frames: list[FrameInfo] = []
         params["offset"] = 0
@@ -123,6 +125,7 @@ class PyobsArchive(Archive):
         binning: str | None = None,
         filter_name: str | None = None,
         rlevel: int | None = None,
+        obsnum: str | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {}
         if start is not None:
@@ -145,6 +148,8 @@ class PyobsArchive(Archive):
             params["FILTER"] = filter_name
         if rlevel is not None:
             params["RLEVEL"] = rlevel
+        if obsnum is not None:
+            params["OBSNUM"] = obsnum
         return params
 
     async def download_frames(self, infos: list[FrameInfo]) -> list[Image]:

--- a/tests/robotic/utils/archive/test_local_archive.py
+++ b/tests/robotic/utils/archive/test_local_archive.py
@@ -28,6 +28,7 @@ def make_frame_headers(
     site: str = "siteA",
     telescope: str = "tel1",
     rlevel: int = 91,
+    obsnum: str = "42",
 ) -> dict[str, object]:
     return {
         "DATE-OBS": date_obs,
@@ -40,6 +41,7 @@ def make_frame_headers(
         "SITEID": site,
         "TELID": telescope,
         "RLEVEL": rlevel,
+        "OBSNUM": obsnum,
     }
 
 
@@ -164,6 +166,18 @@ async def test_list_frames_filters_by_night(tmp_path: Path) -> None:
     frames = await archive.list_frames(night="2024-01-02")
 
     assert len(frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_frames_filters_by_obsnum(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(obsnum="42"))
+    write_fits(tmp_path / "b.fits", **make_frame_headers(obsnum="43"))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames(obsnum="43")
+
+    assert len(frames) == 1
+    assert frames[0].filename == str(tmp_path / "b.fits")
 
 
 @pytest.mark.asyncio

--- a/tests/robotic/utils/archive/test_pyobs_archive.py
+++ b/tests/robotic/utils/archive/test_pyobs_archive.py
@@ -95,6 +95,7 @@ def test_build_query_includes_all_given_params() -> None:
         binning="1x1",
         filter_name="clear",
         rlevel=91,
+        obsnum="42",
     )
 
     assert params["night"] == "2024-01-01"
@@ -105,6 +106,7 @@ def test_build_query_includes_all_given_params() -> None:
     assert params["binning"] == "1x1"
     assert params["FILTER"] == "clear"
     assert params["RLEVEL"] == 91
+    assert params["OBSNUM"] == "42"
     assert params["start"] == "2024-01-01T00:00:00.000"
     assert params["end"] == "2024-01-02T00:00:00.000"
 
@@ -135,6 +137,16 @@ async def test_list_options_raises_on_non_200(mocker) -> None:
         await archive.list_options()
 
 
+@pytest.mark.asyncio
+async def test_list_options_passes_obsnum_to_query(mocker) -> None:
+    archive = make_archive()
+    mock_get = mocker.patch("aiohttp.ClientSession.get", return_value=MockResponse(json={}))
+
+    await archive.list_options(obsnum="42")
+
+    assert mock_get.call_args.kwargs["params"]["OBSNUM"] == "42"
+
+
 # ── list_frames ──────────────────────────────────────────────────────────────
 
 
@@ -160,6 +172,17 @@ async def test_list_frames_paginates_across_multiple_pages(mocker) -> None:
     frames = await archive.list_frames()
 
     assert [f.id for f in frames] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_list_frames_passes_obsnum_to_query(mocker) -> None:
+    archive = make_archive()
+    response = MockResponse(json={"results": [make_frame_dict(id=1)], "count": 1})
+    mock_get = mocker.patch("aiohttp.ClientSession.get", return_value=response)
+
+    await archive.list_frames(obsnum="42")
+
+    assert mock_get.call_args.kwargs["params"]["OBSNUM"] == "42"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #791.

## Summary

`PyobsArchive` could not filter frames by observation number: `_build_query()` emitted no `OBSNUM` parameter, even though the pyobs-archive backend (`filter_frames`) supports it (exact match on `Frame.OBSNUM`). Needed by pyobs-robotic-backend#82 to link observations to their archived frames.

## Changes

- `pyobs/robotic/utils/archive/pyobs_archive.py`: `list_frames()`, `list_options()`, and `_build_query()` gained `obsnum: str | None = None`; `_build_query()` now sets `params["OBSNUM"] = obsnum`.
- `pyobs/robotic/utils/archive/local_archive.py`: the local index now reads the `OBSNUM` FITS header (`_update_root()`), `_filter_data()` filters on it, and `list_frames()`/`list_options()` accept and forward `obsnum`.
- `pyobs/robotic/utils/archive/archive.py`: abstract `Archive.list_frames()`/`list_options()` signatures stay consistent.
- Tests: `_build_query(obsnum=...)` emits `OBSNUM`; `list_frames(obsnum=...)`/`list_options(obsnum=...)` pass it through (mocked session); `LocalArchive` filters by `obsnum`.
- CHANGELOG entry.

## Verification

- `ruff check` / `black --check`: clean
- `pytest tests/robotic/utils/archive/`: 40 passed; pipeline/calibration suites using `Archive` stubs: 13 passed
- `pyrefly`: only the 6 pre-existing errors in `test_pyobs_archive.py` (verified identical on clean tree), unrelated to this change

Note: `OBSNUM` values are written to FITS headers by the already-merged #738/#746.