### PR TITLE
Rename storage.backend to storage.portal (breaking)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 v2.0.0.dev78 (unreleased)
 *************************
+* **Breaking:** ``pyobs.robotic.storage.backend`` is renamed to ``pyobs.robotic.storage.portal``,
+  and ``BackendTaskArchive``/``BackendObservationArchive`` are renamed to
+  ``PortalTaskArchive``/``PortalObservationArchive``, following the ``pyobs-robotic-backend`` ->
+  ``pyobs-portal`` rename (see ADR 0013,
+  ``specs/adrs/0013-renaming-pyobs-robotic-backend.md``). There is no deprecation shim -- update
+  the ``class:`` dotted path in any deployment YAML using the old names before upgrading.
 * ``BaseVideo.raw_handler`` now caches the per-frame ``(meta, frame)`` bytes it builds
   (header assembly, JSON serialization, ``ascontiguousarray``/``tobytes()`` copy), keyed by
   ``_frame_num``. With N simultaneous raw clients (guiding, a recorder, a viewer -- a case

--- a/docs/source/api/robotic/index.rst
+++ b/docs/source/api/robotic/index.rst
@@ -182,8 +182,8 @@ three concrete implementations:
    * - ``pyobs.robotic.storage.filesystem``
      - Tasks and observations stored as YAML files on disk. The simplest setup — no external
        services required. Good for single-telescope systems.
-   * - ``pyobs.robotic.storage.backend``
-     - Tasks and observations managed by the *pyobs-robotic-backend* HTTP service. Enables
+   * - ``pyobs.robotic.storage.portal``
+     - Tasks and observations managed by the *pyobs-portal* HTTP service. Enables
        multi-telescope coordination and a web UI for queue management.
    * - ``pyobs.robotic.storage.lco``
      - Integration with the Las Cumbres Observatory observation portal. Used for LCO-connected

--- a/docs/source/api/robotic/scheduling.rst
+++ b/docs/source/api/robotic/scheduling.rst
@@ -364,16 +364,16 @@ services required — the simplest setup for a single telescope.
    :members:
    :show-inheritance:
 
-**Backend** (``pyobs.robotic.storage.backend``)
+**Portal** (``pyobs.robotic.storage.portal``)
 
-Tasks and observations are managed by the *pyobs-robotic-backend* HTTP service. Enables
+Tasks and observations are managed by the *pyobs-portal* HTTP service. Enables
 multi-telescope coordination, a web UI for queue management, and centralised logging.
 
-.. autoclass:: pyobs.robotic.storage.backend.BackendTaskArchive
+.. autoclass:: pyobs.robotic.storage.portal.PortalTaskArchive
    :members:
    :show-inheritance:
 
-.. autoclass:: pyobs.robotic.storage.backend.BackendObservationArchive
+.. autoclass:: pyobs.robotic.storage.portal.PortalObservationArchive
    :members:
    :show-inheritance:
 

--- a/docs/source/recipes/robotic.rst
+++ b/docs/source/recipes/robotic.rst
@@ -248,8 +248,8 @@ Where to go next
   types (flat fields, focus runs, spectroscopy) — see :doc:`/api/robotic/scripts` for the full
   list of built-in scripts and the writing guide.
 - Replace ``YamlTaskArchive`` and ``YamlObservationArchive`` with
-  :class:`~pyobs.robotic.storage.backend.BackendTaskArchive` and
-  :class:`~pyobs.robotic.storage.backend.BackendObservationArchive` to use the *pyobs-robotic-backend*
+  :class:`~pyobs.robotic.storage.portal.PortalTaskArchive` and
+  :class:`~pyobs.robotic.storage.portal.PortalObservationArchive` to use the *pyobs-portal*
   web service for multi-telescope coordination — see :doc:`/api/robotic/scheduling`.
 - Add :class:`~pyobs.robotic.scheduler.merits.TransitMerit` or
   :class:`~pyobs.robotic.scheduler.merits.TimeWindowMerit` to the task YAML files for more

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -102,7 +102,7 @@ class Scheduler(Module, IStartStop, IRunnable):
 
         # get scheduler
         self._task_archive = self.add_child_object(tasks, TaskArchive, on_tasks_changed=self._update_schedule)
-        # BackendObservationArchive declares auto_update and gates its own polling loop on it --
+        # PortalObservationArchive declares auto_update and gates its own polling loop on it --
         # since we already drive updates via on_tasks_changed above, that poller must stay off.
         # Other ObservationArchive implementations (e.g. LcoObservationArchive) don't declare it at
         # all, so it must not be injected unconditionally.

--- a/pyobs/robotic/storage/backend/__init__.py
+++ b/pyobs/robotic/storage/backend/__init__.py
@@ -1,4 +1,0 @@
-from .observationarchive import BackendObservationArchive
-from .taskarchive import BackendTaskArchive
-
-__all__ = ["BackendObservationArchive", "BackendTaskArchive"]

--- a/pyobs/robotic/storage/portal/__init__.py
+++ b/pyobs/robotic/storage/portal/__init__.py
@@ -1,0 +1,4 @@
+from .observationarchive import PortalObservationArchive
+from .taskarchive import PortalTaskArchive
+
+__all__ = ["PortalObservationArchive", "PortalTaskArchive"]

--- a/pyobs/robotic/storage/portal/observationarchive.py
+++ b/pyobs/robotic/storage/portal/observationarchive.py
@@ -15,8 +15,8 @@ from pyobs.utils.time import Time
 log = logging.getLogger(__name__)
 
 
-class BackendObservationArchive(ObservationArchive):
-    """Observation archive based on pyobs-robotic-backend."""
+class PortalObservationArchive(ObservationArchive):
+    """Observation archive based on pyobs-portal."""
 
     def __init__(
         self,
@@ -39,12 +39,12 @@ class BackendObservationArchive(ObservationArchive):
             self.add_background_task(self._check_for_changes)
 
     async def open(self) -> None:
-        """Opens the backend observation archive."""
+        """Opens the portal observation archive."""
         self._aiohttp_session = aiohttp.ClientSession(headers={"Authorization": f"Token {self._token}"})
         await ObservationArchive.open(self)
 
     async def close(self) -> None:
-        """Closes the backend observation archive."""
+        """Closes the portal observation archive."""
         await ObservationArchive.close(self)
         if self._aiohttp_session is not None:
             await self._aiohttp_session.close()
@@ -57,20 +57,20 @@ class BackendObservationArchive(ObservationArchive):
         return self._aiohttp_session
 
     async def _check_for_changes(self) -> None:
-        """Update schedule in background, gated on the backend's update marker."""
+        """Update schedule in background, gated on the portal's update marker."""
 
         while True:
             try:
                 await self._poll()
             except Exception as e:
-                log.error("Failed to update observations from backend: %s", e)
+                log.error("Failed to update observations from portal: %s", e)
             await asyncio.sleep(5)
 
     async def _poll(self) -> None:
-        """Re-download the schedule when the backend's ``last_observation_update`` marker moved.
+        """Re-download the schedule when the portal's ``last_observation_update`` marker moved.
 
-        The marker is a DB-derived ``Max(updated_at)`` (pyobs-robotic-backend#84), truthful across
-        gunicorn workers, so it is a safe refresh gate; see ``BackendTaskArchive._poll``. The
+        The marker is a DB-derived ``Max(updated_at)`` (pyobs-portal#84), truthful across
+        gunicorn workers, so it is a safe refresh gate; see ``PortalTaskArchive._poll``. The
         content comparison in :meth:`_update` still decides whether to fire ``on_tasks_changed``.
         """
         last_update = await self.last_update_time()
@@ -79,12 +79,12 @@ class BackendObservationArchive(ObservationArchive):
             self._last_marker = last_update
 
     async def _update(self) -> None:
-        """Fetch the schedule from the backend and apply it if anything changed.
+        """Fetch the schedule from the portal and apply it if anything changed.
 
-        Called by :meth:`_poll` after the backend marker moved (or on the first poll). Changes are
+        Called by :meth:`_poll` after the portal marker moved (or on the first poll). Changes are
         detected by comparing full observation contents via ``model_dump(use_task_id=True)``,
         keyed by observation ID so a stable reordering of the same items is not mistaken for a
-        change: the backend serializes ``task`` as a plain FK ID, while cached copies get their
+        change: the portal serializes ``task`` as a plain FK ID, while cached copies get their
         ``task`` replaced by a full ``Task`` when the mastermind calls ``fetch_task()``, so the ID
         normalization keeps both sides comparable. The comparison includes ``state``
         (``Observation.__eq__`` ignores it), which matters for in-set transitions such as
@@ -265,4 +265,4 @@ class BackendObservationArchive(ObservationArchive):
         return ObservationList([self.pyobs_model_validate(Observation, obs) for obs in observations])
 
 
-__all__ = ["BackendObservationArchive"]
+__all__ = ["PortalObservationArchive"]

--- a/pyobs/robotic/storage/portal/taskarchive.py
+++ b/pyobs/robotic/storage/portal/taskarchive.py
@@ -13,14 +13,14 @@ from pyobs.utils.time import Time
 log = logging.getLogger(__name__)
 
 
-class BackendTaskArchive(TaskArchive):
-    """Task archive based on pyobs-robotic-backend."""
+class PortalTaskArchive(TaskArchive):
+    """Task archive based on pyobs-portal."""
 
     def __init__(self, url: str, token: str, auto_update: bool = True, **kwargs: Any):
         """Creates a new task archive.
 
         Args:
-            url: URL of pyobs-robotic-backend.
+            url: URL of pyobs-portal.
             token: Auth token.
         """
         TaskArchive.__init__(self, **kwargs)
@@ -36,12 +36,12 @@ class BackendTaskArchive(TaskArchive):
             self.add_background_task(self._check_for_changes)
 
     async def open(self) -> None:
-        """Opens the backend task archive."""
+        """Opens the portal task archive."""
         self._aiohttp_session = aiohttp.ClientSession(headers={"Authorization": f"Token {self._token}"})
         await TaskArchive.open(self)
 
     async def close(self) -> None:
-        """Closes the backend observation archive."""
+        """Closes the portal task archive."""
         await TaskArchive.close(self)
         if self._aiohttp_session is not None:
             await self._aiohttp_session.close()
@@ -54,18 +54,18 @@ class BackendTaskArchive(TaskArchive):
         return self._aiohttp_session
 
     async def _check_for_changes(self) -> None:
-        """Update tasks in background, gated on the backend's update marker."""
+        """Update tasks in background, gated on the portal's update marker."""
         while True:
             try:
                 await self._poll()
             except Exception as e:
-                log.error("Failed to update tasks from backend: %s", e)
+                log.error("Failed to update tasks from portal: %s", e)
             await asyncio.sleep(5)
 
     async def _poll(self) -> None:
-        """Re-download tasks/projects when the backend's ``last_task_update`` marker moved.
+        """Re-download tasks/projects when the portal's ``last_task_update`` marker moved.
 
-        The marker is a DB-derived ``Max(updated_at)`` (pyobs-robotic-backend#84), truthful across
+        The marker is a DB-derived ``Max(updated_at)`` (pyobs-portal#84), truthful across
         gunicorn workers, so it is a safe refresh gate. Without it the archive re-downloaded (and
         re-compared) on every poll, and the content comparison misfired whenever runtime code
         mutated a serialized task field (e.g. ``DynamicTarget.resolve()`` overwriting ``name``),
@@ -78,14 +78,14 @@ class BackendTaskArchive(TaskArchive):
             self._last_marker = last_update
 
     async def _update(self) -> None:
-        """Fetch tasks/projects from the backend and apply them if anything changed.
+        """Fetch tasks/projects from the portal and apply them if anything changed.
 
-        Called by :meth:`_poll` after the backend marker moved (or on the first poll); applies the
+        Called by :meth:`_poll` after the portal marker moved (or on the first poll); applies the
         download only when the content actually differs from the cached copy. The comparison uses
         ``model_dump()`` rather than pydantic ``==``, which also compares runtime attributes (e.g.
         ``Task._cant_run_reason`` set by ``can_run()``) and would flag unchanged tasks as changed
         on every poll; it is keyed by ID so that a stable reordering of the same items (e.g. an
-        unordered backend queryset) is not mistaken for a change.
+        unordered portal queryset) is not mistaken for a change.
         """
         projects = await self._get_projects()
         tasks = await self._get_tasks()
@@ -105,12 +105,12 @@ class BackendTaskArchive(TaskArchive):
         return Time(res["last_task_update"])
 
     async def _get_projects(self) -> list[Project]:
-        """Fetch projects from backend."""
+        """Fetch projects from portal."""
         projects = await http_request_paginated(self._session, urljoin(self._url, "/api/projects/"), strict=True)
         return [self.pyobs_model_validate(Project, project) for project in projects]
 
     async def _get_tasks(self) -> list[Task]:
-        """Fetch tasks from backend."""
+        """Fetch tasks from portal."""
         tasks = await http_request_paginated(self._session, urljoin(self._url, "/api/tasks/"), strict=True)
         return [self.pyobs_model_validate(Task, task) for task in tasks]
 
@@ -118,7 +118,7 @@ class BackendTaskArchive(TaskArchive):
         """Returns time when last time any tasks changed (as observed by this archive).
 
         This is the local time at which the last content change was detected by the polling loop,
-        not the backend's marker timestamp -- the marker is per-process and unreliable.
+        not the portal's marker timestamp -- the marker is per-process and unreliable.
         """
         return self._last_update
 
@@ -151,4 +151,4 @@ class BackendTaskArchive(TaskArchive):
             return None
 
 
-__all__ = ["BackendTaskArchive"]
+__all__ = ["PortalTaskArchive"]

--- a/pyobs/robotic/task.py
+++ b/pyobs/robotic/task.py
@@ -46,9 +46,9 @@ class Task(PolymorphicBaseModel):
     script: dict[str, Any] = Field(default_factory=dict)
     active: bool = True
     updated_at: str | None = None
-    """Last-modification timestamp as emitted by pyobs-robotic-backend (DB-derived ``updated_at``,
-    added in pyobs-robotic-backend#84). Carried for round-trip fidelity so the strict ``Task``
-    model (``extra="forbid"``) accepts the field the backend now sends; not used by pyobs itself."""
+    """Last-modification timestamp as emitted by pyobs-portal (DB-derived ``updated_at``,
+    added in pyobs-portal#84). Carried for round-trip fidelity so the strict ``Task``
+    model (``extra="forbid"``) accepts the field the portal now sends; not used by pyobs itself."""
 
     _resolved_target: Target | None = PrivateAttr(default=None)
     _cant_run_reason: str | None = None

--- a/specs/adrs/0011-keycloak-identity-broker-for-shared-auth.md
+++ b/specs/adrs/0011-keycloak-identity-broker-for-shared-auth.md
@@ -10,7 +10,7 @@ considered-and-rejected parallel-backends option.
 
 date: 2026-08-10
 
-Repos: pyobs-core (this doc), pyobs-archive, pyobs-robotic-backend
+Repos: pyobs-core (this doc), pyobs-archive, pyobs-portal
 
 ## Context and Problem Statement
 
@@ -21,7 +21,7 @@ Tracks #748. Each pyobs web service currently rolls its own auth, uncoordinated:
   (`BearerAuthentication`). odin is archive's connection to LCO (Las Cumbres Observatory) — this
   needs to keep working, since archive must continue to support LCO as a login/identity option,
   not just GWDG and local accounts.
-- **pyobs-robotic-backend** uses plain DRF `TokenAuthentication`/`SessionAuthentication` against
+- **pyobs-portal** uses plain DRF `TokenAuthentication`/`SessionAuthentication` against
   its own local Django user table, with no connection to odin or to archive's users.
 
 A user authenticated against one pyobs web service has no way to be recognized by another, and
@@ -32,7 +32,7 @@ in, which rules out authenticating directly against GWDG's OIDC provider as a co
 ## Considered Options
 
 * **Standardize on odin** — reuse archive's existing `OAuth2Backend`/`BearerAuthentication`
-  pattern in robotic-backend and future services.
+  pattern in portal and future services.
 * **Authenticate directly against GWDG's OIDC provider** — GWDG runs a standard, working OIDC
   provider (proven via a separate GWDG-affiliated Django project, `labcourse`, which integrates
   it through `authlib`'s Django OIDC client: discovery via `server_metadata_url`, authorization
@@ -87,7 +87,7 @@ at this scale (an institute, plus external collaborators — not internet-scale 
 Keycloak's HA sizing guide targets much larger deployments than this.
 
 This ADR covers user-facing SSO only. Service-to-service auth (e.g. Mastermind calling
-robotic-backend's API) is a separate concern — likely a Keycloak client-credentials grant per
+portal's API) is a separate concern — likely a Keycloak client-credentials grant per
 service, in the same realm — and is left for separate design work rather than folded in here.
 
 Access isn't role-gated by GWDG affiliation: any valid GWDG account is treated as equally

--- a/specs/adrs/index.md
+++ b/specs/adrs/index.md
@@ -27,7 +27,7 @@ Short decision records for choices that had genuine considered-and-rejected alte
   self-hosted Keycloak alongside odin as two parallel auth backends. *superseded 2026-08-19* — the
   design/plan went the other way: observation-portal is brokered *through* Keycloak and archive's
   direct OAuth2 integration was removed (`specs/design/shared-auth-keycloak.md`) (Repos:
-  pyobs-core, pyobs-archive, pyobs-robotic-backend)
+  pyobs-core, pyobs-archive, pyobs-portal)
 - [0012-event-delivery-explicit-pubsub-subscription-not-presence.md](0012-event-delivery-explicit-pubsub-subscription-not-presence.md) —
   event delivery moves from PEP presence auto-subscribe to explicit pubsub subscription.
   *accepted*
@@ -36,4 +36,4 @@ Short decision records for choices that had genuine considered-and-rejected alte
   lockstep; in pyobs-core, `storage.backend`/`Backend*Archive` → `storage.portal`/
   `Portal*Archive`). *accepted*, execution tracked in
   `specs/plans/2026-08-24-rename-robotic-backend-to-portal.md` (Repos:
-  pyobs-robotic-backend, pyobs-auth, pyobs-archive, pyobs-web-admin)
+  pyobs-portal, pyobs-auth, pyobs-archive, pyobs-web-admin)

--- a/specs/design/index.md
+++ b/specs/design/index.md
@@ -25,11 +25,11 @@ Living architecture/design docs, one per feature or subsystem. Kept around after
 - [module_observer_location.md](module_observer_location.md) — module observer-location
   capabilities. *implemented, closed*
 - [obsnum_fits_header.md](obsnum_fits_header.md) — `OBSNUM` per-night observation counter in FITS
-  headers. *implemented, closed* (#738; Repos: pyobs-core, pyobs-robotic-backend)
+  headers. *implemented, closed* (#738; Repos: pyobs-core, pyobs-portal)
 - [pyobs_2_0_wire_protocol.md](pyobs_2_0_wire_protocol.md) — pyobs 2.0 wire protocol, state, and
   access control. *implemented, closed*
 - [rpc_gating_on_startup.md](rpc_gating_on_startup.md) — gating RPC commands until module startup
   completes. *implemented, closed* (#673)
 - [shared-auth-keycloak.md](shared-auth-keycloak.md) — shared auth across pyobs web projects via
   Keycloak. *implemented* (plan `2026-08-12-shared-auth-keycloak.md` closed 2026-08-19;
-  Repos: pyobs-archive, pyobs-robotic-backend)
+  Repos: pyobs-archive, pyobs-portal)

--- a/specs/design/obsnum_fits_header.md
+++ b/specs/design/obsnum_fits_header.md
@@ -1,7 +1,7 @@
 # `OBSNUM`: per-night observation counter in FITS headers
 
-Status: implemented, closed. Tracks #738. Repos: pyobs-core, pyobs-robotic-backend.
-Landed in pyobs-core#746 (released 2.0.0.dev71) and pyobs-robotic-backend#69.
+Status: implemented, closed. Tracks #738. Repos: pyobs-core, pyobs-portal.
+Landed in pyobs-core#746 (released 2.0.0.dev71) and pyobs-portal#69.
 
 ## Problem
 
@@ -127,8 +127,8 @@ implementations to see what this costs:
 - **filesystem** (`filesystem/observationarchive.py:188-202`) rewrites the whole YAML-serialized
   `Observation` — same, free.
 - **backend** (`backend/observationarchive.py:178-190`) PUTs `observation.model_dump(use_task_id=True)`
-  — but this is **not free**, checked against the actual `pyobs-robotic-backend` repo: its Django
-  `Observation` model (`pyobs_robotic_backend/api/models.py:71-85`) has no `obsnum` column, and
+  — but this is **not free**, checked against the actual `pyobs-portal` repo: its Django
+  `Observation` model (`pyobs_portal/api/models.py:71-85`) has no `obsnum` column, and
   `ObservationSerializer` (`api/serializers.py:83-86`) is a `ModelSerializer` with an explicit
   `fields = ["id", "task", "start", "end", "state", "target"]` allowlist — DRF silently drops any
   key in the PUT body that isn't in that list. Sending `obsnum` today would be a silent no-op, not
@@ -188,11 +188,11 @@ class of gap `FRAMENUM` already tolerates when a single exposure fails mid-seque
 - No changes to `Observation.id` — it stays whatever the archive backend uses it for (UUID, unset,
   etc.); `obsnum`/`OBSNUM` is additive, and this proposal doesn't try to unify the two.
 - `Observation` (`observation.py:28-43`) gains `obsnum: str | None = None` (compound form).
-- **`pyobs-robotic-backend`**: add an `obsnum` column to the `Observation` model
-  (`pyobs_robotic_backend/api/models.py:71-85`, e.g. `CharField(max_length=32, null=True,
+- **`pyobs-portal`**: add an `obsnum` column to the `Observation` model
+  (`pyobs_portal/api/models.py:71-85`, e.g. `CharField(max_length=32, null=True,
   blank=True)`) with a migration alongside the existing ones in
-  `pyobs_robotic_backend/api/migrations/`, and add `"obsnum"` to `ObservationSerializer.Meta.fields`
-  (`api/serializers.py:85-86`). Without both, `BackendObservationArchive.update_observation()` keeps
+  `pyobs_portal/api/migrations/`, and add `"obsnum"` to `ObservationSerializer.Meta.fields`
+  (`api/serializers.py:85-86`). Without both, `PortalObservationArchive.update_observation()` keeps
   silently dropping the field even after the pyobs-core side ships.
 - `Mastermind.__init__` (`mastermind.py:66`) gains a `NightlyCounter` (or equivalent) instance,
   cache path `/pyobs/modules/{self.name}/obsnum.yaml`.

--- a/specs/design/shared-auth-keycloak.md
+++ b/specs/design/shared-auth-keycloak.md
@@ -3,7 +3,7 @@
 Status: implemented — the plan (`specs/plans/2026-08-12-shared-auth-keycloak.md`) was closed
 2026-08-19: `pyobs-auth` released (`2.0.0.dev7`), pyobs-archive cutover landed (`2.0.0.dev8`,
 commit `01eb06e` removed `OAuth2Backend`/`BearerAuthentication`/`OAUTH_CLIENT`; `Profile.keycloak_sub`
-user mapping), pyobs-robotic-backend wired in (`KeycloakAuthentication`, `KeycloakIdentity` model);
+user mapping), pyobs-portal wired in (`KeycloakAuthentication`, `KeycloakIdentity` model);
 browser login/logout verified end to end against the running Keycloak. Section 0 of the plan
 (observation-portal brokering in the Keycloak admin console) remains open but is admin/deployment
 config, tracked in #748, not pyobs code.
@@ -16,7 +16,7 @@ is configured: "Log in with `<hinted IdP>`" (default, via `IDP_HINT`) and "Log i
 Keycloak account" (via a present-but-empty `?idp_hint=`), keeping the local-account path reachable.
 The alias and button label are per-deployment `PYOBS_AUTH` config (`IDP_HINT`/`IDP_LABEL`) — an
 instance of this design's "upstream wiring is operational config" principle.
-Repos: pyobs-auth, pyobs-archive, pyobs-robotic-backend, pyobs-web-admin
+Repos: pyobs-auth, pyobs-archive, pyobs-portal, pyobs-web-admin
 
 ## Problem
 
@@ -32,7 +32,7 @@ Tracks #748. Each pyobs web service currently rolls its own auth, uncoordinated:
   a `PROFILE_URL`. Successful auth mints/updates a local Django `User` + `Profile` (storing the
   observation-portal access/refresh token — written but never read elsewhere in archive, confirmed
   by grep; no downstream code depends on archive holding a live observation-portal token).
-- **pyobs-robotic-backend** (`settings.py` `DEFAULT_AUTHENTICATION_CLASSES`) uses plain DRF
+- **pyobs-portal** (`settings.py` `DEFAULT_AUTHENTICATION_CLASSES`) uses plain DRF
   `TokenAuthentication` + `SessionAuthentication` against its own local Django user database — no
   connection to observation-portal or to archive's users at all.
 
@@ -47,14 +47,14 @@ than treating it as a second, permanently-separate integration.
 
 Two separable problems, both in scope, with different trust models:
 
-1. **User-facing SSO** — one login across archive/robotic-backend/future dashboards, via Keycloak
+1. **User-facing SSO** — one login across archive/portal/future dashboards, via Keycloak
    as the sole OIDC provider.
-2. **Service-to-service auth** — e.g. Mastermind calling robotic-backend's API, pyobs-core modules
+2. **Service-to-service auth** — e.g. Mastermind calling portal's API, pyobs-core modules
    calling other services' APIs. Optional: what's already in use here (DRF `TokenAuthentication`,
    a static per-module token — this is what's referred to as "PSK" in this doc, not a real
    HMAC/PSK scheme) stays available as an alternative to OIDC client-credentials, not replaced by
-   it. Concretely: `pyobs/robotic/storage/backend/taskarchive.py` and `observationarchive.py`
-   (pyobs-core) send `Authorization: Token <token>` against robotic-backend today — that path is
+   it. Concretely: `pyobs/robotic/storage/portal/taskarchive.py` and `observationarchive.py`
+   (pyobs-core) send `Authorization: Token <token>` against portal today — that path is
    unaffected by this work.
 
 ## Decision: Keycloak as the single issuer; observation-portal becomes a brokered upstream, not a second integration
@@ -72,7 +72,7 @@ code that talks to observation-portal directly:
   Connect v1.0" IdP type, auto-configured from that discovery document). A user picks "log in with
   observation-portal" on Keycloak's login screen; Keycloak does the federation handshake and mints
   its own Keycloak token.
-- **`pyobs-auth` and every service (archive, robotic-backend, future services) only ever talk to
+- **`pyobs-auth` and every service (archive, portal, future services) only ever talk to
   Keycloak.** There is exactly one issuer, one JWKS endpoint, one client library code path — no
   multi-issuer validation logic, no `AUTH_PROVIDER` switch, no bespoke `OAuth2Backend`/
   `BearerAuthentication` kept alive as permanent second code. Full cutover, not a dual-path state:
@@ -91,18 +91,18 @@ code that talks to observation-portal directly:
   requires the client app to handle the user's raw password directly. `pyobs-auth`'s OIDC client
   logic (below) already does auth-code, so this falls out of the cutover rather than being separate
   work.
-- **pyobs-robotic-backend** currently has no OAuth2 path at all — just DRF `TokenAuthentication`
-  + `SessionAuthentication` (`pyobs_robotic_backend/settings.py:148-155`). It goes straight to
+- **pyobs-portal** currently has no OAuth2 path at all — just DRF `TokenAuthentication`
+  + `SessionAuthentication` (`pyobs_portal/settings.py:148-155`). It goes straight to
   Keycloak, same as every other service — nothing special about it relative to archive post-cutover.
 - **Service-to-service auth remains optional and the existing token mechanism stays supported.**
   Keycloak's client-credentials grant is available for services that want OIDC-based service
-  auth, but existing token-secured calls (pyobs-core modules → robotic-backend, via
+  auth, but existing token-secured calls (pyobs-core modules → portal, via
   `Authorization: Token <token>`) don't have to migrate as a precondition of this work.
 
 ## Proposed change: `pyobs-auth` package
 
 A new shared package, `pyobs-auth`, holds the Keycloak OIDC client logic once, rather than
-duplicating it into archive and robotic-backend separately (which is the situation being fixed).
+duplicating it into archive and portal separately (which is the situation being fixed).
 Released the normal way, like other pyobs repos (`do-python-release`, uv/poetry, GitHub tags) —
 nothing unusual about its release process.
 
@@ -111,20 +111,20 @@ Scope of the package (to be refined during implementation):
 - OIDC discovery + token exchange (authorization-code grant for user login, client-credentials
   grant for service-to-service).
 - Bearer-token validation (signature/issuer/audience checks against Keycloak's JWKS endpoint).
-- A DRF `authentication.BaseAuthentication` implementation, so archive/robotic-backend wire it in
+- A DRF `authentication.BaseAuthentication` implementation, so archive/portal wire it in
   consistently. Single-issuer only — no need to design for multiple trusted issuers, since
   observation-portal (and any other upstream) is brokered behind Keycloak, not validated directly.
 
 ## Decision: realm layout and user mapping
 
 - **One shared realm** for the whole pyobs ecosystem, with one Keycloak client registered per
-  service (archive, robotic-backend, future services), rather than per-service realms. A user
+  service (archive, portal, future services), rather than per-service realms. A user
   authenticated in the realm is inherently known to every service's client — no cross-realm
   federation needed to get the shared-identity property this work is for.
 - **Keycloak's `sub` claim (stable subject/user ID) is the join key** to each service's local
-  Django `User`, not username or email. Both archive and robotic-backend store the Keycloak `sub`
+  Django `User`, not username or email. Both archive and portal store the Keycloak `sub`
   against their local `User` (archive: presumably on `Profile`, or its Keycloak equivalent;
-  robotic-backend needs an equivalent field added, since it has no `Profile`-like model today).
+  portal needs an equivalent field added, since it has no `Profile`-like model today).
   Chosen over matching on username/email because those can change (rename, email update) without
   the underlying identity changing — matching on them would silently orphan or misjoin a user
   after such a change. This also applies to brokered logins (observation-portal or any other

--- a/specs/plans/2026-08-15-pydantic-extra-validation.md
+++ b/specs/plans/2026-08-15-pydantic-extra-validation.md
@@ -109,20 +109,20 @@ behavior that has been hidden by `extra="ignore"`.
   docs examples), but `test_yaml_archives.py`'s `TASK_YAML` has no `class`. The polymorphic validator
   pops `class` when present and no-ops when absent, so it handles both. It also adds `class` to
   `Task.model_dump()`, which round-trips through `YamlObservationArchive` because `Observation.task`
-  re-validates via `Task`'s polymorphic validator. `BackendTaskArchive` validates `Task` from backend
+  re-validates via `Task`'s polymorphic validator. `PortalTaskArchive` validates `Task` from backend
   JSON; whether that carries `class` is a sibling-repo question, but the polymorphic validator is
   harmless either way.
-  - **Sibling-repo question closed** (checked against `pyobs-robotic-backend` source directly):
+  - **Sibling-repo question closed** (checked against `pyobs-portal` source directly):
     `Observation.model_dump(use_task_id=True)` only embeds the full `Task` (now including `class`)
-    when `task.id is None`; `BackendObservationArchive.add_observations`/`update_observation`
-    (`pyobs/robotic/storage/backend/observationarchive.py:110,189`) are the only callers with
+    when `task.id is None`; `PortalObservationArchive.add_observations`/`update_observation`
+    (`pyobs/robotic/storage/portal/observationarchive.py:110,189`) are the only callers with
     `use_task_id=True`. In the actual runtime path, tasks always come from
-    `BackendTaskArchive.get_schedulable_tasks()`, which loads them from `GET /api/tasks/` — always
+    `PortalTaskArchive.get_schedulable_tasks()`, which loads them from `GET /api/tasks/` — always
     already carrying a server-assigned `id`. So `task.id is None` never occurs when
-    `BackendObservationArchive` is paired with `BackendTaskArchive`. A hypothetical mixed config
+    `PortalObservationArchive` is paired with `PortalTaskArchive`. A hypothetical mixed config
     (e.g. `YamlTaskArchive`, whose tasks default to `id: None` unless the YAML sets one, paired with
-    `BackendObservationArchive`) was already non-functional before this PR regardless of `class`:
-    `pyobs-robotic-backend`'s `ObservationSerializer.task` is a plain Django `ForeignKey` with no
+    `PortalObservationArchive`) was already non-functional before this PR regardless of `class`:
+    `pyobs-portal`'s `ObservationSerializer.task` is a plain Django `ForeignKey` with no
     custom field override, so DRF auto-generates a `PrimaryKeyRelatedField` that rejects a nested
     dict outright (`"Incorrect type. Expected pk value, received dict."`). And even where a task
     dict does legitimately reach the backend (`POST /api/tasks/`), `TaskSerializer.to_internal_value`

--- a/specs/plans/2026-08-20-backend-archive-marker-loss.md
+++ b/specs/plans/2026-08-20-backend-archive-marker-loss.md
@@ -1,20 +1,20 @@
 # Plan: Stop gating backend-archive refreshes on the `last_*_update` marker
 
-Status: implemented, closed 2026-08-20 (PR #790, issue #789 closed; robotic-backend root cause
+Status: implemented, closed 2026-08-20 (PR #790, issue #789 closed; portal root cause
 fixed separately via #84, closing #83)
-Repos: pyobs-core, pyobs-robotic-backend
+Repos: pyobs-core, pyobs-portal
 Issue: pyobs-core#789
 
 ## Problem
 
 The Mastermind keeps running stale tasks: edits to tasks (duration, script, priority,
-`active`) and newly scheduled observations made in the pyobs-robotic-backend never reach the
+`active`) and newly scheduled observations made in the pyobs-portal never reach the
 running mastermind, and window-expired observations stay runnable. Verified in the field and
 pinned down in issue #789:
 
-1. `BackendTaskArchive._check_for_changes()` (`pyobs/robotic/storage/backend/taskarchive.py`)
-   and `BackendObservationArchive._check_for_changes()`
-   (`pyobs/robotic/storage/backend/observationarchive.py`) poll
+1. `PortalTaskArchive._check_for_changes()` (`pyobs/robotic/storage/portal/taskarchive.py`)
+   and `PortalObservationArchive._check_for_changes()`
+   (`pyobs/robotic/storage/portal/observationarchive.py`) poll
    `GET /api/last_task_update/` resp. `/api/last_observation_update/` every 5 s and only
    re-download tasks/observations when the returned timestamp is newer than the locally cached
    `_last_update`.
@@ -43,7 +43,7 @@ comparing the downloaded content against the cached copy. This matches the issue
 fix ("re-fetch unconditionally on each poll ... or compare list contents/hash to detect
 changes; treat a missing/older marker as 'refresh anyway'").
 
-### `BackendTaskArchive`
+### `PortalTaskArchive`
 
 - Extract the loop body into a testable `_update()` method; `_check_for_changes()` keeps the
   `while True` / try-except / `asyncio.sleep(5)` shell.
@@ -64,12 +64,12 @@ changes; treat a missing/older marker as 'refresh anyway'").
   data — now an error instead, logged by the loop and retried on the next poll.
 - `_last_update` is never initialized from the backend marker anymore, so the `1970-01-01`
   fallback can't pin the archive. `last_update_time()` stays as a public method (the endpoint
-  still exists; the robotic-backend side may fix the marker later) but is no longer used for
+  still exists; the portal side may fix the marker later) but is no longer used for
   gating.
 - `last_changed()` now returns the local time at which a content change was last observed —
   semantically "last time tasks changed" from this archive's point of view.
 
-### `BackendObservationArchive`
+### `PortalObservationArchive`
 
 Same shape:
 
@@ -93,16 +93,16 @@ Same shape:
   they cause a re-download and a log line, never a missed change. The dangerous direction —
   missing a real change — is what this fix eliminates.
 
-### Out of scope (pyobs-robotic-backend)
+### Out of scope (pyobs-portal)
 
 The root-cause fixes on the backend side (DB-derived `updated_at` markers instead of the
 per-process cache, stamping `updated_at` in the celery bulk paths) live in the sibling repo and
-are not part of this PR — tracked as pyobs-robotic-backend#83. With this change the mastermind no
+are not part of this PR — tracked as pyobs-portal#83. With this change the mastermind no
 longer depends on any of them for correctness.
 
 ## Testing
 
-`tests/robotic/storage/backend/test_backend_archives.py` and `tests/utils/test_http.py`:
+`tests/robotic/storage/portal/test_portal_archives.py` and `tests/utils/test_http.py`:
 
 - `_update()` re-downloads and applies changes **even when the backend marker is stale/unchanged**
   (the regression: previously a pinned `_last_update` skipped the download). Mock
@@ -127,7 +127,7 @@ longer depends on any of them for correctness.
 ## Rollout
 
 No config changes. The archives self-heal on restart; no migration. Rollback is reverting this
-PR (the marker-gated behavior returns). The pyobs-robotic-backend marker fixes can land
+PR (the marker-gated behavior returns). The pyobs-portal marker fixes can land
 independently whenever; they will only make `last_update_time()` truthful again, not change
 refresh behavior.
 

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -83,14 +83,14 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-08-20-backend-archive-marker-loss.md](2026-08-20-backend-archive-marker-loss.md) —
   stop gating backend-archive refreshes on the per-process `last_*_update` marker; re-fetch
   every poll and detect changes by content. **implemented, closed 2026-08-20** (PR #790,
-  issue #789 closed; robotic-backend root cause fixed separately via #84, closing #83;
-  Repos: pyobs-core, pyobs-robotic-backend)
+  issue #789 closed; portal root cause fixed separately via #84, closing #83;
+  Repos: pyobs-core, pyobs-portal)
 - [2026-08-21-keycloak-idp-hint-login.md](2026-08-21-keycloak-idp-hint-login.md) — one-click IdP
   login via `kc_idp_hint`: `IDP_HINT` support in pyobs-auth + dual login buttons (hinted IdP vs.
   local Keycloak account) in the services' login pages. **implemented, closed 2026-08-23** — all
   four repos landed and pinned to `pyobs-auth>=2.0.0.dev9`; live browser E2E / SSO short-circuit /
   deployment env vars are operational follow-ups, not part of this plan's closure (Repos:
-  pyobs-auth, pyobs-archive, pyobs-robotic-backend, pyobs-web-admin)
+  pyobs-auth, pyobs-archive, pyobs-portal, pyobs-web-admin)
 - [2026-08-20-imagewatcher-event-loop-blocking.md](2026-08-20-imagewatcher-event-loop-blocking.md) —
   stop `ImageWatcher._worker`'s FITS parse and `LocalFile` I/O from blocking the event loop.
   **implemented, closed 2026-08-23** (PR #798; MONET South incident, 2026-08-20)
@@ -100,7 +100,8 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-08-24-rename-robotic-backend-to-portal.md](2026-08-24-rename-robotic-backend-to-portal.md) —
   execute ADR 0013: rename `pyobs-robotic-backend` → `pyobs-portal` fleet-wide; in
   pyobs-core, `pyobs.robotic.storage.backend` → `.storage.portal`,
-  `Backend*Archive` → `Portal*Archive`. **proposed, not started** (Repos: pyobs-core,
+  `Backend*Archive` → `Portal*Archive`. **in progress** — GitHub repo renamed, PRs open on
+  pyobs-portal and pyobs-core, not yet merged (Repos: pyobs-core,
   pyobs-robotic-backend, pyobs-auth, pyobs-archive, pyobs-web-admin, pyobs-iagvt,
   pyobs-monet)
 - [2026-08-23-iag50-pyobs-core-2x-migration.md](2026-08-23-iag50-pyobs-core-2x-migration.md) —
@@ -126,18 +127,18 @@ Implementation plans, checklist-style. Newest at the bottom.
   the Dependabot auto-merge workflow (validated live on pyobs-alpaca#33). Closes #752
 - [2026-08-12-shared-auth-keycloak.md](2026-08-12-shared-auth-keycloak.md) — `pyobs-auth` +
   Keycloak integration. **implemented, closed 2026-08-19** — `pyobs-auth` (`2.0.0.dev7`),
-  `pyobs-archive` cutover (`2.0.0.dev8`), and `pyobs-robotic-backend` all landed/released; live
+  `pyobs-archive` cutover (`2.0.0.dev8`), and `pyobs-portal` all landed/released; live
   Keycloak login + logout verified; observation-portal brokering (Section 0) tracked separately,
-  Keycloak admin/deployment config only (Repos: pyobs-archive, pyobs-robotic-backend)
+  Keycloak admin/deployment config only (Repos: pyobs-archive, pyobs-portal)
 - [2026-08-19-archive-project-access-control.md](2026-08-19-archive-project-access-control.md) —
   show only images the logged-in user has access to, keyed on projects from
-  `pyobs-robotic-backend`. **superseded, implemented** — see
+  `pyobs-portal`. **superseded, implemented** — see
   `pyobs-archive/specs/plans/2026-08-20-archive-project-access-control.md` for the current design
-  (pyobs/pyobs-archive#42) (Repos: pyobs-archive, pyobs-robotic-backend, pyobs-core)
+  (pyobs/pyobs-archive#42) (Repos: pyobs-archive, pyobs-portal, pyobs-core)
 - [2026-08-21-basevideo-http-token-auth.md](2026-08-21-basevideo-http-token-auth.md) —
   shared-token auth + browser login page for `BaseVideo`'s HTTP endpoints (design:
   `specs/design/basevideo-http-auth.md`). **implemented, closed** (Repos: pyobs-core, pyobs-gui)
 - [2026-08-24-script-field-interface-annotations.md](2026-08-24-script-field-interface-annotations.md) —
   tag `Script` module-name fields (`ImagingScript.camera`, etc.) with required `pyobs.interfaces`
-  via `typing.Annotated`, for pyobs-robotic-backend's module dropdowns. **implemented, closed**
+  via `typing.Annotated`, for pyobs-portal's module dropdowns. **implemented, closed**
   (closed #808, PR #809)

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -14,8 +14,8 @@ from pyobs.robotic.observation import Observation, ObservationList, ObservationS
 from pyobs.robotic.scheduler import TaskScheduler
 from pyobs.robotic.scheduler.astroplanscheduler import AstroplanScheduler
 from pyobs.robotic.scheduler.ondemandscheduler import OnDemandScheduler
-from pyobs.robotic.storage.backend.observationarchive import BackendObservationArchive
 from pyobs.robotic.storage.lco.observationarchive import LcoObservationArchive
+from pyobs.robotic.storage.portal.observationarchive import PortalObservationArchive
 from pyobs.robotic.task import TaskData
 from pyobs.utils.time import Time
 
@@ -134,13 +134,13 @@ def test_init_defaults() -> None:
 # unconditionally used to rely on the target silently absorbing an unwanted kwarg, which stopped
 # being true once Object.__init__ started forwarding leftovers to object.__init__(). Regression
 # coverage for the auto_update bug found in PR #776 review: dropping it unconditionally would have
-# re-enabled BackendObservationArchive's polling loop in two live fleets.
+# re-enabled PortalObservationArchive's polling loop in two live fleets.
 
 
 @pytest.mark.parametrize(
     "class_path,param_name,expected",
     [
-        ("pyobs.robotic.storage.backend.observationarchive.BackendObservationArchive", "auto_update", True),
+        ("pyobs.robotic.storage.portal.observationarchive.PortalObservationArchive", "auto_update", True),
         ("pyobs.robotic.storage.lco.observationarchive.LcoObservationArchive", "auto_update", False),
         ("pyobs.robotic.scheduler.ondemandscheduler.OnDemandScheduler", "observation_archive", True),
         ("pyobs.robotic.scheduler.astroplanscheduler.AstroplanScheduler", "observation_archive", False),
@@ -153,7 +153,7 @@ def test_class_accepts_param_dict_config(class_path: str, param_name: str, expec
 @pytest.mark.parametrize(
     "klass,param_name,expected",
     [
-        (BackendObservationArchive, "auto_update", True),
+        (PortalObservationArchive, "auto_update", True),
         (LcoObservationArchive, "auto_update", False),
         (OnDemandScheduler, "observation_archive", True),
         (AstroplanScheduler, "observation_archive", False),
@@ -176,7 +176,7 @@ def test_init_injects_auto_update_false_for_backend_observation_archive() -> Non
     # unconditionally re-enabled this 5s polling loop in two live fleet configs
     scheduler = make_scheduler(
         schedule={
-            "class": "pyobs.robotic.storage.backend.observationarchive.BackendObservationArchive",
+            "class": "pyobs.robotic.storage.portal.observationarchive.PortalObservationArchive",
             "url": "http://x",
             "token": "t",
         }

--- a/tests/robotic/scheduler/targets/test_dynamictarget.py
+++ b/tests/robotic/scheduler/targets/test_dynamictarget.py
@@ -72,7 +72,7 @@ async def test_dynamic_target_resolves(observer: Observer, data: DataProvider, m
     assert target._target is not None
     assert target.name == "(dynamic)"
     # resolving must not leak the picked star into the serialized (declared-field) state:
-    # BackendTaskArchive compares model_dump() across polls, so mutating `name` here made
+    # PortalTaskArchive compares model_dump() across polls, so mutating `name` here made
     # every poll look like a change and livelocked the scheduler.
     assert target.model_dump() == dump_before
 

--- a/tests/robotic/storage/portal/test_portal_archives.py
+++ b/tests/robotic/storage/portal/test_portal_archives.py
@@ -8,8 +8,8 @@ from astropy.time import TimeDelta
 
 from pyobs.robotic import Task
 from pyobs.robotic.observation import Observation, ObservationList, ObservationState
-from pyobs.robotic.storage.backend.observationarchive import BackendObservationArchive
-from pyobs.robotic.storage.backend.taskarchive import BackendTaskArchive
+from pyobs.robotic.storage.portal.observationarchive import PortalObservationArchive
+from pyobs.robotic.storage.portal.taskarchive import PortalTaskArchive
 from pyobs.robotic.task import Project
 from pyobs.utils.time import Time
 
@@ -30,19 +30,19 @@ def make_obs(
     return Observation(task=task, start=start, end=end, state=state)
 
 
-def make_task_archive() -> BackendTaskArchive:
-    archive = BackendTaskArchive(url="http://localhost:8000", token="testtoken", auto_update=False)
+def make_task_archive() -> PortalTaskArchive:
+    archive = PortalTaskArchive(url="http://localhost:8000", token="testtoken", auto_update=False)
     archive._aiohttp_session = MagicMock()
     return archive
 
 
-def make_obs_archive() -> BackendObservationArchive:
-    archive = BackendObservationArchive(url="http://localhost:8000", token="testtoken", auto_update=False)
+def make_obs_archive() -> PortalObservationArchive:
+    archive = PortalObservationArchive(url="http://localhost:8000", token="testtoken", auto_update=False)
     archive._aiohttp_session = MagicMock()
     return archive
 
 
-# ── BackendTaskArchive ────────────────────────────────────────────────────────
+# ── PortalTaskArchive ────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ async def test_task_get_task_not_found() -> None:
 async def test_task_last_update_time(mocker) -> None:
     archive = make_task_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_with_retries",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_with_retries",
         AsyncMock(return_value={"last_task_update": "2025-11-03T23:00:00.000"}),
     )
     t = await archive.last_update_time()
@@ -103,10 +103,10 @@ async def test_task_last_update_time(mocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_task_get_projects_from_backend(mocker) -> None:
+async def test_task_get_projects_from_portal(mocker) -> None:
     archive = make_task_archive()
     mock = mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(return_value=[{"code": "test", "name": "Test", "priority": 1.0}]),
     )
     result = await archive._get_projects()
@@ -117,11 +117,11 @@ async def test_task_get_projects_from_backend(mocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_task_get_projects_from_backend_accepts_public(mocker) -> None:
-    """Projects with the backend `public` flag ingest without a strict-model ValidationError."""
+async def test_task_get_projects_from_portal_accepts_public(mocker) -> None:
+    """Projects with the portal `public` flag ingest without a strict-model ValidationError."""
     archive = make_task_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(
             return_value=[
                 {"code": "public", "name": "Public", "priority": 1.0, "public": True},
@@ -138,10 +138,10 @@ async def test_task_get_projects_from_backend_accepts_public(mocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_task_get_tasks_from_backend(mocker) -> None:
+async def test_task_get_tasks_from_portal(mocker) -> None:
     archive = make_task_archive()
     mock = mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(return_value=[{"id": 1, "name": "t1", "duration": 300}]),
     )
     result = await archive._get_tasks()
@@ -151,12 +151,12 @@ async def test_task_get_tasks_from_backend(mocker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_task_get_tasks_from_backend_accepts_updated_at(mocker) -> None:
-    """Tasks with the backend `updated_at` field (pyobs-robotic-backend#84) ingest without a
+async def test_task_get_tasks_from_portal_accepts_updated_at(mocker) -> None:
+    """Tasks with the portal `updated_at` field (pyobs-portal#84) ingest without a
     strict-model ValidationError, and the value round-trips."""
     archive = make_task_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(return_value=[{"id": 1, "name": "t1", "duration": 300, "updated_at": "2026-08-20T17:59:29.526066Z"}]),
     )
     result = await archive._get_tasks()
@@ -164,7 +164,7 @@ async def test_task_get_tasks_from_backend_accepts_updated_at(mocker) -> None:
     assert result[0].updated_at == "2026-08-20T17:59:29.526066Z"
 
 
-# ── BackendObservationArchive ─────────────────────────────────────────────────
+# ── PortalObservationArchive ─────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -178,7 +178,7 @@ async def test_obs_get_schedule_returns_cached() -> None:
 
 @pytest.mark.asyncio
 async def test_obs_get_schedule_time_ignored() -> None:
-    """time parameter is unused — backend returns cached observations."""
+    """time parameter is unused — portal returns cached observations."""
     archive = make_obs_archive()
     obs = make_obs(make_task())
     archive._observations = ObservationList([obs])
@@ -199,7 +199,7 @@ async def test_obs_get_next_returns_active() -> None:
 
 @pytest.mark.asyncio
 async def test_obs_get_next_boundary_exclusive() -> None:
-    """Backend uses strictly exclusive boundaries (start < time < end)."""
+    """Portal uses strictly exclusive boundaries (start < time < end)."""
     archive = make_obs_archive()
     obs = make_obs(make_task(), start=T0, end=T1, state=ObservationState.PENDING)
     archive._observations = ObservationList([obs])
@@ -257,7 +257,7 @@ async def test_obs_get_current_returns_none_when_idle() -> None:
 async def test_obs_add_observations(mocker) -> None:
     archive = make_obs_archive()
     mock_request = mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_with_retries",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_with_retries",
         AsyncMock(return_value={}),
     )
     obs = make_obs(make_task())
@@ -272,7 +272,7 @@ async def test_obs_add_observations(mocker) -> None:
 async def test_obs_clear_schedule(mocker) -> None:
     archive = make_obs_archive()
     mock_request = mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_with_retries",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_with_retries",
         AsyncMock(return_value={}),
     )
     await archive.clear_schedule(T0)
@@ -285,7 +285,7 @@ async def test_obs_clear_schedule(mocker) -> None:
 async def test_obs_update_observation(mocker) -> None:
     archive = make_obs_archive()
     mock_request = mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_with_retries",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_with_retries",
         AsyncMock(return_value={}),
     )
     obs = make_obs(make_task())
@@ -303,7 +303,7 @@ async def test_obs_update_observation(mocker) -> None:
 async def test_obs_get_observations_builds_params(mocker) -> None:
     archive = make_obs_archive()
     mock_request = mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(return_value=[]),
     )
     task = make_task(5)
@@ -326,7 +326,7 @@ async def test_obs_get_observations_builds_params(mocker) -> None:
 async def test_obs_last_update_time(mocker) -> None:
     archive = make_obs_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_with_retries",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_with_retries",
         AsyncMock(return_value={"last_observation_update": "2025-11-03T23:00:00.000"}),
     )
     t = await archive.last_update_time()
@@ -343,13 +343,13 @@ OBS_DICT = {"task": 1, "start": T0.isot, "end": T1.isot, "state": "pending"}
 async def test_task_update_not_gated_on_marker(mocker) -> None:
     """`_update()` itself does not consult the marker -- the gate lives in `_poll()`, so a direct
     download always applies. (The #789 failure mode -- the marker being per-process and stale --
-    is resolved by the backend computing it from the DB; see the `_poll` tests.)"""
+    is resolved by the portal computing it from the DB; see the `_poll` tests.)"""
     archive = make_task_archive()
     marker = mocker.patch.object(archive, "last_update_time", AsyncMock(return_value=T0))
     on_tasks_changed = AsyncMock()
     archive._on_tasks_changed = on_tasks_changed
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(
             side_effect=[
                 [{"code": "test", "name": "Test", "priority": 1.0}],  # projects
@@ -376,7 +376,7 @@ async def test_task_update_no_change_no_notification(mocker) -> None:
     projects = [{"code": "test", "name": "Test", "priority": 1.0}]
     tasks = [{"id": 1, "name": "t1", "duration": 300}]
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(side_effect=[projects, tasks, projects, tasks]),
     )
 
@@ -397,12 +397,12 @@ async def test_task_update_no_change_no_notification(mocker) -> None:
 
 @pytest.mark.asyncio
 async def test_task_update_detects_content_change(mocker) -> None:
-    """Same task identity but changed content (e.g. active=False in the backend) must be applied."""
+    """Same task identity but changed content (e.g. active=False in the portal) must be applied."""
     archive = make_task_archive()
     on_tasks_changed = AsyncMock()
     archive._on_tasks_changed = on_tasks_changed
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(
             side_effect=[
                 [{"code": "test", "name": "Test", "priority": 1.0}],
@@ -434,7 +434,7 @@ async def test_task_update_ignores_runtime_attributes(mocker) -> None:
     tasks = [{"id": 1, "name": "t1", "duration": 300}]
     projects = [{"code": "test", "name": "Test", "priority": 1.0}]
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(side_effect=[projects, tasks, projects, tasks]),
     )
 
@@ -454,7 +454,7 @@ async def test_obs_update_downloads_and_applies(mocker) -> None:
     """New observations appear in the cache on the next poll."""
     archive = make_obs_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[OBS_DICT], [OBS_DICT], [OBS_DICT]]),
     )
 
@@ -471,7 +471,7 @@ async def test_obs_update_no_change_keeps_cache(mocker) -> None:
     """Idempotent poll must not replace the cached list or bump _last_update."""
     archive = make_obs_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[OBS_DICT], [OBS_DICT]]),
     )
 
@@ -488,7 +488,7 @@ async def test_obs_update_no_change_keeps_cache(mocker) -> None:
 
 @pytest.mark.asyncio
 async def test_obs_update_detects_state_transition_in_fetched_set(mocker) -> None:
-    """An in-set state transition (pending -> in_progress, both within the backend's
+    """An in-set state transition (pending -> in_progress, both within the portal's
     state=pending,in_progress filter) must be picked up even though Observation.__eq__ ignores
     state -- the comparison covers the full dumped content."""
     # sanity: plain __eq__ misses the state change entirely (same task id/start/end)
@@ -498,7 +498,7 @@ async def test_obs_update_detects_state_transition_in_fetched_set(mocker) -> Non
 
     archive = make_obs_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[OBS_DICT], [dict(OBS_DICT, state="in_progress")]]),
     )
 
