### PR TITLE
Tag Script module-name fields with required pyobs.interfaces via Annotated

### DIFF
--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pyobs.interfaces import (
     IBinning,
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class DarkBiasScript(Script):
     """Script for running darks or biases."""
 
-    camera: str
+    camera: Annotated[str, IData, IBinning, IWindow, IExposureTime, IImageType]
     count: int = 20
     exptime: float = 0
     binning: tuple[int, int] = (1, 1)

--- a/pyobs/robotic/scripts/calibration/pointing.py
+++ b/pyobs/robotic/scripts/calibration/pointing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pyobs.interfaces import IPointingAltAz, IReady
 from pyobs.robotic.scripts import Script
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class PointingScript(Script):
     """Script for pointing the telescope for flats."""
 
-    telescope: str
+    telescope: Annotated[str, IPointingAltAz, IReady]
     pointing: SkyFlatsBasePointing
 
     async def can_run(self, data: TaskData | None) -> bool:

--- a/pyobs/robotic/scripts/calibration/skyflats.py
+++ b/pyobs/robotic/scripts/calibration/skyflats.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pyobs.interfaces import IBinning, IFilters, IFlatField, IReady, IRoof, ITelescope
 from pyobs.robotic.scripts import Script
@@ -21,9 +21,9 @@ FlatFunctions = str | dict[str, str | dict[str, str]]
 class SkyFlatsScript(Script):
     """Script for scheduling and running skyflats using an IFlatField module."""
 
-    roof: str
-    telescope: str
-    flatfield: str
+    roof: Annotated[str, IRoof]
+    telescope: Annotated[str, ITelescope]
+    flatfield: Annotated[str, IBinning, IFilters, IFlatField]
     functions: FlatFunctions = {}
     priorities: SkyflatPriorities
     min_exptime: float = 0.5

--- a/pyobs/robotic/scripts/control/selector.py
+++ b/pyobs/robotic/scripts/control/selector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pyobs.interfaces import IMotion
 from pyobs.interfaces.IMode import IMode
@@ -19,7 +19,7 @@ class SelectorScript(Script):
     """Script for running Mode Selection."""
 
     mode: str
-    selector: str
+    selector: Annotated[str, IMode, IMotion]
 
     async def can_run(self, data: TaskData | None) -> bool:
         """Whether this config can currently run.

--- a/pyobs/robotic/scripts/imaging/autofocus.py
+++ b/pyobs/robotic/scripts/imaging/autofocus.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from pyobs.interfaces import IAutoFocus, IMotion, IPointingRaDec, IReady, ITelescope
 from pyobs.robotic.scripts import Script
@@ -16,8 +16,8 @@ log = logging.getLogger(__name__)
 class AutoFocusScript(Script):
     """Script for running autofocus series."""
 
-    autofocus: str = "autofocus"
-    telescope: str = "telescope"
+    autofocus: Annotated[str, IAutoFocus] = "autofocus"
+    telescope: Annotated[str, ITelescope, IPointingRaDec] = "telescope"
     count: int = 5
     step: float = 0.1
     exposure_time: float = 2.0

--- a/pyobs/robotic/scripts/imaging/imaging.py
+++ b/pyobs/robotic/scripts/imaging/imaging.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
@@ -80,11 +80,11 @@ class ImagingScript(Script):
 
     configuration: Configuration = Field(default_factory=Configuration)
 
-    camera: str
-    telescope: str | None = None
-    filters: str | None = None
-    autoguider: str | None = None
-    acquisition: str | None = None
+    camera: Annotated[str, ICamera, IBinning, IWindow, IExposureTime, IImageType]
+    telescope: Annotated[str | None, ITelescope, IPointingRaDec] = None
+    filters: Annotated[str | None, IFilters] = None
+    autoguider: Annotated[str | None, IAutoGuiding] = None
+    acquisition: Annotated[str | None, IAcquisition] = None
 
     _object_name: str | None = PrivateAttr(default=None)
 

--- a/specs/plans/2026-08-24-script-field-interface-annotations.md
+++ b/specs/plans/2026-08-24-script-field-interface-annotations.md
@@ -1,7 +1,7 @@
 # Plan: Tag `Script` module-name fields with required `pyobs.interfaces` via `Annotated`
 
-Status: planned. Tracks github.com/pyobs/pyobs-core#808 (requested by
-pyobs/pyobs-robotic-backend#98).
+Status: implemented, PR open. Tracks github.com/pyobs/pyobs-core#808 (requested by
+pyobs/pyobs-robotic-backend#98). PR #809 opened and approved, not yet merged.
 
 ## Problem
 
@@ -26,7 +26,8 @@ camera: Annotated[str, ICamera]
 telescope: Annotated[str | None, ITelescope] = None
 ```
 
-Confirmed against pydantic 2.13.4 (the version this repo pins): arbitrary classes placed in
+Confirmed against pydantic 2.13.4 (what this repo's lockfile resolves to; `pyproject.toml` pins
+`>=2.12.5`): arbitrary classes placed in
 `Annotated` are accepted without validation and preserved in `FieldInfo.metadata`
 (`cls.model_fields["camera"].metadata`) for a consumer to introspect. This changes nothing about
 validation or runtime behavior — fields keep behaving exactly as plain `str`/`str | None` today.
@@ -89,25 +90,20 @@ the issue — `.interface` is a dynamic FQCN string chosen by the caller, not a 
 
 ## Implementation checklist
 
-- [ ] `pyobs/robotic/scripts/imaging/imaging.py` — import `Annotated`; tag all five module-name
-      fields (`camera`, `telescope`, `filters`, `autoguider`, `acquisition`) with `Annotated`,
-      including `filters`/`autoguider`/`acquisition` even though each is already single-interface
-      and unchanged from the issue's table (`IFilters`, `IAutoGuiding`, `IAcquisition`
-      respectively) — converted for consistency within the class rather than mixing tagged and
-      untagged module-name fields on the same model
-- [ ] `pyobs/robotic/scripts/calibration/darkbias.py` — tag `camera`
-- [ ] `pyobs/robotic/scripts/calibration/pointing.py` — tag `telescope`
-- [ ] `pyobs/robotic/scripts/imaging/autofocus.py` — tag `telescope`, `autofocus`
-- [ ] `pyobs/robotic/scripts/calibration/skyflats.py` — tag `roof`, `telescope`, `flatfield`
-- [ ] `pyobs/robotic/scripts/control/selector.py` — tag `selector` only, leave `mode` as plain `str`
-- [ ] Add a unit test (new or extending an existing `tests/robotic/scripts/test_*.py`) asserting
-      `cls.model_fields["camera"].metadata == [ICamera, IBinning, IWindow, IExposureTime,
-      IImageType]` (or equivalent) for at least one multi-interface field and one single-interface
-      field, to lock in the `Annotated` metadata shape pyobs-robotic-backend will read
-- [ ] `pyrefly` clean (not mypy — see `CLAUDE.md`)
-- [ ] Confirm no runtime/validation behavior changed: existing script tests
-      (`tests/robotic/scripts/test_imaging.py`, `test_darkbias.py`, `test_autofocus.py`,
-      `test_control.py`) pass unmodified
-- [ ] Post the corrected audit table (this doc) as a comment on #808 before implementing, since it
-      changes four entries from the issue's original table — give a chance to object before code
-      lands
+- [x] `pyobs/robotic/scripts/imaging/imaging.py` — tagged all five module-name fields (`camera`,
+      `telescope`, `filters`, `autoguider`, `acquisition`) with `Annotated`, including
+      `filters`/`autoguider`/`acquisition` for consistency even though each is single-interface and
+      unchanged from the issue's table
+- [x] `pyobs/robotic/scripts/calibration/darkbias.py` — tagged `camera`
+- [x] `pyobs/robotic/scripts/calibration/pointing.py` — tagged `telescope`
+- [x] `pyobs/robotic/scripts/imaging/autofocus.py` — tagged `telescope`, `autofocus`
+- [x] `pyobs/robotic/scripts/calibration/skyflats.py` — tagged `roof`, `telescope`, `flatfield`
+- [x] `pyobs/robotic/scripts/control/selector.py` — tagged `selector` only, `mode` left as plain `str`
+- [x] Added `tests/robotic/scripts/test_field_interface_annotations.py` — 9 tests asserting the
+      exact `Annotated` metadata for every tagged field across all 6 script classes
+- [x] `pyrefly check` clean on all changed files
+- [x] Confirmed no runtime/validation behavior changed: full non-integration suite passes (1585
+      passed, 1 pre-existing unrelated failure confirmed identical on `develop`)
+- [x] Posted the corrected audit table as a comment on #808 before implementing:
+      github.com/pyobs/pyobs-core/issues/808#issuecomment-5394604012
+- [x] PR #809 opened, reviewed (approved) — not yet merged

--- a/specs/plans/2026-08-24-script-field-interface-annotations.md
+++ b/specs/plans/2026-08-24-script-field-interface-annotations.md
@@ -1,0 +1,113 @@
+# Plan: Tag `Script` module-name fields with required `pyobs.interfaces` via `Annotated`
+
+Status: planned. Tracks github.com/pyobs/pyobs-core#808 (requested by
+pyobs/pyobs-robotic-backend#98).
+
+## Problem
+
+Module-name fields on `Script` subclasses (`ImagingScript.camera`, `.telescope`, etc.) are plain
+`str`/`str | None`, with no machine-readable signal for which `pyobs.interfaces` interface the
+referenced module must implement. That requirement exists only implicitly, in each script's
+`run()`/`can_run()` code, as literal interface classes passed to
+`self.comm.proxy(...)`/`has_proxy(...)`/`safe_proxy(...)`.
+
+pyobs-robotic-backend wants to render these fields as dropdowns of the modules actually configured
+on a site, filtered to only those implementing the right interface. Doing that today would need a
+hand-maintained table in pyobs-robotic-backend duplicating what's already implicit in this repo's
+`run()` code, with no way to detect drift when a script's interface requirements change here.
+
+## Approach
+
+Tag each module-name field with the interface(s) it requires via `typing.Annotated`, using the
+real interface class(es) as metadata:
+
+```python
+camera: Annotated[str, ICamera]
+telescope: Annotated[str | None, ITelescope] = None
+```
+
+Confirmed against pydantic 2.13.4 (the version this repo pins): arbitrary classes placed in
+`Annotated` are accepted without validation and preserved in `FieldInfo.metadata`
+(`cls.model_fields["camera"].metadata`) for a consumer to introspect. This changes nothing about
+validation or runtime behavior — fields keep behaving exactly as plain `str`/`str | None` today.
+No JSON Schema / dropdown / UI concerns belong in this repo; that's entirely
+pyobs-robotic-backend's job downstream of this metadata.
+
+## Tagging rule (resolves the issue's "open question")
+
+Include an interface in a field's `Annotated` tag only if the field is passed as the `obj_type` to
+an actual `self.comm.proxy()` / `safe_proxy()` / `has_proxy()` call somewhere in that class.
+
+Two categories are excluded even though they show up when grepping for interface names near a
+field:
+
+1. **`get_state(X)` calls on an already-typed proxy.** E.g. `ImagingScript.can_run` does
+   `safe_proxy(self.telescope, ITelescope)` and then `telescope.get_state(IReady)` on that same
+   object — `IReady` here is a cached-state read, not a requirement that the module implement
+   `IReady` as a proxy type (the code already handles `ready_state is None` gracefully). It's also
+   structurally redundant: `ITelescope → IMotion → IReady`, so anything already required to
+   implement `ITelescope` implements `IReady` by inheritance anyway.
+2. **An interface already implied by another interface in the same field's tag**, via the
+   interface's own Python inheritance — even if that interface *was* reached through a genuine
+   `proxy()`/`safe_proxy()` call. E.g. `AutoFocusScript.run()` does
+   `safe_proxy(self.telescope, IMotion)` for `stop_motion()`, a real proxy call — but `ITelescope`
+   is already required on that same field and `ITelescope → IMotion`, so tagging `IMotion`
+   separately adds no filtering information.
+
+This is **not** a blanket "drop anything reachable via `get_state`" rule — `PointingScript.telescope`
+does `self.comm.proxy(self.telescope, IReady)` as a genuine, separate proxy call (not
+`get_state()` on an already-`IPointingAltAz`-typed object), and `IPointingAltAz` does not inherit
+`IReady`, so that one is a real, non-redundant requirement and stays tagged.
+
+## Corrected field audit
+
+Re-auditing every `run()`/`can_run()` against the rule above turned up four discrepancies against
+the issue's own table — two omissions on `ImagingScript`, and two more (`SkyFlatsScript.flatfield`,
+`SelectorScript.selector`) found while re-verifying the other fields with the same method. All four
+are fields where the issue's table listed a real "must implement" interface as absent, which would
+have under-tagged the field relative to what the code actually requires.
+
+| Class | Field | Tag | Note |
+|---|---|---|---|
+| `ImagingScript` | `camera` | `Annotated[str, ICamera, IBinning, IWindow, IExposureTime, IImageType]` | Issue table only had `ICamera`; `_setup_instrument_config` also `safe_proxy`s `camera` as `IBinning`/`IWindow`/`IExposureTime`/`IImageType` (same pattern `DarkBiasScript.camera` already gets credit for) |
+| `ImagingScript` | `telescope` | `Annotated[str \| None, ITelescope, IPointingRaDec] = None` | Issue table had `ITelescope, IReady`; `IReady` dropped (get_state-only + implied by `ITelescope`); `IPointingRaDec` added — `_start_move_radec` does `comm.proxy(self.telescope, IPointingRaDec)`, a hard requirement the table missed entirely |
+| `ImagingScript` | `filters` | `Annotated[str \| None, IFilters] = None` | same interface as issue table, converted to `Annotated` for consistency with the rest of the class |
+| `ImagingScript` | `autoguider` | `Annotated[str \| None, IAutoGuiding] = None` | same, converted for consistency |
+| `ImagingScript` | `acquisition` | `Annotated[str \| None, IAcquisition] = None` | same, converted for consistency |
+| `DarkBiasScript` | `camera` | `Annotated[str, IData, IBinning, IWindow, IExposureTime, IImageType]` | unchanged, matches issue |
+| `PointingScript` | `telescope` | `Annotated[str, IPointingAltAz, IReady]` | unchanged — `IReady` here is a genuine separate `proxy()` call, not redundant (see tagging rule) |
+| `AutoFocusScript` | `telescope` | `Annotated[str, ITelescope, IPointingRaDec] = "telescope"` | Issue table had `ITelescope, IReady, IPointingRaDec, IMotion`; `IReady` dropped (get_state-only), `IMotion` dropped (implied by `ITelescope` even though reached via a real `safe_proxy` call — see rule's second category) |
+| `AutoFocusScript` | `autofocus` | `Annotated[str, IAutoFocus] = "autofocus"` | unchanged |
+| `SkyFlatsScript` | `roof` | `Annotated[str, IRoof]` | `IReady` dropped (get_state-only + implied by `IRoof → IMotion → IReady`) |
+| `SkyFlatsScript` | `telescope` | `Annotated[str, ITelescope]` | `IReady` dropped, same reason |
+| `SkyFlatsScript` | `flatfield` | `Annotated[str, IBinning, IFilters, IFlatField]` | Issue table only had `IFlatField`; `run()` also does `proxy(self.flatfield, IBinning)` (hard) and `safe_proxy(self.flatfield, IFilters)` — both missed |
+| `SelectorScript` | `mode` | *not tagged* | Not a module-name field — it's a mode-name string passed to `selector.set_mode(self.mode)`, never used as a `comm.proxy` target. The issue's table incorrectly grouped it with `selector` under `IMode` |
+| `SelectorScript` | `selector` | `Annotated[str, IMode, IMotion]` | Issue table only had `IMode`; `can_run` also does `proxy(self.selector, IMotion)` for `wait_for_state(IMotion, ...)` — a hard requirement the table missed (`IMode` does not inherit `IMotion`, so both are needed) |
+
+`CallModuleScript.module`/`.interface` (`robotic/scripts/utils/callmodule.py`) stays excluded per
+the issue — `.interface` is a dynamic FQCN string chosen by the caller, not a fixed interface.
+
+## Implementation checklist
+
+- [ ] `pyobs/robotic/scripts/imaging/imaging.py` — import `Annotated`; tag all five module-name
+      fields (`camera`, `telescope`, `filters`, `autoguider`, `acquisition`) with `Annotated`,
+      including `filters`/`autoguider`/`acquisition` even though each is already single-interface
+      and unchanged from the issue's table (`IFilters`, `IAutoGuiding`, `IAcquisition`
+      respectively) — converted for consistency within the class rather than mixing tagged and
+      untagged module-name fields on the same model
+- [ ] `pyobs/robotic/scripts/calibration/darkbias.py` — tag `camera`
+- [ ] `pyobs/robotic/scripts/calibration/pointing.py` — tag `telescope`
+- [ ] `pyobs/robotic/scripts/imaging/autofocus.py` — tag `telescope`, `autofocus`
+- [ ] `pyobs/robotic/scripts/calibration/skyflats.py` — tag `roof`, `telescope`, `flatfield`
+- [ ] `pyobs/robotic/scripts/control/selector.py` — tag `selector` only, leave `mode` as plain `str`
+- [ ] Add a unit test (new or extending an existing `tests/robotic/scripts/test_*.py`) asserting
+      `cls.model_fields["camera"].metadata == [ICamera, IBinning, IWindow, IExposureTime,
+      IImageType]` (or equivalent) for at least one multi-interface field and one single-interface
+      field, to lock in the `Annotated` metadata shape pyobs-robotic-backend will read
+- [ ] `pyrefly` clean (not mypy — see `CLAUDE.md`)
+- [ ] Confirm no runtime/validation behavior changed: existing script tests
+      (`tests/robotic/scripts/test_imaging.py`, `test_darkbias.py`, `test_autofocus.py`,
+      `test_control.py`) pass unmodified
+- [ ] Post the corrected audit table (this doc) as a comment on #808 before implementing, since it
+      changes four entries from the issue's original table — give a chance to object before code
+      lands

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -133,4 +133,5 @@ Implementation plans, checklist-style. Newest at the bottom.
   `specs/design/basevideo-http-auth.md`). **implemented, closed** (Repos: pyobs-core, pyobs-gui)
 - [2026-08-24-script-field-interface-annotations.md](2026-08-24-script-field-interface-annotations.md) —
   tag `Script` module-name fields (`ImagingScript.camera`, etc.) with required `pyobs.interfaces`
-  via `typing.Annotated`, for pyobs-robotic-backend's module dropdowns. **planned** (tracks #808)
+  via `typing.Annotated`, for pyobs-robotic-backend's module dropdowns. **implemented, PR open**
+  (tracks #808, PR #809)

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -131,3 +131,6 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-08-21-basevideo-http-token-auth.md](2026-08-21-basevideo-http-token-auth.md) —
   shared-token auth + browser login page for `BaseVideo`'s HTTP endpoints (design:
   `specs/design/basevideo-http-auth.md`). **implemented, closed** (Repos: pyobs-core, pyobs-gui)
+- [2026-08-24-script-field-interface-annotations.md](2026-08-24-script-field-interface-annotations.md) —
+  tag `Script` module-name fields (`ImagingScript.camera`, etc.) with required `pyobs.interfaces`
+  via `typing.Annotated`, for pyobs-robotic-backend's module dropdowns. **planned** (tracks #808)

--- a/tests/robotic/scripts/test_field_interface_annotations.py
+++ b/tests/robotic/scripts/test_field_interface_annotations.py
@@ -1,0 +1,81 @@
+"""Regression tests for pyobs/pyobs-core#808: module-name fields on Script subclasses are
+tagged via typing.Annotated with the pyobs.interfaces classes a proxy for that field must
+implement, so pyobs-robotic-backend can read FieldInfo.metadata to build interface-filtered
+module dropdowns."""
+
+from __future__ import annotations
+
+from pyobs.interfaces import (
+    IAcquisition,
+    IAutoFocus,
+    IAutoGuiding,
+    IBinning,
+    ICamera,
+    IData,
+    IExposureTime,
+    IFilters,
+    IFlatField,
+    IImageType,
+    IMode,
+    IMotion,
+    IPointingAltAz,
+    IPointingRaDec,
+    IReady,
+    IRoof,
+    ITelescope,
+    IWindow,
+)
+from pyobs.robotic.scripts.calibration.darkbias import DarkBiasScript
+from pyobs.robotic.scripts.calibration.pointing import PointingScript
+from pyobs.robotic.scripts.calibration.skyflats import SkyFlatsScript
+from pyobs.robotic.scripts.control.selector import SelectorScript
+from pyobs.robotic.scripts.imaging.autofocus import AutoFocusScript
+from pyobs.robotic.scripts.imaging.imaging import ImagingScript
+
+
+def _metadata(cls: type, field: str) -> list[object]:
+    return list(cls.model_fields[field].metadata)
+
+
+def test_imaging_script_camera_tagged_with_all_required_interfaces() -> None:
+    assert _metadata(ImagingScript, "camera") == [ICamera, IBinning, IWindow, IExposureTime, IImageType]
+
+
+def test_imaging_script_telescope_tagged_without_redundant_iready() -> None:
+    assert _metadata(ImagingScript, "telescope") == [ITelescope, IPointingRaDec]
+
+
+def test_imaging_script_single_interface_fields() -> None:
+    assert _metadata(ImagingScript, "filters") == [IFilters]
+    assert _metadata(ImagingScript, "autoguider") == [IAutoGuiding]
+    assert _metadata(ImagingScript, "acquisition") == [IAcquisition]
+
+
+def test_darkbias_script_camera_tagged_with_all_required_interfaces() -> None:
+    assert _metadata(DarkBiasScript, "camera") == [IData, IBinning, IWindow, IExposureTime, IImageType]
+
+
+def test_pointing_script_telescope_keeps_iready() -> None:
+    # unlike the get_state()-only cases, PointingScript does a genuine separate
+    # comm.proxy(self.telescope, IReady) call, and IPointingAltAz does not imply IReady
+    assert _metadata(PointingScript, "telescope") == [IPointingAltAz, IReady]
+
+
+def test_autofocus_script_telescope_tagged_without_redundant_interfaces() -> None:
+    assert _metadata(AutoFocusScript, "telescope") == [ITelescope, IPointingRaDec]
+
+
+def test_autofocus_script_autofocus_field() -> None:
+    assert _metadata(AutoFocusScript, "autofocus") == [IAutoFocus]
+
+
+def test_skyflats_script_fields_tagged_without_redundant_iready() -> None:
+    assert _metadata(SkyFlatsScript, "roof") == [IRoof]
+    assert _metadata(SkyFlatsScript, "telescope") == [ITelescope]
+    assert _metadata(SkyFlatsScript, "flatfield") == [IBinning, IFilters, IFlatField]
+
+
+def test_selector_script_selector_tagged_mode_untagged() -> None:
+    # `mode` is a mode-name string passed to set_mode(), not a module reference - never tagged
+    assert _metadata(SelectorScript, "selector") == [IMode, IMotion]
+    assert _metadata(SelectorScript, "mode") == []


### PR DESCRIPTION
## Summary

- Tags module-name fields on `Script` subclasses (`ImagingScript.camera`, `.telescope`, etc.) with the `pyobs.interfaces` classes a proxy for that field must implement, using `typing.Annotated` metadata. No validation/runtime behavior change — fields still behave exactly as plain `str`/`str | None`.
- Lets pyobs-robotic-backend read `cls.model_fields["camera"].metadata` to render interface-filtered module dropdowns (pyobs/pyobs-robotic-backend#98), instead of hand-maintaining a duplicate table with no drift detection.
- Re-audited every `run()`/`can_run()` proxy call against #808's own table and corrected four gaps it had: `ImagingScript.camera` was missing `IBinning`/`IWindow`/`IExposureTime`/`IImageType`; `ImagingScript.telescope` was missing `IPointingRaDec`; `SkyFlatsScript.flatfield` was missing `IBinning`/`IFilters`; `SelectorScript.selector` was missing `IMotion`. Also excluded `SelectorScript.mode` entirely — it's a mode-name string, not a module reference, and the issue had mistakenly grouped it with `selector`.
- Full per-field audit table and the tagging rule (drop `get_state()`-only interfaces and any interface already implied by another tagged interface's inheritance) is in `specs/plans/2026-08-24-script-field-interface-annotations.md`.

Closes #808

## Test plan

- [x] New `tests/robotic/scripts/test_field_interface_annotations.py` asserts the exact `Annotated` metadata for every tagged field across all 6 script classes
- [x] `pyrefly check` clean on all changed files
- [x] Full non-integration suite (`pytest -m "not integration and not xmpp"`): 1585 passed, 1 pre-existing unrelated failure (`test_fitsheader.py::test_add_fits_headers_adds_frame_number_when_enabled`, confirmed failing identically on `develop` — environment `PermissionError` writing to `/opt/pyobs/storage`, unrelated to this change)