### PR TITLE
Stop ImageWatcher per-file processing from blocking the event loop

### DIFF
--- a/pyobs/modules/image/imagewatcher.py
+++ b/pyobs/modules/image/imagewatcher.py
@@ -176,7 +176,7 @@ class ImageWatcher(Module):
                 try:
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore", fits.verify.VerifyWarning)
-                        fits_file = fits.HDUList.fromstring(data)
+                        fits_file = await asyncio.to_thread(fits.HDUList.fromstring, data)
                 except Exception:
                     fits_file = None
 
@@ -234,6 +234,10 @@ class ImageWatcher(Module):
         """Can be overwritten by derived classes to do extra processing on files.
         All information are stored in self.current_file and can be checked against the given filename.
 
+        Note:
+            This hook runs on the module's event loop and must not block: no CPU-heavy or
+            synchronous I/O here. Offload such work to a thread, e.g. with ``asyncio.to_thread``.
+
         Args:
             filename: Input name of original file.
 
@@ -245,6 +249,10 @@ class ImageWatcher(Module):
     async def cleanup_extra(self, filename: str) -> None:
         """Can be overwritten by derived classes to do clean up after successful copying.
         All information are stored in self.current_file and can be checked against the given filename.
+
+        Note:
+            This hook runs on the module's event loop and must not block: no CPU-heavy or
+            synchronous I/O here. Offload such work to a thread, e.g. with ``asyncio.to_thread``.
 
         Args:
             filename: Input name of original file.

--- a/pyobs/vfs/localfile.py
+++ b/pyobs/vfs/localfile.py
@@ -7,13 +7,53 @@ from typing import IO, Any
 from .file import VFSFile
 
 
+def _open_sync(full_path: str, mode: str, mkdir: bool) -> IO[Any]:
+    """Open a local file, creating parent directories first if needed.
+
+    Runs on an executor thread off the event loop. Raises ``ValueError`` when ``mkdir`` is
+    disabled and the parent directory does not exist.
+    """
+    path = os.path.dirname(full_path)
+    if not os.path.exists(path):
+        if mkdir:
+            os.makedirs(path)
+        else:
+            raise ValueError("Cannot write into sub-directory with disabled mkdir option.")
+    return open(full_path, mode)
+
+
+def _find_sync(full_path: str, pattern: str) -> list[str]:
+    """Walk ``full_path`` and return the paths of files matching ``pattern``, relative to it."""
+    files = []
+    for cur, dirnames, filenames in os.walk(full_path):
+        for filename in fnmatch.filter(filenames, pattern):
+            files += [os.path.relpath(os.path.join(cur, filename), full_path)]
+    return files
+
+
+def _remove_sync(full_path: str) -> bool:
+    """Remove the file at ``full_path``; return False if it does not exist or is a directory."""
+    try:
+        os.remove(full_path)
+        return True
+    except (FileNotFoundError, IsADirectoryError):
+        return False
+
+
 class LocalFile(VFSFile):
-    """Wraps a local file with the virtual file system."""
+    """Wraps a local file with the virtual file system.
+
+    All potentially blocking I/O (open/read/write/close/remove/find/exists) runs on the default
+    executor, keeping the event loop responsive even on slow (e.g. network-mounted) paths.
+    """
 
     __module__ = "pyobs.vfs"
 
     def __init__(self, name: str, mode: str = "r", root: str | None = None, mkdir: bool = True, **kwargs: Any):
-        """Open a local file.
+        """Create a new local file.
+
+        Only validates the path here; the file itself is opened in ``__aenter__`` off the event
+        loop, so construction stays cheap and never blocks.
 
         Args:
             name: Name of file.
@@ -32,27 +72,27 @@ class LocalFile(VFSFile):
 
         # build filename
         self.filename = name
-        full_path = os.path.join(root, name)
+        self._full_path = os.path.join(root, name)
+        self._mode = mode
+        self._mkdir = mkdir
+        self.fd: IO[Any] | None = None
 
