### PR TITLE
feat(basevideo): shared-token auth with browser login page

### DIFF
--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -172,6 +172,10 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
 
         # define web server
         self._token = token
+        # serializes /login attempts so _LOGIN_FAILURE_SLEEP actually caps the guess rate;
+        # without it, concurrent connections each sleep independently and the rate scales
+        # with concurrency instead of being capped
+        self._login_lock = asyncio.Lock()
         self._app = web.Application()
         routes = [web.get("/ping", self.ping_handler), web.get("/{filename}", self.image_handler)]
         if self._video_path is not None:
@@ -221,6 +225,23 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         """Whether the server is started."""
         return self._is_listening
 
+    def _sign(self, expiry: int) -> str:
+        """HMAC-SHA256 of ``expiry``, keyed with the configured token, as a hex digest.
+
+        Shared by _make_session_value (signs) and _check_cookie (verifies), so the two can't
+        drift apart on hash algo/encoding.
+
+        Args:
+            expiry: Session expiry timestamp being signed.
+
+        Returns:
+            Hex-encoded HMAC signature.
+        """
+        token = self._token
+        if token is None:
+            raise ValueError("Cannot sign a session without a configured token.")
+        return hmac.new(token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
+
     def _make_session_value(self) -> str:
         """Build the value for the login session cookie.
 
@@ -231,14 +252,13 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             Cookie value.
         """
-        token = self._token
-        assert token is not None  # only called from login_post_handler, registered only with a token
         expiry = int(time.time()) + _COOKIE_LIFETIME
-        signature = hmac.new(token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
-        return f"{expiry}.{signature}"
+        return f"{expiry}.{self._sign(expiry)}"
 
     def _check_bearer(self, request: web.Request) -> bool:
         """Whether the request carries the token as "Authorization: Bearer <token>".
+
+        Only called (via _check_auth) once a token is configured.
 
         Args:
             request: Request to check.
@@ -246,16 +266,16 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             True if the header matches the configured token.
         """
-        if self._token is None:
-            return True
         prefix = "Bearer "
         header = request.headers.get("Authorization", "")
         if not header.startswith(prefix):
             return False
-        return hmac.compare_digest(header[len(prefix) :], self._token)
+        return hmac.compare_digest(header[len(prefix) :], self._token or "")
 
     def _check_cookie(self, request: web.Request) -> bool:
         """Whether the request carries a valid, unexpired session cookie.
+
+        Only called (via _check_auth) once a token is configured.
 
         Args:
             request: Request to check.
@@ -263,8 +283,6 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             True if the cookie's HMAC signature verifies and it has not expired.
         """
-        if self._token is None:
-            return True
         value = request.cookies.get(_COOKIE_NAME)
         if value is None:
             return False
@@ -275,8 +293,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             return False
         if expiry < time.time():
             return False
-        expected = hmac.new(self._token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
-        return hmac.compare_digest(signature, expected)
+        return hmac.compare_digest(signature, self._sign(expiry))
 
     def _check_auth(self, request: web.Request) -> None:
         """Raises HTTPUnauthorized if a token is configured and the request doesn't carry it.
@@ -336,10 +353,13 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             raise web.HTTPUnauthorized()
         data = await request.post()
         password = str(data.get("token", ""))
-        if not hmac.compare_digest(password, token):
-            # the compare above is constant-time; this sleep additionally slows brute force
-            await asyncio.sleep(_LOGIN_FAILURE_SLEEP)
-            raise web.HTTPUnauthorized()
+        async with self._login_lock:
+            # serialized: caps the guess rate at 1/_LOGIN_FAILURE_SLEEP regardless of how many
+            # connections attempt concurrently
+            if not hmac.compare_digest(password, token):
+                # the compare above is constant-time; this sleep additionally slows brute force
+                await asyncio.sleep(_LOGIN_FAILURE_SLEEP)
+                raise web.HTTPUnauthorized()
         response = web.HTTPSeeOther("/")
         response.set_cookie(
             _COOKIE_NAME,

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import hmac
 import io
 import json
 import logging
@@ -39,6 +41,12 @@ INDEX_HTML = """
 
 """
 
+# session cookie for browser login (see _check_auth); only used when a token is configured
+_COOKIE_NAME = "pyobs_video_session"
+_COOKIE_LIFETIME = 24 * 60 * 60  # 24 h, in seconds
+# delay on a wrong login password, to slow brute force (compare is constant-time either way)
+_LOGIN_FAILURE_SLEEP = 1.0
+
 
 async def calc_expose_timeout(webcam: IExposureTime, *args: Any, **kwargs: Any) -> float:
     """Calculates timeout for grabe_image()."""
@@ -71,7 +79,14 @@ class LastImage(NamedTuple):
 
 
 class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCMeta):
-    """Base class for all webcam modules."""
+    """Base class for all webcam modules.
+
+    The built-in HTTP server serves the MJPEG live view, the raw frame stream and cached FITS
+    images. Set the ``token`` parameter to protect all of them: machine clients send
+    ``Authorization: Bearer <token>`` (as :class:`pyobs.vfs.HttpFile` does), browsers log in once
+    at ``/login`` and get an HMAC-signed session cookie that rides the same-origin ``<img>``
+    requests. Without a token (the default), no auth is enforced.
+    """
 
     __module__ = "pyobs.modules.camera"
 
@@ -90,6 +105,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         flip: bool = False,
         sleep_time: int = 60,
         fits_header_timeout: float = 15.0,
+        token: str | None = None,
         **kwargs: Any,
     ):
         """Creates a new BaseWebcam.
@@ -112,6 +128,8 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             flip: Whether to flip around Y axis.
             sleep_time: Time in s with inactivity after which the camera should go to sleep.
             fits_header_timeout: Maximum seconds to wait for a peer's FITS headers before skipping them.
+            token: Shared secret required in the "Authorization: Bearer <token>" header (or a
+                login-page cookie) for stream and data access. If None (default), no auth is enforced.
         """
         super().__init__(
             fits_namespaces=fits_namespaces,
@@ -153,12 +171,19 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self._cache = DataCache(cache_size)
 
         # define web server
+        self._token = token
         self._app = web.Application()
         routes = [web.get("/ping", self.ping_handler), web.get("/{filename}", self.image_handler)]
         if self._video_path is not None:
             routes += [web.get("/", self.web_handler), web.get("/video.mjpg", self.video_handler)]
         if self._raw_path is not None:
             routes.append(web.get("/video.raw", self.raw_handler))
+        if self._token is not None:
+            routes += [
+                web.get("/login", self.login_handler),
+                web.post("/login", self.login_post_handler),
+                web.get("/logout", self.logout_handler),
+            ]
         self._app.add_routes(routes)
         self._runner = web.AppRunner(self._app)
         self._site: web.TCPSite | None = None
@@ -196,6 +221,149 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         """Whether the server is started."""
         return self._is_listening
 
+    def _make_session_value(self) -> str:
+        """Build the value for the login session cookie.
+
+        Stateless and HMAC-signed -- the cookie does not contain the token itself:
+
+        ``value = "{expiry_ts}.{hex}"`` where ``hex = HMAC-SHA256(key=token, msg=str(expiry_ts))``
+
+        Returns:
+            Cookie value.
+        """
+        token = self._token
+        assert token is not None  # only called from login_post_handler, registered only with a token
+        expiry = int(time.time()) + _COOKIE_LIFETIME
+        signature = hmac.new(token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
+        return f"{expiry}.{signature}"
+
+    def _check_bearer(self, request: web.Request) -> bool:
+        """Whether the request carries the token as "Authorization: Bearer <token>".
+
+        Args:
+            request: Request to check.
+
+        Returns:
+            True if the header matches the configured token.
+        """
+        if self._token is None:
+            return True
+        prefix = "Bearer "
+        header = request.headers.get("Authorization", "")
+        if not header.startswith(prefix):
+            return False
+        return hmac.compare_digest(header[len(prefix) :], self._token)
+
+    def _check_cookie(self, request: web.Request) -> bool:
+        """Whether the request carries a valid, unexpired session cookie.
+
+        Args:
+            request: Request to check.
+
+        Returns:
+            True if the cookie's HMAC signature verifies and it has not expired.
+        """
+        if self._token is None:
+            return True
+        value = request.cookies.get(_COOKIE_NAME)
+        if value is None:
+            return False
+        try:
+            expiry_str, signature = value.rsplit(".", 1)
+            expiry = int(expiry_str)
+        except ValueError:
+            return False
+        if expiry < time.time():
+            return False
+        expected = hmac.new(self._token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(signature, expected)
+
+    def _check_auth(self, request: web.Request) -> None:
+        """Raises HTTPUnauthorized if a token is configured and the request doesn't carry it.
+
+        Accepts either a valid "Authorization: Bearer <token>" header or a valid session cookie.
+        No-op when no token is configured. Same contract as HttpFileCache._check_auth: the
+        exception type is identical regardless of which handler called it.
+
+        Args:
+            request: Request to check.
+        """
+        if self._token is None:
+            return
+        if not (self._check_bearer(request) or self._check_cookie(request)):
+            raise web.HTTPUnauthorized()
+
+    async def login_handler(self, request: web.Request) -> web.Response:
+        """Handles GET access to /login and returns the login form.
+
+        Served unauthenticated: this is the bootstrap a browser needs, since it cannot attach an
+        "Authorization" header to an <img> request. Only registered when a token is configured.
+
+        Args:
+            request: Request to respond to.
+
+        Returns:
+            Response containing the login form.
+        """
+        html = """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+  </head>
+  <body>
+    <form method="post" action="/login">
+      <label>Password: <input type="password" name="token" autofocus></label>
+      <button type="submit">Login</button>
+    </form>
+  </body>
+</html>
+"""
+        return web.Response(text=html, content_type="text/html")
+
+    async def login_post_handler(self, request: web.Request) -> web.Response:
+        """Handles POST access to /login, verifying the password and issuing the session cookie.
+
+        Args:
+            request: Request to respond to.
+
+        Returns:
+            303 redirect to / on success, 401 on wrong password.
+        """
+        token = self._token
+        if token is None:
+            # login routes are only registered when a token is configured -- defensive
+            raise web.HTTPUnauthorized()
+        data = await request.post()
+        password = str(data.get("token", ""))
+        if not hmac.compare_digest(password, token):
+            # the compare above is constant-time; this sleep additionally slows brute force
+            await asyncio.sleep(_LOGIN_FAILURE_SLEEP)
+            raise web.HTTPUnauthorized()
+        response = web.HTTPSeeOther("/")
+        response.set_cookie(
+            _COOKIE_NAME,
+            self._make_session_value(),
+            max_age=_COOKIE_LIFETIME,
+            path="/",
+            httponly=True,
+            samesite="Lax",
+        )
+        return response
+
+    async def logout_handler(self, request: web.Request) -> web.Response:
+        """Handles GET access to /logout and clears the session cookie.
+
+        Args:
+            request: Request to respond to.
+
+        Returns:
+            303 redirect to /login.
+        """
+        response = web.HTTPSeeOther("/login")
+        response.del_cookie(_COOKIE_NAME, path="/")
+        return response
+
     async def web_handler(self, request: web.Request) -> web.Response:
         """Handles access to / and returns HTML page.
 
@@ -205,6 +373,11 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             Response containing web page.
         """
+        # a browser landing on / should be taken to the login form, not shown a bare 401
+        try:
+            self._check_auth(request)
+        except web.HTTPUnauthorized:
+            raise web.HTTPSeeOther("/login")
         return web.Response(text=INDEX_HTML, content_type="text/html")
 
     async def ping_handler(self, request: web.Request) -> web.Response:
@@ -227,6 +400,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             Response containing video stream.
         """
+        self._check_auth(request)
 
         # create response
         response = web.StreamResponse()
@@ -273,6 +447,8 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             Response containing raw frame stream.
         """
+        # auth first: an unauthenticated request must not wake the camera
+        self._check_auth(request)
 
         # activate camera
         await self.activate_camera()
@@ -368,6 +544,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         Returns:
             Response containing image.
         """
+        self._check_auth(request)
 
         # get filename
         filename = request.match_info["filename"]

--- a/pyobs/vfs/httpfile.py
+++ b/pyobs/vfs/httpfile.py
@@ -78,6 +78,11 @@ class HttpFile(BufferedFile):
             raise ValueError("No download URL given.")
         return urljoin(self._download_path, self.filename)
 
+    @property
+    def headers(self) -> dict[str, str]:
+        """Headers sent with GET/POST requests, e.g. "Authorization: Bearer <token>"."""
+        return self._headers
+
     async def _download(self) -> None:
         """For read access, download the file into a local buffer.
 

--- a/pyobs/vfs/httpfile.py
+++ b/pyobs/vfs/httpfile.py
@@ -80,8 +80,11 @@ class HttpFile(BufferedFile):
 
     @property
     def headers(self) -> dict[str, str]:
-        """Headers sent with GET/POST requests, e.g. "Authorization: Bearer <token>"."""
-        return self._headers
+        """Headers sent with GET/POST requests, e.g. "Authorization: Bearer <token>".
+
+        Returns a copy; mutating it does not affect this instance's headers.
+        """
+        return dict(self._headers)
 
     async def _download(self) -> None:
         """For read access, download the file into a local buffer.

--- a/specs/design/basevideo-http-auth.md
+++ b/specs/design/basevideo-http-auth.md
@@ -1,6 +1,7 @@
 # `BaseVideo`: shared-token auth with a browser login page
 
-Status: proposed
+Status: implemented (see `specs/plans/2026-08-21-basevideo-http-token-auth.md` for the landing
+checklist)
 
 Repos: pyobs-core (this doc, implementation), pyobs-gui (consumer change)
 

--- a/specs/design/index.md
+++ b/specs/design/index.md
@@ -4,7 +4,7 @@ Living architecture/design docs, one per feature or subsystem. Kept around after
 (`status: implemented`), not deleted.
 
 - [basevideo-http-auth.md](basevideo-http-auth.md) — shared-token auth + browser login
-  page for `BaseVideo`'s HTTP endpoints. *proposed* (Repos: pyobs-core, pyobs-gui)
+  page for `BaseVideo`'s HTTP endpoints. *implemented* (Repos: pyobs-core, pyobs-gui)
 - [basevideo-raw-frame-streaming.md](basevideo-raw-frame-streaming.md) — `BaseVideo` raw-frame
   streaming endpoint alongside the existing MJPEG live view. *implemented*
 - [exception_handling.md](exception_handling.md) — exception handling across the RPC boundary.

--- a/specs/plans/2026-08-21-basevideo-http-token-auth.md
+++ b/specs/plans/2026-08-21-basevideo-http-token-auth.md
@@ -1,6 +1,11 @@
 # Plan: shared-token auth + browser login for `BaseVideo`
 
-Status: proposed
+Status: implemented, closed. Verified against code 2026-08-21: `token` param, HMAC-signed
+session cookie, `/login`/`/logout` routes, and `_check_auth` in
+`pyobs/modules/camera/basevideo.py`; `headers` property in `pyobs/vfs/httpfile.py`; covered by
+`tests/modules/camera/test_basevideo.py` and `tests/vfs/test_httpfile.py`. The pyobs-gui half
+(`pyobs_gui/videowidget.py` + `tests/test_videowidget.py`) lands in its own PR on
+`pyobs/pyobs-gui` — both PRs must merge together (see Consequences).
 
 Design: `specs/design/basevideo-http-auth.md`
 
@@ -23,20 +28,20 @@ page + cookie for the `<img>`-based index page to keep working.
 
 ### pyobs-core — `pyobs/modules/camera/basevideo.py`
 
-- [ ] Add `token: str | None = None` to `__init__` (`basevideo.py:78-94`), store
+- [x] Add `token: str | None = None` to `__init__` (`basevideo.py:78-94`), store
       `self._token`. Docstring entry mirroring `HttpFileCache`'s: "Shared secret required
       in the `Authorization: Bearer <token>` header (or a login-page cookie) for stream
       and data access. If `None` (default), no auth is enforced."
-- [ ] Add cookie constants (name e.g. `pyobs_video_session`, lifetime 24 h) and helpers:
+- [x] Add cookie constants (name e.g. `pyobs_video_session`, lifetime 24 h) and helpers:
       `_make_session_value() -> str` (expiry + HMAC-SHA256 over `str(expiry)` keyed with
       the token), `_check_bearer(request) -> bool`, `_check_cookie(request) -> bool`,
       `_check_auth(request)` (raises `HTTPUnauthorized` unless either passes; no-op when
       `self._token is None`). Constant-time compares via `hmac.compare_digest`
       everywhere — same as `HttpFileCache._check_auth` (`httpfilecache.py:82-93`).
-- [ ] Register `/login` (GET + POST) and `/logout` (GET) routes **only when
+- [x] Register `/login` (GET + POST) and `/logout` (GET) routes **only when
       `self._token is not None`**, alongside the existing conditional registration of
       `/video.mjpg`/`/video.raw` (`basevideo.py:158-161`).
-- [ ] Implement the three handlers:
+- [x] Implement the three handlers:
       - `login_handler` — GET: minimal HTML form (one password input, POST to `/login`),
         served unauthenticated.
       - `login_post_handler` — POST: `await request.post()`, compare form field with
@@ -44,32 +49,32 @@ page + cookie for the `<img>`-based index page to keep working.
         max_age=lifetime, path="/", httponly=True, samesite="Lax")` + `303 See Other
         → /`. Failure: `401` (optional small `asyncio.sleep` delay against brute force).
       - `logout_handler` — GET: `del_cookie(name, path="/")` + `303 → /login`.
-- [ ] Call `_check_auth(request)` at the top of `video_handler` (`:221`), `raw_handler`
+- [x] Call `_check_auth(request)` at the top of `video_handler` (`:221`), `raw_handler`
       (`:267`), and `image_handler` (`:362`), letting its `HTTPUnauthorized` propagate
       unchanged. `web_handler` (`:199`) is the exception: it wraps the call in
       `try/except web.HTTPUnauthorized: raise web.HTTPSeeOther("/login")` so a browser
       landing on `/` reaches the login form instead of a bare 401 — `_check_auth` itself
       always raises the same exception regardless of caller, it has no per-handler
       behavior.
-- [ ] Confirm ordering in the streaming handlers: auth check runs before
+- [x] Confirm ordering in the streaming handlers: auth check runs before
       `response.prepare(request)` (`:234`, `:283`) and before `activate_camera()` in
       `raw_handler` (`:278`) — an unauthenticated request must not wake the camera.
-- [ ] `INDEX_HTML` (`:28-40`) unchanged — the cookie rides the same-origin `<img>`
+- [x] `INDEX_HTML` (`:28-40`) unchanged — the cookie rides the same-origin `<img>`
       request automatically.
-- [ ] Update the class docstring (webcam VFS note) with a sentence on token/login.
+- [x] Update the class docstring (webcam VFS note) with a sentence on token/login.
 
 ### pyobs-core — `pyobs/vfs/httpfile.py`
 
-- [ ] Add a public read-only `headers` property returning `self._headers` (`:50`), so
+- [x] Add a public read-only `headers` property returning `self._headers` (`:50`), so
       pyobs-gui doesn't reach into the private attribute. (No behavior change; existing
       callers unaffected.)
 
 ### pyobs-gui — `pyobs_gui/videowidget.py`
 
-- [ ] In `_init`, after the `HttpFile` type check (`:140`), store
+- [x] In `_init`, after the `HttpFile` type check (`:140`), store
       `self._auth_header = video_file.headers.get("Authorization")` (None when the VFS
       root configures no token).
-- [ ] In `_showEvent`, append `Authorization: <value>\r\n` to the raw-socket GET when
+- [x] In `_showEvent`, append `Authorization: <value>\r\n` to the raw-socket GET when
       `self._auth_header` is set (`:206-208`). When unset, bytes written are unchanged.
 
 ## Testing
@@ -80,27 +85,27 @@ Existing unit style: direct handler invocation, mocked
 `pyobs.modules.camera.basevideo.web.StreamResponse`, `_route_paths()` helper
 (`test_basevideo.py:509`). No aiohttp TestClient in the repo — keep it that way.
 
-- [ ] `token=None` (default): `/login`/`/logout` not registered; all handlers accept
+- [x] `token=None` (default): `/login`/`/logout` not registered; all handlers accept
       unauthenticated requests — existing tests unchanged.
-- [ ] `token` set: `_route_paths` includes `/login`; `/` unauthenticated → `303` to
+- [x] `token` set: `_route_paths` includes `/login`; `/` unauthenticated → `303` to
       `/login` (not a bare `401` — confirms `web_handler`'s `HTTPUnauthorized` →
       `HTTPSeeOther` translation); `/video.mjpg`, `/video.raw`, `/{filename}`
       unauthenticated → `401`; `/ping` → `200`.
-- [ ] Bearer header: correct `Authorization: Bearer <token>` → `200`; wrong token →
+- [x] Bearer header: correct `Authorization: Bearer <token>` → `200`; wrong token →
       `401`.
-- [ ] Login POST: correct token → response carries `Set-Cookie` + `303`; wrong token →
+- [x] Login POST: correct token → response carries `Set-Cookie` + `303`; wrong token →
       `401`.
-- [ ] Cookie: valid cookie → `200` on `/` and stream endpoints; tampered cookie →
+- [x] Cookie: valid cookie → `200` on `/` and stream endpoints; tampered cookie →
       `401`; expired cookie (expiry in the past) → `401`; after `/logout` → `401`.
-- [ ] `raw_handler` with a bad/missing credential raises `401` **without** calling
+- [x] `raw_handler` with a bad/missing credential raises `401` **without** calling
       `activate_camera()` (mock it, assert not called).
-- [ ] Streaming handlers: `401` raised before `StreamResponse.prepare()` is reached.
+- [x] Streaming handlers: `401` raised before `StreamResponse.prepare()` is reached.
 
 ### pyobs-gui — `tests/test_videowidget.py`
 
-- [ ] With an `HttpFile` carrying a token, the bytes written to the (mocked) socket
+- [x] With an `HttpFile` carrying a token, the bytes written to the (mocked) socket
       include `Authorization: Bearer <token>`.
-- [ ] Without a token, the written GET bytes are unchanged from today.
+- [x] Without a token, the written GET bytes are unchanged from today.
 
 ## Explicitly out of scope
 

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -118,7 +118,7 @@ Implementation plans, checklist-style. Newest at the bottom.
   **proposed** (MONET South incident, 2026-08-20)
 - [2026-08-21-basevideo-http-token-auth.md](2026-08-21-basevideo-http-token-auth.md) —
   shared-token auth + browser login page for `BaseVideo`'s HTTP endpoints (design:
-  `specs/design/basevideo-http-auth.md`). **proposed** (Repos: pyobs-core, pyobs-gui)
+  `specs/design/basevideo-http-auth.md`). **implemented, closed** (Repos: pyobs-core, pyobs-gui)
 - [2026-08-21-keycloak-idp-hint-login.md](2026-08-21-keycloak-idp-hint-login.md) — one-click IdP
   login via `kc_idp_hint`: `IDP_HINT` support in pyobs-auth + dual login buttons (hinted IdP vs.
   local Keycloak account) in the services' login pages. **proposed** (Repos: pyobs-auth,

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -903,6 +903,20 @@ async def test_cookie_rejects_value_signed_with_other_token() -> None:
 
 
 @pytest.mark.asyncio
+async def test_login_handler_serves_form_without_authentication() -> None:
+    bv = make_basevideo(token="secret")
+
+    # no Authorization header, no session cookie -- must still succeed, since this is the
+    # bootstrap page an unauthenticated browser needs before it can obtain a session
+    response = await bv.login_handler(make_request())
+
+    assert response.status == 200
+    assert response.content_type == "text/html"
+    assert "form" in response.text
+    assert 'action="/login"' in response.text
+
+
+@pytest.mark.asyncio
 async def test_login_post_correct_token_sets_cookie_and_redirects() -> None:
     bv = make_basevideo(token="secret")
     request = make_request()
@@ -928,6 +942,30 @@ async def test_login_post_wrong_token_returns_401(mocker) -> None:
 
     with pytest.raises(web.HTTPUnauthorized):
         await bv.login_post_handler(request)
+
+
+@pytest.mark.asyncio
+async def test_login_post_serializes_concurrent_failed_attempts(mocker) -> None:
+    # regression test: concurrent failed attempts must be serialized through the sleep, so the
+    # guess rate is capped regardless of concurrency -- not each sleeping independently in parallel
+    mocker.patch("pyobs.modules.camera.basevideo._LOGIN_FAILURE_SLEEP", 0.05)
+    bv = make_basevideo(token="secret")
+
+    def make_wrong_request():
+        request = make_request()
+        request.post = AsyncMock(return_value={"token": "wrong"})
+        return request
+
+    start = time.monotonic()
+    results = await asyncio.gather(
+        bv.login_post_handler(make_wrong_request()),
+        bv.login_post_handler(make_wrong_request()),
+        return_exceptions=True,
+    )
+    elapsed = time.monotonic() - start
+
+    assert all(isinstance(r, web.HTTPUnauthorized) for r in results)
+    assert elapsed >= 0.09  # ~2x the sleep; would be ~0.05s if the two ran in parallel
 
 
 @pytest.mark.asyncio

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
+from aiohttp import web
 
 from pyobs.comm import Comm
 from pyobs.events import NewImageEvent
 from pyobs.interfaces import IImageType, IVideo
 from pyobs.modules import Module
-from pyobs.modules.camera.basevideo import BaseVideo, ImageRequest, LastImage, NextImage
+from pyobs.modules.camera.basevideo import _COOKIE_NAME, BaseVideo, ImageRequest, LastImage, NextImage
 from pyobs.utils import exceptions as exc
 from pyobs.utils.enums import ImageType
 
@@ -21,9 +25,15 @@ def make_basevideo(**kwargs) -> BaseVideo:
     return BaseVideo(comm=comm, **kwargs)
 
 
-def make_request(filename: str | None = None) -> MagicMock:
+def make_request(
+    filename: str | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> MagicMock:
     request = MagicMock()
     request.match_info = {} if filename is None else {"filename": filename}
+    request.headers = headers or {}
+    request.cookies = cookies or {}
     return request
 
 
@@ -141,8 +151,6 @@ async def test_image_handler_returns_cached_data() -> None:
 
 @pytest.mark.asyncio
 async def test_image_handler_404_when_missing() -> None:
-    from aiohttp import web
-
     bv = make_basevideo()
     with pytest.raises(web.HTTPNotFound):
         await bv.image_handler(make_request("missing.fits"))
@@ -640,3 +648,305 @@ async def test_raw_handler_touches_activity_without_new_frame(mocker) -> None:
     assert activate_calls >= 2
     assert response.write.await_count == 1
     assert bv.camera_active is True
+
+
+# ── token auth ─────────────────────────────────────────────────────────────
+
+
+def _session_value(token: str, expiry: int | None = None) -> str:
+    """Build a valid session-cookie value for the given token (mirror of BaseVideo._make_session_value)."""
+    expiry = int(time.time()) + 24 * 60 * 60 if expiry is None else expiry
+    signature = hmac.new(token.encode(), str(expiry).encode(), hashlib.sha256).hexdigest()
+    return f"{expiry}.{signature}"
+
+
+# route registration gating
+
+
+def test_token_param_stored() -> None:
+    bv = make_basevideo(token="secret")
+    assert bv._token == "secret"
+
+
+def test_login_routes_not_registered_without_token() -> None:
+    bv = make_basevideo()
+    paths = _route_paths(bv)
+    assert "/login" not in paths
+    assert "/logout" not in paths
+
+
+def test_login_routes_registered_with_token() -> None:
+    bv = make_basevideo(token="secret")
+    paths = _route_paths(bv)
+    assert "/login" in paths
+    assert "/logout" in paths
+
+
+# _check_auth
+
+
+def test_check_auth_noop_without_token() -> None:
+    bv = make_basevideo()
+    bv._check_auth(make_request())  # must not raise
+
+
+def test_check_auth_raises_without_credentials() -> None:
+    bv = make_basevideo(token="secret")
+    with pytest.raises(web.HTTPUnauthorized):
+        bv._check_auth(make_request())
+
+
+def test_check_auth_accepts_bearer_and_cookie() -> None:
+    bv = make_basevideo(token="secret")
+    bv._check_auth(make_request(headers={"Authorization": "Bearer secret"}))  # must not raise
+    bv._check_auth(make_request(cookies={_COOKIE_NAME: _session_value("secret")}))  # must not raise
+
+
+def test_make_session_value_roundtrips_through_check_cookie() -> None:
+    bv = make_basevideo(token="secret")
+    assert bv._check_cookie(make_request(cookies={_COOKIE_NAME: bv._make_session_value()})) is True
+
+
+# web_handler: unauthenticated browser gets a redirect to the login page, not a bare 401
+
+
+@pytest.mark.asyncio
+async def test_web_handler_redirects_to_login_when_unauthenticated() -> None:
+    bv = make_basevideo(token="secret")
+    with pytest.raises(web.HTTPSeeOther) as exc:
+        await bv.web_handler(make_request())
+    assert exc.value.location == "/login"
+
+
+@pytest.mark.asyncio
+async def test_web_handler_accepts_valid_bearer() -> None:
+    bv = make_basevideo(token="secret")
+    response = await bv.web_handler(make_request(headers={"Authorization": "Bearer secret"}))
+    assert response.status == 200
+    assert response.content_type == "text/html"
+
+
+@pytest.mark.asyncio
+async def test_web_handler_accepts_valid_cookie() -> None:
+    bv = make_basevideo(token="secret")
+    response = await bv.web_handler(make_request(cookies={_COOKIE_NAME: _session_value("secret")}))
+    assert response.status == 200
+
+
+# streaming handlers: 401 raised before StreamResponse.prepare() is reached
+
+
+@pytest.mark.asyncio
+async def test_video_handler_401_without_auth_before_prepare(mocker) -> None:
+    bv = make_basevideo(token="secret")
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.video_handler(make_request())
+
+    response.prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_video_handler_401_with_bad_token_before_prepare(mocker) -> None:
+    bv = make_basevideo(token="secret")
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.video_handler(make_request(headers={"Authorization": "Bearer wrong"}))
+
+    response.prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_video_handler_accepts_valid_bearer(mocker) -> None:
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    bv = make_basevideo(token="secret")
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    response.write = AsyncMock(side_effect=ClientConnectionResetError())
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+    bv.image_jpeg = AsyncMock(return_value=(1, b"jpeg-bytes"))
+
+    await bv.video_handler(make_request(headers={"Authorization": "Bearer secret"}))
+
+    # auth passed: the stream was prepared and one frame written before the client reset
+    response.prepare.assert_awaited_once()
+    assert response.write.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_video_handler_accepts_valid_cookie(mocker) -> None:
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    bv = make_basevideo(token="secret")
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    response.write = AsyncMock(side_effect=ClientConnectionResetError())
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+    bv.image_jpeg = AsyncMock(return_value=(1, b"jpeg-bytes"))
+
+    await bv.video_handler(make_request(cookies={_COOKIE_NAME: _session_value("secret")}))
+
+    response.prepare.assert_awaited_once()
+    assert response.write.await_count == 1
+
+
+# raw_handler: unauthenticated requests must not wake the camera
+
+
+@pytest.mark.asyncio
+async def test_raw_handler_401_without_auth_does_not_activate_camera() -> None:
+    bv = make_basevideo(token="secret")
+    bv.activate_camera = AsyncMock()
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.raw_handler(make_request())
+
+    bv.activate_camera.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_handler_401_with_bad_token_does_not_activate_camera() -> None:
+    bv = make_basevideo(token="secret")
+    bv.activate_camera = AsyncMock()
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.raw_handler(make_request(headers={"Authorization": "Bearer wrong"}))
+
+    bv.activate_camera.assert_not_awaited()
+
+
+# image_handler
+
+
+@pytest.mark.asyncio
+async def test_image_handler_401_without_auth() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.image_handler(make_request("test.fits"))
+
+
+@pytest.mark.asyncio
+async def test_image_handler_401_with_wrong_token() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.image_handler(make_request("test.fits", headers={"Authorization": "Bearer wrong"}))
+
+
+@pytest.mark.asyncio
+async def test_image_handler_accepts_valid_bearer() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    response = await bv.image_handler(make_request("test.fits", headers={"Authorization": "Bearer secret"}))
+
+    assert response.status == 200
+    assert response.body == b"fits-bytes"
+
+
+@pytest.mark.asyncio
+async def test_image_handler_accepts_valid_cookie() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    response = await bv.image_handler(make_request("test.fits", cookies={_COOKIE_NAME: _session_value("secret")}))
+
+    assert response.status == 200
+    assert response.body == b"fits-bytes"
+
+
+# cookies: tampering, expiry, cross-token signature
+
+
+@pytest.mark.asyncio
+async def test_cookie_rejects_tampered_signature() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+    value = _session_value("secret")
+    tampered = value[:-1] + ("0" if value[-1] != "0" else "1")
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.image_handler(make_request("test.fits", cookies={_COOKIE_NAME: tampered}))
+
+
+@pytest.mark.asyncio
+async def test_cookie_rejects_expired_value() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.image_handler(
+            make_request("test.fits", cookies={_COOKIE_NAME: _session_value("secret", expiry=int(time.time()) - 3600)})
+        )
+
+
+@pytest.mark.asyncio
+async def test_cookie_rejects_value_signed_with_other_token() -> None:
+    bv = make_basevideo(token="secret")
+    bv._cache["test.fits"] = b"fits-bytes"
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.image_handler(make_request("test.fits", cookies={_COOKIE_NAME: _session_value("other-token")}))
+
+
+# login / logout
+
+
+@pytest.mark.asyncio
+async def test_login_post_correct_token_sets_cookie_and_redirects() -> None:
+    bv = make_basevideo(token="secret")
+    request = make_request()
+    request.post = AsyncMock(return_value={"token": "secret"})
+
+    response = await bv.login_post_handler(request)
+
+    assert response.status == 303
+    assert response.headers["Location"] == "/"
+    cookie = response._cookies[_COOKIE_NAME]
+    assert cookie["max-age"] == str(24 * 60 * 60)
+    assert cookie["path"] == "/"
+    assert cookie["httponly"] is True
+    assert cookie["samesite"] == "Lax"
+
+
+@pytest.mark.asyncio
+async def test_login_post_wrong_token_returns_401(mocker) -> None:
+    bv = make_basevideo(token="secret")
+    request = make_request()
+    request.post = AsyncMock(return_value={"token": "wrong"})
+    mocker.patch("pyobs.modules.camera.basevideo.asyncio.sleep", AsyncMock())
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await bv.login_post_handler(request)
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_cookie_and_redirects_to_login() -> None:
+    bv = make_basevideo(token="secret")
+
+    response = await bv.logout_handler(make_request())
+
+    assert response.status == 303
+    assert response.headers["Location"] == "/login"
+    cookie = response._cookies[_COOKIE_NAME]
+    assert cookie["max-age"] == "0"
+
+
+# ping stays open
+
+
+@pytest.mark.asyncio
+async def test_ping_handler_stays_open_with_token() -> None:
+    bv = make_basevideo(token="secret")
+    response = await bv.ping_handler(make_request())
+    assert response.status == 200

--- a/tests/vfs/test_httpfile.py
+++ b/tests/vfs/test_httpfile.py
@@ -76,3 +76,13 @@ async def test_download_without_token_sends_no_auth_header() -> None:
 
     _, get_kwargs = session.get.call_args
     assert get_kwargs["headers"] == {}
+
+
+def test_headers_property_returns_configured_headers() -> None:
+    f = HttpFile("test.txt", "r", download="http://localhost:37075/test.txt", token="secret")
+    assert f.headers == {"Authorization": "Bearer secret"}
+
+
+def test_headers_property_empty_without_token() -> None:
+    f = HttpFile("test.txt", "r", download="http://localhost:37075/test.txt")
+    assert f.headers == {}


### PR DESCRIPTION
Implements `specs/plans/2026-08-21-basevideo-http-token-auth.md` (server-side half).

## What

Adds an opt-in `token: str | None = None` parameter to `BaseVideo` (`pyobs/modules/camera/basevideo.py`). When set, all content endpoints (`/`, `/video.mjpg`, `/video.raw`, `/{filename}`) require either `Authorization: Bearer <token>` or a valid HMAC-signed session cookie:

- `_check_auth(request)` — same contract as `HttpFileCache._check_auth`: no-op without a token, otherwise `401` unless Bearer header or cookie verifies; constant-time compares (`hmac.compare_digest`) throughout.
- Cookie is stateless: `"<expiry_ts>.<hex HMAC-SHA256(key=token, msg=str(expiry_ts))>"`, 24 h lifetime, `HttpOnly`, `SameSite=Lax`, `path=/`. Rotating the token invalidates all cookies at once.
- `/login` (GET form + POST verify, `303` + cookie on success, `401` after a short delay on failure) and `/logout` (clears cookie, `303 → /login`) — registered **only** when a token is configured.
- `web_handler` translates the `401` into `303 → /login` so a browser landing on `/` reaches the login form; the streaming handlers check auth before `response.prepare()`, and `raw_handler` before `activate_camera()` (unauthenticated requests never wake the camera). `/ping` stays open.

`HttpFile` gains a public read-only `headers` property (`pyobs/vfs/httpfile.py`) so consumers don't reach into `_headers`.

## Tests

`tests/modules/camera/test_basevideo.py` (unit style, no TestClient): route gating, `401`/`303` behavior per endpoint, Bearer accept/reject, login POST success/failure, cookie accept / tampered / expired / cross-token rejection, logout clearing, `raw_handler` not activating the camera on bad credentials, `401` raised before `StreamResponse.prepare()`. `tests/vfs/test_httpfile.py` covers the `headers` property. `token=None` default behavior unchanged (existing tests untouched).

## ⚠️ Coupling — land both halves together

- **This PR** (pyobs-core): server-side implementation + `HttpFile.headers`.
- **Companion PR** `pyobs/pyobs-gui` (same feature branch name, one consumer change): `VideoWidget` now sends the `Authorization` header on its raw-socket MJPEG GET.

With `token` set, the GUI live view breaks until the pyobs-gui half lands — merge both PRs together.

Out of scope (per plan): CORS for `BaseVideo` endpoints, per-user accounts/Keycloak, other unauthenticated HTTP servers, browser page features beyond the login form.