@@ -512,13 +512,13 @@ async def test_obs_update_detects_state_transition_in_fetched_set(mocker) -> Non
 
 @pytest.mark.asyncio
 async def test_obs_update_applies_shrinkage_when_observation_disappears(mocker) -> None:
-    """The production path for the window_expired symptom from #789: the backend's server-side
+    """The production path for the window_expired symptom from #789: the portal's server-side
     state=pending,in_progress and end_after=now filters drop the expired observation from the
     response, and the unconditional refetch must apply that shrinkage -- otherwise the mastermind
     keeps treating the window-expired observation as runnable."""
     archive = make_obs_archive()
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[OBS_DICT], []]),
     )
 
@@ -532,7 +532,7 @@ async def test_obs_update_applies_shrinkage_when_observation_disappears(mocker) 
 
 @pytest.mark.asyncio
 async def test_task_update_order_insensitive(mocker) -> None:
-    """The same items in a different order (e.g. an unordered backend queryset) must not be
+    """The same items in a different order (e.g. an unordered portal queryset) must not be
     reported as a change -- the comparison is keyed by ID."""
     archive = make_task_archive()
     on_tasks_changed = AsyncMock()
@@ -540,7 +540,7 @@ async def test_task_update_order_insensitive(mocker) -> None:
     projects = [{"code": "a", "name": "A", "priority": 1.0}, {"code": "b", "name": "B", "priority": 1.0}]
     tasks = [{"id": 1, "name": "t1", "duration": 300}, {"id": 2, "name": "t2", "duration": 300}]
     mocker.patch(
-        "pyobs.robotic.storage.backend.taskarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
         AsyncMock(side_effect=[projects, tasks, list(reversed(projects)), list(reversed(tasks))]),
     )
 