-        # need to create directory?
-        path = os.path.dirname(full_path)
-        if not os.path.exists(path):
-            if mkdir:
-                os.makedirs(path)
-            else:
-                raise ValueError("Cannot write into sub-directory with disabled mkdir option.")
-
-        # file object
-        self.fd: IO[Any] = open(full_path, mode)
+    async def __aenter__(self) -> "LocalFile":
+        """Open the file on an executor thread, keeping the event loop responsive."""
+        loop = asyncio.get_running_loop()
+        self.fd = await loop.run_in_executor(None, _open_sync, self._full_path, self._mode, self._mkdir)
+        return self
 
     async def close(self) -> None:
         if self.fd:
-            self.fd.close()
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self.fd.close)
 
     async def read(self, n: int = -1) -> str | bytes:
         if self.fd is None:
             raise OSError
-        buf = self.fd.read(n)
+        loop = asyncio.get_running_loop()
+        buf = await loop.run_in_executor(None, self.fd.read, n)
         if not isinstance(buf, str) and not isinstance(buf, bytes):
             raise OSError
         return buf
@@ -60,7 +100,8 @@ class LocalFile(VFSFile):
     async def write(self, s: str | bytes) -> None:
         if self.fd is None:
             raise OSError
-        self.fd.write(s)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.fd.write, s)
 
     @staticmethod
     async def local_path(path: str, **kwargs: Any) -> str:
@@ -120,12 +161,9 @@ class LocalFile(VFSFile):
         # build full path
         full_path = os.path.join(root, path)
 
-        # loop directories
-        files = []
-        for cur, dirnames, filenames in os.walk(full_path):
-            for filename in fnmatch.filter(filenames, pattern):
-                files += [os.path.relpath(os.path.join(cur, filename), full_path)]
-        return files
+        # walk directories off the event loop
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _find_sync, full_path, pattern)
 
     @staticmethod
     async def remove(path: str, *args: Any, **kwargs: Any) -> bool:
@@ -141,13 +179,10 @@ class LocalFile(VFSFile):
         # get root from kwargs
         root = kwargs["root"]
 
-        # build full path and remove
+        # build full path and remove off the event loop
         full_path = os.path.join(root, path)
-        try:
-            os.remove(full_path)
-            return True
-        except (FileNotFoundError, IsADirectoryError):
-            return False
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _remove_sync, full_path)
 
     @classmethod
     async def exists(cls, path: str, root: str = "", *args: Any, **kwargs: Any) -> bool:
@@ -164,8 +199,9 @@ class LocalFile(VFSFile):
         # build full path
         full_path = os.path.join(root, path)
 
-        # check
-        return os.path.exists(full_path)
+        # check off the event loop
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, os.path.exists, full_path)
 
 
 __all__ = ["LocalFile"]

--- a/pyobs/vfs/localfile.py
+++ b/pyobs/vfs/localfile.py
@@ -16,7 +16,9 @@ def _open_sync(full_path: str, mode: str, mkdir: bool) -> IO[Any]:
     path = os.path.dirname(full_path)
     if not os.path.exists(path):
         if mkdir:
-            os.makedirs(path)
+            # exist_ok: this runs on an executor thread, so concurrent opens into the same new
+            # sibling directory can race between the exists() check and makedirs() here.
+            os.makedirs(path, exist_ok=True)
         else:
             raise ValueError("Cannot write into sub-directory with disabled mkdir option.")
     return open(full_path, mode)
@@ -90,7 +92,7 @@ class LocalFile(VFSFile):
 
     async def read(self, n: int = -1) -> str | bytes:
         if self.fd is None:
-            raise OSError
+            raise OSError("LocalFile is not open; use 'async with' to open it before reading.")
         loop = asyncio.get_running_loop()
         buf = await loop.run_in_executor(None, self.fd.read, n)
         if not isinstance(buf, str) and not isinstance(buf, bytes):
@@ -99,7 +101,7 @@ class LocalFile(VFSFile):
 
     async def write(self, s: str | bytes) -> None:
         if self.fd is None:
-            raise OSError
+            raise OSError("LocalFile is not open; use 'async with' to open it before writing.")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self.fd.write, s)
 

--- a/specs/plans/2026-08-20-imagewatcher-event-loop-blocking.md
+++ b/specs/plans/2026-08-20-imagewatcher-event-loop-blocking.md
@@ -241,18 +241,18 @@ correct regardless, but the measurement is what closes the incident properly.
 
 - [ ] Step 0: at the affected site, capture the exact blocking call once (asyncio debug or
       `py-spy`) — confirm FITS parse and/or `LocalFile` I/O, record baseline stall duration
