### PR TITLE
Dedupe per-frame header/JSON build in BaseVideo raw_handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,11 @@ v2.0.0.dev78 (unreleased)
 *************************
 * ``BaseVideo.raw_handler`` now caches the per-frame ``(meta, frame)`` bytes it builds
   (header assembly, JSON serialization, ``ascontiguousarray``/``tobytes()`` copy), keyed by
-  ``_frame_num``. With N simultaneous raw clients (guiding, a recorder, a viewer -- see
-  ``specs/design/basevideo-raw-frame-streaming.md``), only the first consumer to wake for a
-  given frame does the work; the rest reuse the cached result instead of redoing it (#769).
-  Costs nothing with 0 or 1 raw clients connected.
+  ``_frame_num``. With N simultaneous raw clients (guiding, a recorder, a viewer -- a case
+  the raw endpoint (``specs/design/basevideo-raw-frame-streaming.md``) already supports but
+  didn't dedupe for), only the first consumer to wake for a given frame does the work; the
+  rest reuse the cached result instead of redoing it (#769). Costs nothing with 0 or 1 raw
+  clients connected.
 * ``Application`` now logs module-creation failures (unconsumed config keys, broken ``__init__``
   chains, ...) at ERROR level with the full traceback before re-raising, so they land in the
   configured log file / journald instead of only on stderr -- which is ``/dev/null`` for

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 v2.0.0.dev78 (unreleased)
 *************************
+* ``BaseVideo.raw_handler`` now caches the per-frame ``(meta, frame)`` bytes it builds
+  (header assembly, JSON serialization, ``ascontiguousarray``/``tobytes()`` copy), keyed by
+  ``_frame_num``. With N simultaneous raw clients (guiding, a recorder, a viewer -- see
+  ``specs/design/basevideo-raw-frame-streaming.md``), only the first consumer to wake for a
+  given frame does the work; the rest reuse the cached result instead of redoing it (#769).
+  Costs nothing with 0 or 1 raw clients connected.
 * ``Application`` now logs module-creation failures (unconsumed config keys, broken ``__init__``
   chains, ...) at ERROR level with the full traceback before re-raising, so they land in the
   configured log file / journald instead of only on stderr -- which is ``/dev/null`` for

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -154,6 +154,10 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
         self._image_requests: list[ImageRequest] = []
         self._next_image: NextImage | None = None
         self._last_image: LastImage | None = None
+        # lazy per-frame cache for raw_handler: the first of N simultaneous raw
+        # consumers to wake for a given frame computes (meta, frame) bytes and the
+        # rest reuse it, instead of each redoing the header build/JSON/copy (#769)
+        self._raw_frame_cache: tuple[int, bytes, bytes] | None = None
         self._last_time = 0.0
         self._flip = flip
         # 60s is a starting point, not measured -- trades off against _activate_camera()/
@@ -500,8 +504,16 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             if last is None:
                 continue
 
-            # build frame bytes (JSON meta header + raw little-endian bytes)
-            meta, frame = self._raw_frame(last.data, last.date_obs)
+            # build frame bytes (JSON meta header + raw little-endian bytes), reusing
+            # the cached result if another consumer already built this frame -- safe
+            # without a lock since _raw_frame() is synchronous, so no other task can
+            # interleave between the cache check and the store (design doc §769)
+            cached = self._raw_frame_cache
+            if cached is not None and cached[0] == self._frame_num:
+                _, meta, frame = cached
+            else:
+                meta, frame = self._raw_frame(last.data, last.date_obs)
+                self._raw_frame_cache = (self._frame_num, meta, frame)
 
             # now send it!
             try:

--- a/pyobs/modules/camera/basevideo.py
+++ b/pyobs/modules/camera/basevideo.py
@@ -507,7 +507,7 @@ class BaseVideo(Module, ImageFitsHeaderMixin, IVideo, IImageType, metaclass=ABCM
             # build frame bytes (JSON meta header + raw little-endian bytes), reusing
             # the cached result if another consumer already built this frame -- safe
             # without a lock since _raw_frame() is synchronous, so no other task can
-            # interleave between the cache check and the store (design doc §769)
+            # interleave between the cache check and the store (#769)
             cached = self._raw_frame_cache
             if cached is not None and cached[0] == self._frame_num:
                 _, meta, frame = cached

--- a/tests/modules/camera/test_basevideo.py
+++ b/tests/modules/camera/test_basevideo.py
@@ -650,6 +650,66 @@ async def test_raw_handler_touches_activity_without_new_frame(mocker) -> None:
     assert bv.camera_active is True
 
 
+@pytest.mark.asyncio
+async def test_raw_handler_dedupes_frame_build_across_consumers(mocker) -> None:
+    # two simultaneous raw clients waking for the *same* frame must not each pay for
+    # the header build/JSON serialization/tobytes() copy -- only the first computes
+    # it, the second reuses the cached (meta, frame) bytes (#769). Both handlers are
+    # started while genuinely blocked on the (unset) event, so a single set() wakes
+    # both in the same batch -- mirrors Event.wait()'s real coalescing behavior,
+    # unlike calling raw_handler() while the event happens to already be set.
+    bv = make_basevideo()
+    await bv._set_image(np.zeros((4, 4), dtype=np.uint16))
+    bv._new_frame.clear()
+
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    responses = []
+
+    def make_response(*args, **kwargs) -> MagicMock:
+        response = MagicMock()
+        response.prepare = AsyncMock()
+        response.write = AsyncMock(side_effect=ClientConnectionResetError())
+        responses.append(response)
+        return response
+
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", side_effect=make_response)
+    raw_frame_spy = mocker.spy(bv, "_raw_frame")
+
+    task1 = asyncio.create_task(bv.raw_handler(make_request()))
+    task2 = asyncio.create_task(bv.raw_handler(make_request()))
+    await asyncio.sleep(0)  # let both tasks reach the event wait and actually suspend
+
+    await bv._set_image(np.ones((4, 4), dtype=np.uint16))  # single wake -> both proceed
+
+    await asyncio.wait_for(asyncio.gather(task1, task2), timeout=2)
+
+    assert raw_frame_spy.call_count == 1
+    assert len(responses) == 2
+    assert responses[0].write.await_args.args == responses[1].write.await_args.args
+
+
+@pytest.mark.asyncio
+async def test_raw_handler_recomputes_after_new_frame(mocker) -> None:
+    # the cache must not serve stale bytes once a new frame has arrived
+    bv = make_basevideo()
+    await bv._set_image(np.zeros((4, 4), dtype=np.uint16))
+
+    from aiohttp.client_exceptions import ClientConnectionResetError
+
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    response.write = AsyncMock(side_effect=ClientConnectionResetError())
+    mocker.patch("pyobs.modules.camera.basevideo.web.StreamResponse", return_value=response)
+    raw_frame_spy = mocker.spy(bv, "_raw_frame")
+
+    await bv.raw_handler(make_request())
+    await bv._set_image(np.ones((4, 4), dtype=np.uint16))
+    await bv.raw_handler(make_request())
+
+    assert raw_frame_spy.call_count == 2
+
+
 # ── token auth ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Closes #769: with N simultaneous raw clients, each connection's own `raw_handler` task independently rebuilt the header, JSON meta, and raw bytes for the same frame.
- Adds a lazy per-frame cache keyed by `_frame_num`: the first handler to wake for a frame computes and caches `(meta, frame)` bytes; later handlers waking for the same frame reuse it instead of recomputing.
- `_raw_frame()` is fully synchronous, so no other task can interleave between the cache check and the store — no lock needed.
- Costs nothing with 0 or 1 raw clients connected, matching the "costs nothing when no raw client is connected" property in `specs/design/basevideo-raw-frame-streaming.md` §1.

## Test plan
- [x] `pytest tests/modules/camera/test_basevideo.py` — 72 passed, including two new tests: dedup across two concurrently-woken consumers on the same frame, and recompute after a new frame arrives.
- [x] Full suite: 1570 passed, 25 skipped (7 pre-existing unrelated failures in `tests/cli/test_pyobsd.py`, confirmed present on `develop` without this change — environment lacks the `pyobs` executable).
- [x] `ruff check`, `black --check`, `pyrefly check` all clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fnu6xv2jcUfFKVgEbgqTae