@@ -559,7 +559,7 @@ async def test_obs_update_order_insensitive(mocker) -> None:
     obs_a = {"id": "obs-a", "task": 1, "start": T0.isot, "end": T1.isot, "state": "pending"}
     obs_b = {"id": "obs-b", "task": 1, "start": T1.isot, "end": T2.isot, "state": "pending"}
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[obs_a, obs_b], [obs_b, obs_a]]),
     )
 
@@ -581,7 +581,7 @@ async def test_obs_update_normalizes_task_id(mocker) -> None:
     # seed cache the way the mastermind leaves it: task resolved to a full Task object
     archive._observations = ObservationList([make_obs(make_task())])
     mocker.patch(
-        "pyobs.robotic.storage.backend.observationarchive.http_request_paginated",
+        "pyobs.robotic.storage.portal.observationarchive.http_request_paginated",
         AsyncMock(side_effect=[[OBS_DICT]]),
     )
 


### PR DESCRIPTION
## Summary
- **Breaking:** `pyobs.robotic.storage.backend` -> `pyobs.robotic.storage.portal`; `BackendTaskArchive`/`BackendObservationArchive` -> `PortalTaskArchive`/`PortalObservationArchive`. No deprecation shim, per this repo's rename convention.
- Per ADR 0013, following the `pyobs-robotic-backend` -> `pyobs-portal` rename (see pyobs/pyobs-portal#104).
- Fixes stray old-name references outside the originally-scoped file list: `pyobs/modules/robotic/scheduler.py` (comment), `tests/modules/robotic/test_scheduler.py` (a live import of the old dotted path), `tests/robotic/scheduler/targets/test_dynamictarget.py` (comment), and a docstring in `specs/design/obsnum_fits_header.md`.
- Updates cross-repo spec docs to track the new name: `specs/design/index.md`, `specs/adrs/index.md`, `specs/adrs/0011-...md`, `specs/design/shared-auth-keycloak.md`, `specs/design/obsnum_fits_header.md`, `specs/plans/index.md`, and two closed investigation plans.
- Adds a `CHANGELOG.rst` entry under the unreleased section documenting the breaking change.

## Not included
Deployment YAML on `pyobs-iagvt`/`pyobs-monet` still reference the old dotted path (`pyobs.robotic.storage.backend.BackendTaskArchive`/`BackendObservationArchive`) and must be updated **before** those hosts upgrade past this release — tracked as a separate held PR (Step 5 of the plan below), not merged until paired with this release.

## Related
`specs/plans/2026-08-24-rename-robotic-backend-to-portal.md` (Step 2).

## Test plan
- [x] `uv run pytest tests/robotic/storage/portal tests/modules/robotic/test_scheduler.py tests/robotic/scheduler/targets/test_dynamictarget.py` — 91/91 passing
- [x] `uv run pyrefly check` — 0 errors on touched files (pre-existing unrelated `sunpy`/`qfitswidget` optional-extra import errors in a fresh venv, confirmed present on `develop` too)
- [x] `black --check` / `ruff check` — clean
- [ ] Coordinate release + iagvt/monet YAML update before deploying to those hosts