-- [ ] `imagewatcher.py`: offload `fits.HDUList.fromstring(data)` via `asyncio.to_thread` in
+- [x] `imagewatcher.py`: offload `fits.HDUList.fromstring(data)` via `asyncio.to_thread` in
       `_worker`
-- [ ] `localfile.py`: route `read`, `write`, `close` bodies through `run_in_executor`
-- [ ] `localfile.py`: route `remove`, `exists`, `find` through `run_in_executor` (`remove`/`find`
+- [x] `localfile.py`: route `read`, `write`, `close` bodies through `run_in_executor`
+- [x] `localfile.py`: route `remove`, `exists`, `find` through `run_in_executor` (`remove`/`find`
       bodies extracted as module-level helpers; `exists` calls `os.path.exists` directly)
-- [ ] `localfile.py`: move `open()`/`makedirs` out of `__init__` into an overridden `__aenter__`,
+- [x] `localfile.py`: move `open()`/`makedirs` out of `__init__` into an overridden `__aenter__`,
       routed through `run_in_executor` via a `_open_sync` helper
-- [ ] Docstring note on `ImageWatcher.process_extra`/`cleanup_extra`: subclass hooks run on the
+- [x] Docstring note on `ImageWatcher.process_extra`/`cleanup_extra`: subclass hooks run on the
       event loop and must not block
-- [ ] New heartbeat-style tests in `tests/modules/image/test_imagewatcher.py` and
+- [x] New heartbeat-style tests in `tests/modules/image/test_imagewatcher.py` and
       `tests/vfs/test_localfile.py` (per Tests above)
-- [ ] `pytest tests/modules/image/ tests/vfs/` green; `pyrefly` clean on both touched files
+- [x] `pytest tests/modules/image/ tests/vfs/` green; `pyrefly` clean on both touched files
 - [ ] Deploy to site; confirm `module.py:205/207` stall warnings gone (or below threshold) over
       one night
 - [ ] Update this doc's `Status:` to `implemented` once landed and verified

--- a/tests/modules/image/test_imagewatcher.py
+++ b/tests/modules/image/test_imagewatcher.py
@@ -11,6 +11,7 @@ import pytest
 from astropy.io import fits
 
 from pyobs.comm.dummy import DummyComm
+from pyobs.modules.image import imagewatcher as imagewatcher_module
 from pyobs.modules.image.imagewatcher import ImageWatcher
 from pyobs.vfs import VirtualFileSystem
 
@@ -194,6 +195,57 @@ async def test_worker_requeues_on_write_failure(caplog) -> None:
 
     watcher._vfs.remove.assert_not_called()
     assert "skipping for now" in caplog.text
+
+
+# ── event-loop responsiveness during file processing ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_worker_fits_parse_does_not_block_event_loop(monkeypatch) -> None:
+    """A slow FITS parse must not freeze the loop: offloaded, a heartbeat keeps ticking."""
+    watcher = make_watcher(destinations=["/dest"], wait_time=0)
+    data = b"raw data"
+    read_ctx, write_ctx = make_read_write_ctx(data)
+
+    def open_side_effect(filename, mode):
+        return read_ctx if mode == "rb" else write_ctx
+
+    watcher._vfs.open_file = MagicMock(side_effect=open_side_effect)
+
+    # the file is fully processed once remove (the last step) is reached
+    removed = asyncio.Event()
+    watcher._vfs.remove = AsyncMock(side_effect=lambda path: removed.set())
+
+    # simulate a slow, CPU-heavy FITS parse
+    def slow_fromstring(_data: bytes):
+        time.sleep(0.2)
+        return None
+
+    monkeypatch.setattr(imagewatcher_module.fits.HDUList, "fromstring", staticmethod(slow_fromstring))
+
+    watcher._queue.put_nowait(("/watch/test.fits", 0.0))
+    worker = asyncio.create_task(watcher._worker())
+
+    heartbeats = 0
+
+    async def heartbeat() -> None:
+        nonlocal heartbeats
+        while not removed.is_set():
+            await asyncio.sleep(0.01)
+            heartbeats += 1
+
+    try:
+        await asyncio.wait_for(heartbeat(), timeout=5)
+    finally:
+        worker.cancel()
+        try:
+            await worker
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    # ~0.2s of parse at a 10ms heartbeat cadence: the loop should have kept ticking throughout
+    # if (and only if) the parse was actually offloaded onto a worker thread.
+    assert heartbeats >= 5
 
 
 # ── process_extra / cleanup_extra ─────────────────────────────────────────────

--- a/tests/vfs/test_localfile.py
+++ b/tests/vfs/test_localfile.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -161,3 +162,38 @@ async def test_async_enter_does_not_block_event_loop(monkeypatch, tmp_path: Path
 
     assert heartbeats >= 5
     assert tmp_path.joinpath("test.txt").read_text() == "This is a test"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_opens_creating_same_new_dir(monkeypatch, tmp_path: Path) -> None:
+    """Concurrent opens racing to create the same not-yet-existing sub-directory must not raise.
+
+    __aenter__ moved directory creation onto executor threads, so the exists()/makedirs()
+    check-then-act in _open_sync races for real between threads. A barrier deterministically
+    forces every thread past the exists() check before any calls makedirs(), guaranteeing the
+    race window is hit; regression test for the resulting FileExistsError.
+    """
+    root = str(tmp_path)
+    n = 4
+    target_dir = os.path.join(root, "newdir")
+    barrier = threading.Barrier(n)
+    real_exists = os.path.exists
+
+    def widened_exists(path: str) -> bool:
+        result = real_exists(path)
+        # only synchronize on the exists() checks we're racing; ignore unrelated calls made
+        # concurrently elsewhere in the process (e.g. by asyncio/pytest internals)
+        if not result and path == target_dir:
+            barrier.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(os.path, "exists", widened_exists)
+
+    async def open_write_close(i: int) -> None:
+        async with LocalFile(f"newdir/file{i}.txt", "w", root=root) as f:
+            await f.write("data")
+
+    await asyncio.gather(*(open_write_close(i) for i in range(n)))
+
+    for i in range(n):
+        assert tmp_path.joinpath("newdir", f"file{i}.txt").read_text() == "data"

--- a/tests/vfs/test_localfile.py
+++ b/tests/vfs/test_localfile.py
@@ -1,8 +1,11 @@
+import asyncio
 import os
+import time
 from pathlib import Path
 
 import pytest
 
+import pyobs.vfs.localfile as localfile_module
 from pyobs.vfs import LocalFile
 
 """
@@ -74,3 +77,87 @@ async def test_create_dir(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         async with LocalFile("sub2/test.txt", "w", root=root, mkdir=False) as f:
             await f.write("This is a test")
+
+
+# ── event-loop responsiveness ────────────────────────────────────────────────
+
+
+class SlowFd:
+    """Fake file object whose I/O blocks for a fixed time, simulating slow local disk access."""
+
+    def __init__(self, delay: float = 0.2):
+        self._delay = delay
+
+    def read(self, n: int = -1) -> bytes:
+        time.sleep(self._delay)
+        return b"data"
+
+    def write(self, s: str | bytes) -> None:
+        time.sleep(self._delay)
+
+    def close(self) -> None:
+        pass
+
+
+async def _run_with_heartbeat(coro, interval: float = 0.01):
+    """Runs coro concurrently with a fast heartbeat, returns (coro's result, heartbeat count)."""
+    stop = asyncio.Event()
+    heartbeats = 0
+
+    async def heartbeat() -> None:
+        nonlocal heartbeats
+        while not stop.is_set():
+            await asyncio.sleep(interval)
+            heartbeats += 1
+
+    async def run_and_stop():
+        result = await coro
+        stop.set()
+        return result
+
+    result, _ = await asyncio.gather(run_and_stop(), heartbeat())
+    return result, heartbeats
+
+
+@pytest.mark.asyncio
+async def test_read_does_not_block_event_loop(tmp_path: Path) -> None:
+    """A slow read must not freeze the loop: offloaded, a heartbeat keeps ticking."""
+    async with LocalFile("test.txt", "w", root=str(tmp_path)) as f:
+        f.fd.close()
+        f.fd = SlowFd()
+        data, heartbeats = await _run_with_heartbeat(f.read())
+
+    assert data == b"data"
+    assert heartbeats >= 5
+
+
+@pytest.mark.asyncio
+async def test_write_does_not_block_event_loop(tmp_path: Path) -> None:
+    """A slow write must not freeze the loop: offloaded, a heartbeat keeps ticking."""
+    async with LocalFile("test.txt", "w", root=str(tmp_path)) as f:
+        f.fd.close()
+        f.fd = SlowFd()
+        _, heartbeats = await _run_with_heartbeat(f.write("x"))
+
+    assert heartbeats >= 5
+
+
+@pytest.mark.asyncio
+async def test_async_enter_does_not_block_event_loop(monkeypatch, tmp_path: Path) -> None:
+    """A slow open (e.g. a network-mounted watch path) must not freeze the loop."""
+
+    # simulate a slow file open
+    def slow_open(full_path: str, mode: str, mkdir: bool):
+        time.sleep(0.2)
+        return open(full_path, mode)
+
+    monkeypatch.setattr(localfile_module, "_open_sync", slow_open)
+
+    async def open_write_close():
+        async with LocalFile("test.txt", "w", root=str(tmp_path)) as f:
+            await f.write("This is a test")
+
+    _, heartbeats = await _run_with_heartbeat(open_write_close())
+
+    assert heartbeats >= 5
+    assert tmp_path.joinpath("test.txt").read_text() == "This is a test"


### PR DESCRIPTION
Implements `specs/plans/2026-08-20-imagewatcher-event-loop-blocking.md` (Status stays `proposed` — the plan's own checklist flips it to `implemented` only once landed *and* verified at the site over one night).

## Problem

`ImageWatcher._worker` processes every watched file with synchronous, never-yielding operations directly on the module's single event loop:

1. `fits.HDUList.fromstring(data)` — a synchronous, CPU-bound astropy parse per file.
2. `LocalFile.read` / `write` / `close` / `remove` / `exists` / `find` — declared `async def` but execute plain blocking syscalls with no executor (`listdir` already offloads; the others never got the treatment).
3. `LocalFile.__init__` opens the file synchronously, and `VirtualFileSystem.open_file` has no `await` point before that — so even with read/write/remove offloaded, a slow/network-mounted watch path could still stall the loop at open time.

Result: RPC replies, inotify handling, and comm keepalive freeze for seconds at a time (the 2026-08-20 MONET South incident, `module.py:205/207` "Event loop stalled for 0.81s" / 2.81 s total).

## Changes

- **`pyobs/modules/image/imagewatcher.py`**: offload the FITS parse via `asyncio.to_thread` in `_worker`; add docstring notes that `process_extra`/`cleanup_extra` run on the event loop and must not block.
- **`pyobs/vfs/localfile.py`**: route `read`, `write`, `close`, `remove`, `find`, `exists` through the default executor (module-level `_find_sync`/`_remove_sync` helpers; `exists` calls `os.path.exists` directly), mirroring the existing `listdir` pattern. Move the `open()`/`makedirs` work out of `__init__` into an overridden `__aenter__` via a `_open_sync` helper — path validation still raises synchronously at construction; every call site already uses `async with`, so nothing observes the open moving one step later. All VFS consumers inherit the fix.
- **Tests**: heartbeat-style loop-responsiveness tests in `tests/modules/image/test_imagewatcher.py` (slow FITS parse) and `tests/vfs/test_localfile.py` (slow read/write/open via a fake slow `fd` and a monkeypatched `_open_sync`). Verified they **fail on the old code** and pass on the new.

## Verification

- `pytest tests/modules/image/ tests/vfs/` → 34 passed, 1 skipped (pre-existing SSH-disabled skip).
- Full suite: 1558 passed; the 14 failures are sandbox-environment issues unrelated to this change (read-only `/opt/pyobs/storage`, read-only `~/.config/sunpy`, missing `pyobs` console script in the venv).
- `ruff` clean, `black` clean, `pyrefly` 0 errors on touched files.

## Out of scope (per plan)

Archive upload latency / queue backlog (already async, never freezes the loop) and step 0's live site measurement are flagged for follow-up in the plan.