### PR TITLE
Implement IRobotic/IRoboticScheduler interfaces

### DIFF
--- a/pyobs/events/taskfailed.py
+++ b/pyobs/events/taskfailed.py
@@ -18,7 +18,7 @@ class TaskFailedEvent(Event):
         """Initializes a new task failed event.
 
         Args:
-            name: Name of task that just finished
+            name: Name of task that just failed
             id: Unique identifier for task
             obsnum: Per-night observation number of the run that just failed, e.g. "20260810-001"
         """

--- a/pyobs/events/taskfailed.py
+++ b/pyobs/events/taskfailed.py
@@ -6,6 +6,7 @@ from pyobs.events.event import Event
 class DataType(TypedDict):
     name: str
     id: Any
+    obsnum: str | None
 
 
 class TaskFailedEvent(Event):
@@ -13,15 +14,16 @@ class TaskFailedEvent(Event):
 
     __module__ = "pyobs.events"
 
-    def __init__(self, name: str, id: Any, **kwargs: Any):
+    def __init__(self, name: str, id: Any, obsnum: str | None = None, **kwargs: Any):
         """Initializes a new task failed event.
 
         Args:
             name: Name of task that just finished
             id: Unique identifier for task
+            obsnum: Per-night observation number of the run that just failed, e.g. "20260810-001"
         """
         Event.__init__(self)
-        self.data: DataType = {"name": name, "id": id}
+        self.data: DataType = {"name": name, "id": id, "obsnum": obsnum}
 
     @property
     def name(self) -> str:
@@ -30,6 +32,10 @@ class TaskFailedEvent(Event):
     @property
     def id(self) -> Any:
         return self.data["id"]
+
+    @property
+    def obsnum(self) -> str | None:
+        return self.data["obsnum"]
 
 
 __all__ = ["TaskFailedEvent"]

--- a/pyobs/events/taskfinished.py
+++ b/pyobs/events/taskfinished.py
@@ -6,6 +6,7 @@ from pyobs.events.event import Event
 class DataType(TypedDict):
     name: str
     id: Any
+    obsnum: str | None
 
 
 class TaskFinishedEvent(Event):
@@ -13,15 +14,16 @@ class TaskFinishedEvent(Event):
 
     __module__ = "pyobs.events"
 
-    def __init__(self, name: str, id: Any, **kwargs: Any):
+    def __init__(self, name: str, id: Any, obsnum: str | None = None, **kwargs: Any):
         """Initializes a new task finished event.
 
         Args:
             name: Name of task that just finished
             id: Unique identifier for task
+            obsnum: Per-night observation number of the run that just finished, e.g. "20260810-001"
         """
         Event.__init__(self)
-        self.data: DataType = {"name": name, "id": id}
+        self.data: DataType = {"name": name, "id": id, "obsnum": obsnum}
 
     @property
     def name(self) -> str:
@@ -30,6 +32,10 @@ class TaskFinishedEvent(Event):
     @property
     def id(self) -> Any:
         return self.data["id"]
+
+    @property
+    def obsnum(self) -> str | None:
+        return self.data["obsnum"]
 
 
 __all__ = ["TaskFinishedEvent"]

--- a/pyobs/events/taskstarted.py
+++ b/pyobs/events/taskstarted.py
@@ -52,7 +52,7 @@ class TaskStartedEvent(Event):
             eta = Time(d["eta"])
 
         # get obsnum
-        obsnum: str | None = d.get("obsnum")
+        obsnum: str | None = d["obsnum"] if isinstance(d.get("obsnum"), str) else None
 
         # return object
         return TaskStartedEvent(name=name, id=id, eta=eta, obsnum=obsnum)

--- a/pyobs/events/taskstarted.py
+++ b/pyobs/events/taskstarted.py
@@ -12,6 +12,7 @@ class DataType(TypedDict):
     name: str
     id: Any
     eta: str | None
+    obsnum: str | None
 
 
 class TaskStartedEvent(Event):
@@ -19,16 +20,17 @@ class TaskStartedEvent(Event):
 
     __module__ = "pyobs.events"
 
-    def __init__(self, name: str, id: Any, eta: Time | None = None, **kwargs: Any):
+    def __init__(self, name: str, id: Any, eta: Time | None = None, obsnum: str | None = None, **kwargs: Any):
         """Initializes a new task started event.
 
         Args:
             name: Name of task that just started
             id: Unique identifier for task
             eta: Predicted ETA for when the task will finish
+            obsnum: Per-night observation number assigned to this run, e.g. "20260810-001"
         """
         Event.__init__(self)
-        self.data: DataType = {"name": name, "id": id, "eta": None if eta is None else eta.isot}
+        self.data: DataType = {"name": name, "id": id, "eta": None if eta is None else eta.isot, "obsnum": obsnum}
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> Event:
@@ -49,8 +51,11 @@ class TaskStartedEvent(Event):
         if "eta" in d and isinstance(d["eta"], str):
             eta = Time(d["eta"])
 
+        # get obsnum
+        obsnum: str | None = d.get("obsnum")
+
         # return object
-        return TaskStartedEvent(name=name, id=id, eta=eta)
+        return TaskStartedEvent(name=name, id=id, eta=eta, obsnum=obsnum)
 
     @property
     def name(self) -> str:
@@ -65,6 +70,10 @@ class TaskStartedEvent(Event):
         from pyobs.utils.time import Time
 
         return Time(self.data["eta"]) if self.data["eta"] is not None else None
+
+    @property
+    def obsnum(self) -> str | None:
+        return self.data["obsnum"]
 
 
 __all__ = ["TaskStartedEvent"]

--- a/pyobs/interfaces/IRobotic.py
+++ b/pyobs/interfaces/IRobotic.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from abc import ABCMeta
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from ..utils.time import Time
+from .IStartStop import IStartStop
+
+if TYPE_CHECKING:
+    from ..robotic.observation import Observation
+
+
+@dataclass
+class RoboticTask:
+    id: Any
+    name: str
+    target: str | None = None  # target name, resolved if available
+    start: Time | None = None  # planned start (next) / actual start (current)
+    end: Time | None = None  # planned end / ETA
+    obsnum: str | None = None  # "20260810-001" once assigned by the executor
+    # ObservationState value (e.g. "in_progress"), kept as a plain str rather than
+    # pyobs.robotic.observation.ObservationState: pyobs.interfaces must not depend on
+    # pyobs.robotic (which itself depends on pyobs.interfaces), or module import order decides
+    # whether it works.
+    state: str | None = None
+    priority: float | None = None
+
+    @classmethod
+    def from_observation(cls, observation: Observation) -> RoboticTask:
+        """Build a wire-sized task summary from a full `Observation` record."""
+        return cls(
+            id=observation.task.id,
+            name=observation.task.name,
+            target=observation.target.name if observation.target is not None else None,
+            start=Time(observation.start),
+            end=Time(observation.end),
+            obsnum=observation.obsnum,
+            state=observation.state.value,
+            priority=observation.priority,
+        )
+
+
+@dataclass
+class RoboticState:
+    current: RoboticTask | None = None
+    next: RoboticTask | None = None  # immediate next observation to run
+    cant_run_reason: str | None = None  # from TaskRunner.cant_run_reason(), for `next`
+    time: Time = field(default_factory=Time.now)
+
+
+class IRobotic(IStartStop, metaclass=ABCMeta):
+    """The module executes a schedule of tasks (e.g. Mastermind)."""
+
+    __module__ = "pyobs.interfaces"
+
+    state = RoboticState
+
+
+__all__ = ["IRobotic", "RoboticTask", "RoboticState"]

--- a/pyobs/interfaces/IRoboticScheduler.py
+++ b/pyobs/interfaces/IRoboticScheduler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..utils.time import Time
+from .IRobotic import RoboticTask
+from .IStartStop import IStartStop
+
+
+@dataclass
+class SchedulerState:
+    last_reschedule: Time | None = None
+    time: Time = field(default_factory=Time.now)
+
+
+class IRoboticScheduler(IStartStop, metaclass=ABCMeta):
+    """The module plans a schedule of tasks for an IRobotic executor to run (e.g. Scheduler)."""
+
+    __module__ = "pyobs.interfaces"
+
+    state = SchedulerState
+
+    @abstractmethod
+    async def get_schedule(self, limit: int = 20, **kwargs: Any) -> list[RoboticTask]:
+        """Return the upcoming (pending/in-progress) schedule, most imminent first.
+
+        Args:
+            limit: Maximum number of entries to return. The implementation also enforces its
+                own hard ceiling regardless of what's requested here, so the full schedule
+                never has to go over the wire.
+
+        Returns:
+            Up to `limit` scheduled tasks.
+        """
+        ...
+
+
+__all__ = ["IRoboticScheduler", "SchedulerState"]

--- a/pyobs/interfaces/__init__.py
+++ b/pyobs/interfaces/__init__.py
@@ -52,6 +52,8 @@ from .IPointingOrbitalElements import IPointingOrbitalElements, OrbitalElements
 from .IPointingRaDec import IPointingRaDec, RaDecState
 from .IPointingSeries import IPointingSeries
 from .IReady import IReady, ReadyState
+from .IRobotic import IRobotic, RoboticState, RoboticTask
+from .IRoboticScheduler import IRoboticScheduler, SchedulerState
 from .IRoof import IRoof
 from .IRotation import IRotation, RotationState
 from .IRunnable import IRunnable
@@ -149,6 +151,11 @@ __all__ = [
     "IPointingSeries",
     "IReady",
     "ReadyState",
+    "IRobotic",
+    "RoboticTask",
+    "RoboticState",
+    "IRoboticScheduler",
+    "SchedulerState",
     "IRoof",
     "IRotation",
     "RotationState",

--- a/pyobs/modules/robotic/mastermind.py
+++ b/pyobs/modules/robotic/mastermind.py
@@ -5,7 +5,8 @@ from typing import Any
 import astropy.units as u
 
 from pyobs.events import TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
-from pyobs.interfaces import FitsHeaderEntry, IAutonomous, IFitsHeaderBefore, IRunning
+from pyobs.interfaces import FitsHeaderEntry, IAutonomous, IFitsHeaderBefore, IRobotic, IRunning
+from pyobs.interfaces.IRobotic import RoboticState, RoboticTask
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.robotic import (
@@ -23,7 +24,7 @@ from pyobs.utils.time import Time
 log = logging.getLogger(__name__)
 
 
-class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
+class Mastermind(Module, IAutonomous, IRobotic, IFitsHeaderBefore):
     """Mastermind for a full robotic mode."""
 
     __module__ = "pyobs.modules.robotic"
@@ -52,7 +53,8 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
         self._allowed_overrun = allowed_overrun
         self._running = False
         self._after_task_sleep = after_task_sleep
-        self._last_cant_run_reason: dict[Any, str] = {}
+        self._cant_run_reason: str | None = None
+        self._next_observation: Observation | None = None
 
         # add thread func
         self.add_background_task(self._run_thread, True)
@@ -66,6 +68,8 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
         self._task: Task | None = None
         self._task_target: Target | None = None
         self._obsnum: str | None = None
+        self._task_start: Time | None = None
+        self._task_eta: Time | None = None
 
         # per-night observation counter
         self._obsnum_cache = f"/pyobs/modules/{self.name}/obsnum.yaml"
@@ -110,18 +114,41 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
         # start
         self._running = True
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish_robotic_state()
 
     async def start(self, **kwargs: Any) -> None:
         """Starts a service."""
         log.info("Starting robotic system...")
         self._running = True
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish_robotic_state()
 
     async def stop(self, **kwargs: Any) -> None:
         """Stops a service."""
         log.info("Stopping robotic system...")
         self._running = False
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish_robotic_state()
+
+    async def _publish_robotic_state(self) -> None:
+        """Publish IRobotic state: current task (from self._task/...), and self._next_observation
+        / self._cant_run_reason as last updated by _run_thread."""
+        current = None
+        if self._task is not None:
+            current = RoboticTask(
+                id=self._task.id,
+                name=self._task.name,
+                target=self._task_target.name if self._task_target is not None else None,
+                start=self._task_start,
+                end=self._task_eta,
+                obsnum=self._obsnum,
+                state=ObservationState.IN_PROGRESS.value,
+                priority=self._task.priority,
+            )
+        next_task = RoboticTask.from_observation(self._next_observation) if self._next_observation else None
+        await self.comm.set_state(
+            IRobotic, RoboticState(current=current, next=next_task, cant_run_reason=self._cant_run_reason)
+        )
 
     async def _run_thread(self) -> None:
         # wait a little
@@ -146,21 +173,35 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
                 now, self._task_archive
             )
             if observation is None:
+                # nothing scheduled at all -- publish once when this changes, not every loop
+                if self._next_observation is not None or self._cant_run_reason is not None:
+                    self._next_observation = None
+                    self._cant_run_reason = None
+                    await self._publish_robotic_state()
                 await asyncio.sleep(10)
                 continue
 
             if not await self._task_runner.can_run(observation.task, observation.target):
                 reason = self._task_runner.cant_run_reason(observation.task)
-                if reason is not None:
-                    last = self._last_cant_run_reason.get(observation.task.id)
-                    if last != reason:
+                # publish (and log) only when the next task or its reason actually changed --
+                # avoids spamming a state update every 10s while stuck on the same block
+                changed = (
+                    reason != self._cant_run_reason
+                    or self._next_observation is None
+                    or self._next_observation.task.id != observation.task.id
+                )
+                if changed:
+                    if reason is not None:
                         log.info("Task %s cannot run: %s", observation.task.name, reason)
-                        self._last_cant_run_reason[observation.task.id] = reason
+                    self._cant_run_reason = reason
+                    self._next_observation = observation
+                    await self._publish_robotic_state()
                 await asyncio.sleep(10)
                 continue
 
             # task can run — clear stored reason
-            self._last_cant_run_reason.pop(observation.task.id, None)
+            self._cant_run_reason = None
+            self._next_observation = None
 
             # starting too late?
             if not observation.task.can_start_late:
@@ -190,14 +231,19 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             # ETA
             now = Time.now()
             eta = now + self._task.duration * u.second
+            self._task_start = now
+            self._task_eta = eta
 
             # send event and change state
-            await self.comm.send_event(TaskStartedEvent(name=self._task.name, id=self._task.id, eta=eta))
+            await self.comm.send_event(
+                TaskStartedEvent(name=self._task.name, id=self._task.id, eta=eta, obsnum=self._obsnum)
+            )
             observation.state = ObservationState.IN_PROGRESS
             observation.start = now
             observation.end = eta
             observation.obsnum = self._obsnum
             await self._observation_archive.update_observation(observation)
+            await self._publish_robotic_state()
 
             # run task in thread
             log.info("Running task %s...", self._task.name)
@@ -215,14 +261,17 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
                 observation.end = Time.now()
                 observation.state = ObservationState.FAILED
                 await self._observation_archive.update_observation(observation)
-                await self.comm.send_event(TaskFailedEvent(name=self._task.name, id=self._task.id))
+                await self.comm.send_event(TaskFailedEvent(name=self._task.name, id=self._task.id, obsnum=self._obsnum))
                 self._task = None
                 self._task_target = None
                 self._obsnum = None
+                self._task_start = None
+                self._task_eta = None
+                await self._publish_robotic_state()
                 continue
 
             # send event and change state
-            await self.comm.send_event(TaskFinishedEvent(name=self._task.name, id=self._task.id))
+            await self.comm.send_event(TaskFinishedEvent(name=self._task.name, id=self._task.id, obsnum=self._obsnum))
             observation.end = Time.now()
             observation.state = ObservationState.COMPLETED
             await self._observation_archive.update_observation(observation)
@@ -232,6 +281,9 @@ class Mastermind(Module, IAutonomous, IFitsHeaderBefore):
             self._task = None
             self._task_target = None
             self._obsnum = None
+            self._task_start = None
+            self._task_eta = None
+            await self._publish_robotic_state()
 
             # sleep?
             await asyncio.sleep(self._after_task_sleep)

--- a/pyobs/modules/robotic/mastermind.py
+++ b/pyobs/modules/robotic/mastermind.py
@@ -5,8 +5,15 @@ from typing import Any
 import astropy.units as u
 
 from pyobs.events import TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
-from pyobs.interfaces import FitsHeaderEntry, IAutonomous, IFitsHeaderBefore, IRobotic, IRunning
-from pyobs.interfaces.IRobotic import RoboticState, RoboticTask
+from pyobs.interfaces import (
+    FitsHeaderEntry,
+    IAutonomous,
+    IFitsHeaderBefore,
+    IRobotic,
+    IRunning,
+    RoboticState,
+    RoboticTask,
+)
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.robotic import (
@@ -150,6 +157,27 @@ class Mastermind(Module, IAutonomous, IRobotic, IFitsHeaderBefore):
             IRobotic, RoboticState(current=current, next=next_task, cant_run_reason=self._cant_run_reason)
         )
 
+    async def _track_next_observation(self, observation: Observation, reason: str | None) -> bool:
+        """Update self._next_observation/_cant_run_reason and publish, but only if either
+        actually changed since the last publish -- avoids spamming a state update every loop
+        iteration while stuck on the same block (cannot-run, or late-start skip).
+
+        Returns:
+            Whether anything had changed (and was therefore published).
+        """
+        changed = (
+            reason != self._cant_run_reason
+            or self._next_observation is None
+            or self._next_observation.task.id != observation.task.id
+            or self._next_observation.start != observation.start
+            or self._next_observation.end != observation.end
+        )
+        if changed:
+            self._cant_run_reason = reason
+            self._next_observation = observation
+            await self._publish_robotic_state()
+        return changed
+
     async def _run_thread(self) -> None:
         # wait a little
         await asyncio.sleep(5)
@@ -183,19 +211,8 @@ class Mastermind(Module, IAutonomous, IRobotic, IFitsHeaderBefore):
 
             if not await self._task_runner.can_run(observation.task, observation.target):
                 reason = self._task_runner.cant_run_reason(observation.task)
-                # publish (and log) only when the next task or its reason actually changed --
-                # avoids spamming a state update every 10s while stuck on the same block
-                changed = (
-                    reason != self._cant_run_reason
-                    or self._next_observation is None
-                    or self._next_observation.task.id != observation.task.id
-                )
-                if changed:
-                    if reason is not None:
-                        log.info("Task %s cannot run: %s", observation.task.name, reason)
-                    self._cant_run_reason = reason
-                    self._next_observation = observation
-                    await self._publish_robotic_state()
+                if await self._track_next_observation(observation, reason) and reason is not None:
+                    log.info("Task %s cannot run: %s", observation.task.name, reason)
                 await asyncio.sleep(10)
                 continue
 
@@ -215,6 +232,10 @@ class Mastermind(Module, IAutonomous, IRobotic, IFitsHeaderBefore):
                             self._allowed_late_start,
                         )
                     first_late_start_warning = False
+
+                    # keep the skipped observation visible as `next` rather than leaving
+                    # whatever was last published stale for as long as this repeats
+                    await self._track_next_observation(observation, None)
 
                     # sleep a little and skip
                     await asyncio.sleep(10)

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -17,9 +17,7 @@ from pyobs.events import (
     TaskFinishedEvent,
     TaskStartedEvent,
 )
-from pyobs.interfaces import IRoboticScheduler, IRunnable, IRunning
-from pyobs.interfaces.IRobotic import RoboticTask
-from pyobs.interfaces.IRoboticScheduler import SchedulerState
+from pyobs.interfaces import IRoboticScheduler, IRunnable, IRunning, RoboticTask, SchedulerState
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.object import get_class_from_string
@@ -378,7 +376,19 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
             (obs for obs in schedule if obs.state in (ObservationState.PENDING, ObservationState.IN_PROGRESS)),
             key=lambda obs: obs.start,
         )
-        return [RoboticTask.from_observation(obs) for obs in pending[:limit]]
+
+        tasks = []
+        for obs in pending[:limit]:
+            # PortalObservationArchive.get_schedule() (unlike get_next_observation /
+            # get_current_observation) returns observations with `task` as a bare FK id, not a
+            # resolved Task -- fetch_task() is a no-op for backends that already store a full
+            # Task (memory/filesystem/LCO).
+            await obs.fetch_task(self._task_archive)
+            if obs.task is None:
+                log.error("Could not resolve task for observation %s, skipping.", obs.id)
+                continue
+            tasks.append(RoboticTask.from_observation(obs))
+        return tasks
 
     async def _on_task_started(self, event: Event, sender: str) -> bool:
         """Re-schedule when task has started and we can predict its end.

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -17,13 +17,16 @@ from pyobs.events import (
     TaskFinishedEvent,
     TaskStartedEvent,
 )
-from pyobs.interfaces import IRunnable, IRunning, IStartStop
+from pyobs.interfaces import IRoboticScheduler, IRunnable, IRunning
+from pyobs.interfaces.IRobotic import RoboticTask
+from pyobs.interfaces.IRoboticScheduler import SchedulerState
 from pyobs.interfaces.IRunning import RunningState
 from pyobs.modules import Module
 from pyobs.object import get_class_from_string
 from pyobs.robotic import (
     ObservationArchive,
     ObservationList,
+    ObservationState,
     Project,
     Task,
     TaskArchive,
@@ -66,10 +69,13 @@ def _class_accepts_param(config: dict[str, Any] | Any, param_name: str) -> bool:
     return False
 
 
-class Scheduler(Module, IStartStop, IRunnable):
+class Scheduler(Module, IRunnable, IRoboticScheduler):
     """Scheduler."""
 
     __module__ = "pyobs.modules.robotic"
+
+    # hard ceiling on get_schedule()'s limit, regardless of what a client requests
+    _MAX_SCHEDULE_LIMIT = 100
 
     def __init__(
         self,
@@ -128,6 +134,7 @@ class Scheduler(Module, IStartStop, IRunnable):
 
         # time to start next schedule from
         self._schedule_start: Time = Time.now()
+        self._last_reschedule: Time | None = None
 
         # ID of currently running task, and current (or last if finished) block
         self._current_task_id = None
@@ -152,16 +159,19 @@ class Scheduler(Module, IStartStop, IRunnable):
             await self.comm.register_event(GoodWeatherEvent, self._on_good_weather)
 
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
 
     async def start(self, **kwargs: Any) -> None:
         """Start scheduler."""
         self._running = True
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
 
     async def stop(self, **kwargs: Any) -> None:
         """Stop scheduler."""
         self._running = False
         await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
 
     async def _update_schedule(self) -> None:
         # get schedulable tasks and sort them
@@ -312,6 +322,10 @@ class Scheduler(Module, IStartStop, IRunnable):
                     # clean up
                     del scheduled_tasks
 
+                    # record + publish
+                    self._last_reschedule = Time.now()
+                    await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
+
                 except asyncio.CancelledError:
                     return
 
@@ -341,6 +355,30 @@ class Scheduler(Module, IStartStop, IRunnable):
     async def run(self, **kwargs: Any) -> None:
         """Trigger a re-schedule."""
         self._need_update = True
+
+    async def get_schedule(self, limit: int = 20, **kwargs: Any) -> list[RoboticTask]:
+        """Return the upcoming (pending/in-progress) schedule, most imminent first.
+
+        Args:
+            limit: Maximum number of entries to return.
+
+        Returns:
+            Up to `limit` scheduled tasks, capped at `_MAX_SCHEDULE_LIMIT` regardless of what's
+            requested.
+
+        Raises:
+            ValueError: If limit is negative.
+        """
+        if limit < 0:
+            raise ValueError("limit must be >= 0.")
+        limit = min(limit, self._MAX_SCHEDULE_LIMIT)
+
+        schedule = await self._schedule.get_schedule()
+        pending = sorted(
+            (obs for obs in schedule if obs.state in (ObservationState.PENDING, ObservationState.IN_PROGRESS)),
+            key=lambda obs: obs.start,
+        )
+        return [RoboticTask.from_observation(obs) for obs in pending[:limit]]
 
     async def _on_task_started(self, event: Event, sender: str) -> bool:
         """Re-schedule when task has started and we can predict its end.

--- a/specs/design/irobotic.md
+++ b/specs/design/irobotic.md
@@ -146,7 +146,11 @@ state on `open()`, `start()`, `stop()`, and on every task transition in `_run_th
 
 ### `Scheduler`
 
-`class Scheduler(Module, IStartStop, IRunnable, IRoboticScheduler)`. Publish `SchedulerState`
+`class Scheduler(Module, IRunnable, IRoboticScheduler)` — **not** `IStartStop` too: `IRoboticScheduler`
+already inherits it, and listing it explicitly *before* a subclass of it is an invalid MRO (Python
+raises `TypeError: Cannot create a consistent method resolution order`, confirmed against the real
+`IRunnable`/`IAbortable`/`IStartStop` chain). Same reasoning as `Mastermind` not listing `IStartStop`
+alongside `IAutonomous`/`IRobotic`. Publish `SchedulerState`
 on `open()`, `start()`, `stop()`, and after each `_schedule_worker` pass (`last_reschedule`).
 `get_schedule()` delegates to `self._schedule.get_schedule()`, maps observations to
 `RoboticTask`, filters to pending/in-progress, trims to `limit`.

--- a/specs/design/irobotic.md
+++ b/specs/design/irobotic.md
@@ -1,6 +1,8 @@
 # `IRobotic` / `IRoboticScheduler`: executor and planner widgets for robotic modules
 
-Status: proposed (issue #825).
+Status: partially implemented (issue #825). pyobs-core side (interfaces, `Mastermind`,
+`Scheduler`) landed in [pyobs-core#826](https://github.com/pyobs/pyobs-core/pull/826);
+pyobs-gui widgets not yet started.
 
 Repos: pyobs-core (interfaces, `Mastermind`, `Scheduler`), pyobs-gui (`RoboticWidget`,
 `ScheduleWidget`).
@@ -38,7 +40,7 @@ role-owned data differs:
 
 | | Mastermind (executor) | Scheduler (planner) |
 |---|---|---|
-| owns | the task it is executing right now (in-memory `_task`, `_task_target`, `_obsnum`, ETA) and **why a task can't run** (`TaskRunner.cant_run_reason`, tracked as `_last_cant_run_reason`) | the **plan** it computed and the action to **recompute it** (`IRunnable.run()`) |
+| owns | the task it is executing right now (in-memory `_task`, `_task_target`, `_obsnum`, ETA) and **why a task can't run** (`TaskRunner.cant_run_reason`, tracked alongside the blocked/skipped observation as `_cant_run_reason`/`_next_observation`) | the **plan** it computed and the action to **recompute it** (`IRunnable.run()`) |
 | additionally knows | the immediate next observation it will pick up (`ObservationArchive.get_next_observation` every loop) | — |
 | must not expose | the full schedule (shared data; would duplicate the planner tab) | current-task execution detail (only knows task IDs from `TaskStartedEvent`) |
 
@@ -88,13 +90,17 @@ class IRobotic(IStartStop, metaclass=ABCMeta):
   `ObservationArchive.get_next_observation()`, which does a live portal HTTP call for
   `LcoObservationArchive` — an RPC-triggered pull would turn a GUI refresh into a network
   request that can hang or fail if the portal is slow or down.
-- `cant_run_reason` must be computed fresh at publish time from the *current* `next`
-  observation (`self._task_runner.cant_run_reason(next.task)` if `next` is not `None`, else
-  `None`). It must **not** be read off `Mastermind._last_cant_run_reason` — that field is a
-  `dict[task_id, str]` used only to dedupe repeated log lines in `_run_thread`, keyed by
-  whichever tasks have recently failed `can_run()`; entries for tasks that stop being "next"
-  are never cleared, so it can hold several stale reasons at once and has no defined mapping
-  to a single scalar.
+- `cant_run_reason` is tracked as a scalar pair with `next` — `Mastermind._cant_run_reason` /
+  `_next_observation` — updated together via a single `_track_next_observation(observation,
+  reason)` helper, not read off a per-task dict. (An earlier draft of this field kept a
+  `dict[task_id, str]` purely to dedupe repeated log lines; that had no defined mapping to a
+  single scalar and is gone — the scalar pair now serves both the log dedup and the published
+  state.) The helper republishes only when the observation (by task id, `start`, `end`) or the
+  reason actually changed since the last publish, so `_run_thread`'s ~10s poll doesn't spam a
+  state update while stuck on the same block. It's called from both places `_run_thread` can be
+  stuck without transitioning: the "cannot run" branch (real `cant_run_reason`) and the
+  late-start-skip branch (`cant_run_reason=None` — `TaskRunner.cant_run_reason()` was never
+  consulted for that failure mode, so the field stays honest about what it actually reflects).
 - `next` is the immediate next observation the executor will start — deliberately *not* the
   full schedule; it pairs with `cant_run_reason` to answer "what's next and why are we
   waiting?".
@@ -130,19 +136,22 @@ class IRoboticScheduler(IStartStop, metaclass=ABCMeta):
 ### `Mastermind`
 
 `class Mastermind(Module, IAutonomous, IRobotic, IFitsHeaderBefore)`. Publish `IRobotic`
-state on `open()`, `start()`, `stop()`, and on every task transition in `_run_thread`
-(started / finished / failed):
+state on `open()`, `start()`, `stop()`, on every task transition in `_run_thread`
+(started / finished / failed), and — via `_track_next_observation()` — whenever the tracked
+`next` observation or `cant_run_reason` actually changes while nothing is transitioning (stuck
+on a "cannot run" block, or repeatedly skipping the same observation for starting too late):
 
 - `current` ← `self._task`, `self._task_target`, `self._obsnum` (+ ETA from `task.duration`);
   already in memory, no extra query.
-- `next` ← `self._observation_archive.get_next_observation(now, self._task_archive)` — **not**
-  free: for `LcoObservationArchive` this is a live portal HTTP call. Only call it from inside
+- `next` ← `self._next_observation`, set from whatever `_run_thread` last got back from
+  `self._observation_archive.get_next_observation(now, self._task_archive)` — **not** free: for
+  `LcoObservationArchive` this is a live portal HTTP call. Only call it from inside
   `_run_thread`, where it already runs every loop iteration regardless; never re-derive it on
   an RPC path (there is no `get_status()` — see above).
-- `cant_run_reason` ← computed at publish time as `self._task_runner.cant_run_reason(next.task)`
-  if `next` is not `None`, else `None`. Do not read `self._last_cant_run_reason` for this —
-  it's a private log-dedup cache (`dict[task_id, str]`), not a snapshot of "why can't the next
-  task run right now".
+- `cant_run_reason` ← `self._cant_run_reason`, set alongside `_next_observation` by
+  `_track_next_observation`: `self._task_runner.cant_run_reason(next.task)` when blocked, or
+  `None` on a late-start skip (see the note above — that failure mode isn't sourced from
+  `TaskRunner.cant_run_reason()`).
 
 ### `Scheduler`
 
@@ -200,11 +209,19 @@ ACLs via `self.permitted(...)` (see `pyobs-gui/specs/plans/2026-07-29-gui-acl-aw
 
 ## What a plan would need to cover
 
-1. Interface files + exports + dataclass serialization (round-trip tests).
-2. `Mastermind` state publishing (transitions in `_run_thread`, `cant_run_reason` derived fresh
-   from `next` at publish time — not from `_last_cant_run_reason`).
-3. `Scheduler` state publishing and `get_schedule` trimming + hard server-side cap.
-4. Add `obsnum: str | None` to `TaskStartedEvent` / `TaskFinishedEvent` / `TaskFailedEvent`.
-5. `RoboticWidget` + `ScheduleWidget` implementations and `DEFAULT_WIDGETS` registration.
-6. Tests: state round-trip, publish transitions, schedule trimming, `get_schedule` cap; GUI
-   fake-comm tests per `pyobs-gui/tests/test_mainwindow_startup.py` patterns.
+pyobs-core side (1–4, and the pyobs-core half of 6) implemented in
+[pyobs-core#826](https://github.com/pyobs/pyobs-core/pull/826):
+
+1. ~~Interface files + exports + dataclass serialization (round-trip tests).~~ Done.
+2. ~~`Mastermind` state publishing (transitions in `_run_thread`, plus `_track_next_observation`
+   republishing on change while stuck without transitioning).~~ Done.
+3. ~~`Scheduler` state publishing and `get_schedule` trimming + hard server-side cap.~~ Done
+   (`get_schedule()` also resolves bare-FK-id tasks via `TaskArchive` for
+   `PortalObservationArchive`, whose `get_schedule()` doesn't resolve them itself).
+4. ~~Add `obsnum: str | None` to `TaskStartedEvent` / `TaskFinishedEvent` / `TaskFailedEvent`.~~
+   Done.
+5. `RoboticWidget` + `ScheduleWidget` implementations and `DEFAULT_WIDGETS` registration —
+   pyobs-gui, not yet started.
+6. ~~Tests: state round-trip, publish transitions, schedule trimming, `get_schedule` cap.~~
+   pyobs-core half done. GUI fake-comm tests per
+   `pyobs-gui/tests/test_mainwindow_startup.py` patterns — not yet started.

--- a/tests/integration/test_mastermind.py
+++ b/tests/integration/test_mastermind.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import pytest
 from astropy.time import TimeDelta
 
+from pyobs.interfaces import IRobotic
 from pyobs.modules.robotic.mastermind import Mastermind
 from pyobs.robotic import Task
 from pyobs.robotic.observation import Observation, ObservationList, ObservationState
@@ -37,6 +38,19 @@ class FailingRunner(TaskRunner):
 
     async def run_task(self, task, target=None) -> bool:
         raise RuntimeError("intentional failure")
+
+
+class BlockedRunner(TaskRunner):
+    """TaskRunner that never lets its task run, with a fixed reason."""
+
+    async def can_run(self, task, target=None) -> bool:
+        return False
+
+    def cant_run_reason(self, task) -> str:
+        return "weather bad"
+
+    async def run_task(self, task, target=None) -> bool:
+        raise AssertionError("should never be called -- can_run() is always False")
 
 
 # ── fixed time so get_next_observation finds our observations ─────────────────
@@ -334,3 +348,95 @@ async def test_mastermind_resets_obsnum_on_new_night() -> None:
     obsnums = {o.start.strftime("%Y%m%d"): o.obsnum for o in await obs_archive.get_schedule()}
     assert obsnums[NIGHT.strftime("%Y%m%d")] == "20251103-001"
     assert obsnums[next_night.strftime("%Y%m%d")] == "20251104-001"
+
+
+# ── IRobotic state publishing ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_events_carry_obsnum() -> None:
+    """TaskStartedEvent/TaskFinishedEvent carry the same obsnum as the observation."""
+    from pyobs.events import TaskFinishedEvent, TaskStartedEvent
+
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs()]))
+
+    events_sent = []
+    original_send = mm.comm.send_event
+
+    async def tracking_send(event):
+        events_sent.append(event)
+        return await original_send(event)
+
+    mm.comm.send_event = tracking_send
+
+    await run_until_state(mm, obs_archive, ObservationState.COMPLETED)
+
+    started = next(e for e in events_sent if isinstance(e, TaskStartedEvent))
+    finished = next(e for e in events_sent if isinstance(e, TaskFinishedEvent))
+    assert started.obsnum == "20251103-001"
+    assert finished.obsnum == "20251103-001"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_publishes_robotic_state_on_task_start() -> None:
+    """comm.set_state(IRobotic, ...) fires with the running task once it starts."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+    await obs_archive.add_observations(ObservationList([make_obs()]))
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+
+    await run_until_state(mm, obs_archive, ObservationState.IN_PROGRESS)
+
+    assert any(s.current is not None and s.current.name == "test_task" for s in states)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_publishes_cant_run_reason(mocker) -> None:
+    """comm.set_state(IRobotic, ...) reports why the next task can't run yet."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive, runner=BlockedRunner())
+    await obs_archive.add_observations(ObservationList([make_obs()]))
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+
+    call_count = 0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            raise asyncio.CancelledError()
+        await real_sleep(0)
+
+    mocker.patch("pyobs.modules.robotic.mastermind.asyncio.sleep", side_effect=fake_sleep)
+
+    with patch("pyobs.utils.time.Time.now", return_value=NIGHT):
+        with pytest.raises(asyncio.CancelledError):
+            await mm._run_thread()
+
+    assert mm._cant_run_reason == "weather bad"
+    assert mm._next_observation is not None
+    assert any(s.cant_run_reason == "weather bad" and s.next is not None for s in states)

--- a/tests/integration/test_mastermind.py
+++ b/tests/integration/test_mastermind.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import astropy.units as u
 import pytest
@@ -440,3 +440,137 @@ async def test_mastermind_publishes_cant_run_reason(mocker) -> None:
     assert mm._cant_run_reason == "weather bad"
     assert mm._next_observation is not None
     assert any(s.cant_run_reason == "weather bad" and s.next is not None for s in states)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_publishes_robotic_state_on_open(mocker) -> None:
+    """comm.set_state(IRobotic, ...) fires on open(), even with no task running yet."""
+    from pyobs.modules import Module
+
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+    mocker.patch.object(Module, "open", AsyncMock())
+
+    await mm.open()
+
+    assert len(states) == 1
+    assert states[0].current is None
+    assert states[0].next is None
+    assert states[0].cant_run_reason is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_publishes_robotic_state_on_start_and_stop() -> None:
+    """comm.set_state(IRobotic, ...) fires on start() and stop() too."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive)
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+
+    await mm.start()
+    await mm.stop()
+
+    assert len(states) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_does_not_republish_unchanged_cant_run_reason(mocker) -> None:
+    """No repeated comm.set_state(IRobotic, ...) call while stuck on the same block with the
+    same reason -- the anti-spam dedup in _track_next_observation."""
+    obs_archive = make_obs_archive()
+    mm = make_mastermind(obs_archive, runner=BlockedRunner())
+    await obs_archive.add_observations(ObservationList([make_obs()]))
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+
+    call_count = 0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 5:  # several iterations of the "cannot run" branch
+            raise asyncio.CancelledError()
+        await real_sleep(0)
+
+    mocker.patch("pyobs.modules.robotic.mastermind.asyncio.sleep", side_effect=fake_sleep)
+
+    with patch("pyobs.utils.time.Time.now", return_value=NIGHT):
+        with pytest.raises(asyncio.CancelledError):
+            await mm._run_thread()
+
+    # same blocked observation + same reason every iteration -- exactly one publish, not one
+    # per loop iteration
+    assert len(states) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mastermind_publishes_late_start_skip() -> None:
+    """comm.set_state(IRobotic, ...) keeps the skipped observation visible as `next` while a
+    task is repeatedly skipped for starting too late, instead of leaving a stale publish."""
+    obs_archive = make_obs_archive()
+    runner = QuickRunner()
+    mm = make_mastermind(obs_archive, runner=runner)
+    mm._allowed_late_start = 0
+    # window opened well in the past (immediately "too late" with allowed_late_start=0) but is
+    # still active at NIGHT, so get_next_observation() actually returns it
+    obs = make_obs(duration=60.0)
+    obs.start = NIGHT - TimeDelta(3600 * u.second)
+    obs.end = NIGHT + TimeDelta(60 * u.second)
+    await obs_archive.add_observations(ObservationList([obs]))
+
+    states = []
+    original_set_state = mm.comm.set_state
+
+    async def tracking_set_state(interface, state):
+        if interface is IRobotic:
+            states.append(state)
+        return await original_set_state(interface, state)
+
+    mm.comm.set_state = tracking_set_state
+
+    with patch("pyobs.utils.time.Time.now", return_value=NIGHT):
+        task_handle = asyncio.create_task(mm._run_thread())
+        try:
+            await asyncio.sleep(6)  # clear the initial 5s startup delay
+        finally:
+            await mm.stop()
+            task_handle.cancel()
+            try:
+                await task_handle
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    assert mm._task is None  # never actually started
+    assert mm._next_observation is not None
+    assert any(s.next is not None for s in states)

--- a/tests/interfaces/test_irobotic.py
+++ b/tests/interfaces/test_irobotic.py
@@ -1,0 +1,107 @@
+"""Tests for the IRobotic/IRoboticScheduler interfaces' state dataclasses."""
+
+from __future__ import annotations
+
+from pyobs.comm.xmpp.serializer import _dataclass_to_xml, _xml_to_dataclass
+from pyobs.interfaces import (
+    IRobotic,
+    IRoboticScheduler,
+    RoboticState,
+    RoboticTask,
+    SchedulerState,
+)
+from pyobs.robotic.observation import Observation, ObservationState
+from pyobs.robotic.task import Task
+from pyobs.utils.time import Time
+
+
+def test_has_own_state() -> None:
+    assert IRobotic.has_own_state() is True
+    assert IRoboticScheduler.has_own_state() is True
+
+
+def test_robotic_task_defaults() -> None:
+    task = RoboticTask(id=1, name="foo")
+    assert task.target is None
+    assert task.start is None
+    assert task.end is None
+    assert task.obsnum is None
+    assert task.state is None
+    assert task.priority is None
+
+
+def test_robotic_state_roundtrip_with_current_and_next() -> None:
+    ns = f"urn:pyobs:state:IRobotic:{IRobotic.version}"
+    current = RoboticTask(
+        id=1, name="foo", target="M31", start=Time.now(), end=Time.now(), obsnum="20260830-001", state="in_progress"
+    )
+    next_task = RoboticTask(id=2, name="bar", state="pending")
+    state = RoboticState(current=current, next=next_task, cant_run_reason="weather bad")
+
+    xml = _dataclass_to_xml(state, ns)
+    restored = _xml_to_dataclass(xml, RoboticState)
+
+    # Time round-trips through isot text on the wire, which drops sub-millisecond precision --
+    # compare that text form rather than the Time objects themselves.
+    assert restored.current.start.isot == current.start.isot
+    assert restored.current.end.isot == current.end.isot
+    restored.current.start = restored.current.end = current.start = current.end = None
+    assert restored.current == current
+    assert restored.next == next_task
+    assert restored.cant_run_reason == "weather bad"
+
+
+def test_robotic_state_roundtrip_with_none_current_and_next() -> None:
+    ns = f"urn:pyobs:state:IRobotic:{IRobotic.version}"
+    state = RoboticState()
+
+    xml = _dataclass_to_xml(state, ns)
+    restored = _xml_to_dataclass(xml, RoboticState)
+
+    assert restored.current is None
+    assert restored.next is None
+    assert restored.cant_run_reason is None
+
+
+def test_scheduler_state_roundtrip() -> None:
+    ns = f"urn:pyobs:state:IRoboticScheduler:{IRoboticScheduler.version}"
+    state = SchedulerState(last_reschedule=Time.now())
+
+    xml = _dataclass_to_xml(state, ns)
+    restored = _xml_to_dataclass(xml, SchedulerState)
+
+    assert restored.last_reschedule.isot == state.last_reschedule.isot
+
+
+def test_scheduler_state_roundtrip_none_last_reschedule() -> None:
+    ns = f"urn:pyobs:state:IRoboticScheduler:{IRoboticScheduler.version}"
+    state = SchedulerState()
+
+    xml = _dataclass_to_xml(state, ns)
+    restored = _xml_to_dataclass(xml, SchedulerState)
+
+    assert restored.last_reschedule is None
+
+
+def test_robotic_task_from_observation() -> None:
+    task = Task(id="t1", name="task1", priority=3.0)
+    obs = Observation(
+        id=1,
+        task=task,
+        start="2026-08-30T10:00:00",
+        end="2026-08-30T10:05:00",
+        state=ObservationState.PENDING,
+        priority=3.0,
+        obsnum="20260830-002",
+    )
+
+    rt = RoboticTask.from_observation(obs)
+
+    assert rt.id == "t1"
+    assert rt.name == "task1"
+    assert rt.target is None
+    assert rt.obsnum == "20260830-002"
+    assert rt.state == "pending"
+    assert rt.priority == 3.0
+    assert isinstance(rt.start, Time)
+    assert isinstance(rt.end, Time)

--- a/tests/interfaces/test_irobotic.py
+++ b/tests/interfaces/test_irobotic.py
@@ -43,6 +43,9 @@ def test_robotic_state_roundtrip_with_current_and_next() -> None:
 
     # Time round-trips through isot text on the wire, which drops sub-millisecond precision --
     # compare that text form rather than the Time objects themselves.
+    assert restored.current is not None
+    assert current.start is not None and current.end is not None
+    assert restored.current.start is not None and restored.current.end is not None
     assert restored.current.start.isot == current.start.isot
     assert restored.current.end.isot == current.end.isot
     restored.current.start = restored.current.end = current.start = current.end = None
@@ -70,6 +73,8 @@ def test_scheduler_state_roundtrip() -> None:
     xml = _dataclass_to_xml(state, ns)
     restored = _xml_to_dataclass(xml, SchedulerState)
 
+    assert restored.last_reschedule is not None
+    assert state.last_reschedule is not None
     assert restored.last_reschedule.isot == state.last_reschedule.isot
 
 
@@ -105,3 +110,22 @@ def test_robotic_task_from_observation() -> None:
     assert rt.priority == 3.0
     assert isinstance(rt.start, Time)
     assert isinstance(rt.end, Time)
+
+
+def test_robotic_task_from_observation_with_resolved_target() -> None:
+    from pyobs.robotic.scheduler.targets.siderealtarget import SiderealTarget
+
+    task = Task(id="t1", name="task1")
+    target = SiderealTarget(name="M31", ra=10.68, dec=41.27)
+    obs = Observation(
+        id=1,
+        task=task,
+        start="2026-08-30T10:00:00",
+        end="2026-08-30T10:05:00",
+        state=ObservationState.PENDING,
+        target=target,
+    )
+
+    rt = RoboticTask.from_observation(obs)
+
+    assert rt.target == "M31"

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -683,7 +683,8 @@ async def test_get_schedule_sorts_by_start_time() -> None:
 
     result = await scheduler.get_schedule()
 
-    assert [r.start.isot for r in result] == [earlier.start.isot, later.start.isot]
+    assert all(r.start is not None for r in result)
+    assert [r.start.isot for r in result if r.start is not None] == [earlier.start.isot, later.start.isot]
 
 
 @pytest.mark.asyncio
@@ -704,16 +705,25 @@ async def test_get_schedule_respects_limit() -> None:
 async def test_get_schedule_caps_limit_at_hard_ceiling() -> None:
     scheduler = make_scheduler()
     task = DummyTask(id=1, name="t1", duration=100)
+    base = Time("2024-01-01T00:00:00")
     obs_list = ObservationList(
-        [make_obs(task, f"2024-01-01T00:{i:02d}:00", f"2024-01-01T00:{i:02d}:05") for i in range(5)]
+        [
+            Observation(
+                task=task,
+                start=base + i * u.minute,
+                end=base + (i + 1) * u.minute,
+                state=ObservationState.PENDING,
+            )
+            for i in range(scheduler._MAX_SCHEDULE_LIMIT + 10)
+        ]
     )
     scheduler._schedule.get_schedule = AsyncMock(return_value=obs_list)
 
+    # more candidates exist than the hard ceiling, so the clamp -- not just the sheer count
+    # requested -- is what determines the result size
     result = await scheduler.get_schedule(limit=10_000)
 
-    # would return all 5 either way, so pin the clamp itself rather than the outcome
-    assert scheduler._MAX_SCHEDULE_LIMIT < 10_000
-    assert len(result) == 5
+    assert len(result) == scheduler._MAX_SCHEDULE_LIMIT
 
 
 @pytest.mark.asyncio
@@ -721,6 +731,35 @@ async def test_get_schedule_rejects_negative_limit() -> None:
     scheduler = make_scheduler()
     with pytest.raises(ValueError):
         await scheduler.get_schedule(limit=-1)
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_resolves_unresolved_task() -> None:
+    """PortalObservationArchive.get_schedule() returns `task` as a bare id -- get_schedule()
+    must resolve it via the task archive before mapping to RoboticTask."""
+    scheduler = make_scheduler()
+    resolved = DummyTask(id=42, name="resolved", duration=100)
+    unresolved_obs = Observation(task=42, start="2024-01-01T00:00:00", end="2024-01-01T00:05:00", state="pending")
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([unresolved_obs]))
+    scheduler._task_archive.get_task = AsyncMock(return_value=resolved)
+
+    result = await scheduler.get_schedule()
+
+    scheduler._task_archive.get_task.assert_awaited_once_with(42)
+    assert len(result) == 1
+    assert result[0].name == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_skips_unresolvable_task() -> None:
+    scheduler = make_scheduler()
+    unresolved_obs = Observation(task=99, start="2024-01-01T00:00:00", end="2024-01-01T00:05:00", state="pending")
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([unresolved_obs]))
+    scheduler._task_archive.get_task = AsyncMock(return_value=None)
+
+    result = await scheduler.get_schedule()
+
+    assert result == []
 
 
 # ── SchedulerState publishing ────────────────────────────────────────────────

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -6,7 +6,7 @@ import pytest
 
 from pyobs.comm import Comm
 from pyobs.events import GoodWeatherEvent, TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
-from pyobs.interfaces import IRunning
+from pyobs.interfaces import IRoboticScheduler, IRunning
 from pyobs.modules.robotic import Scheduler
 from pyobs.modules.robotic.scheduler import _class_accepts_param
 from pyobs.robotic import ObservationArchive, Task, TaskArchive
@@ -652,3 +652,121 @@ async def test_abort_is_noop() -> None:
     scheduler = make_scheduler()
     # should not raise
     await scheduler.abort()
+
+
+# ── get_schedule ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_filters_to_pending_and_in_progress() -> None:
+    scheduler = make_scheduler()
+    task = DummyTask(id=1, name="t1", duration=100)
+    pending = make_obs(task, "2024-01-01T00:00:00", "2024-01-01T00:05:00")
+    in_progress = make_obs(task, "2024-01-01T00:05:00", "2024-01-01T00:10:00")
+    in_progress.state = ObservationState.IN_PROGRESS
+    completed = make_obs(task, "2024-01-01T00:10:00", "2024-01-01T00:15:00")
+    completed.state = ObservationState.COMPLETED
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([completed, pending, in_progress]))
+
+    result = await scheduler.get_schedule()
+
+    assert [r.state for r in result] == ["pending", "in_progress"]
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_sorts_by_start_time() -> None:
+    scheduler = make_scheduler()
+    task = DummyTask(id=1, name="t1", duration=100)
+    later = make_obs(task, "2024-01-01T01:00:00", "2024-01-01T01:05:00")
+    earlier = make_obs(task, "2024-01-01T00:00:00", "2024-01-01T00:05:00")
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([later, earlier]))
+
+    result = await scheduler.get_schedule()
+
+    assert [r.start.isot for r in result] == [earlier.start.isot, later.start.isot]
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_respects_limit() -> None:
+    scheduler = make_scheduler()
+    task = DummyTask(id=1, name="t1", duration=100)
+    obs_list = ObservationList(
+        [make_obs(task, f"2024-01-01T{i:02d}:00:00", f"2024-01-01T{i:02d}:05:00") for i in range(5)]
+    )
+    scheduler._schedule.get_schedule = AsyncMock(return_value=obs_list)
+
+    result = await scheduler.get_schedule(limit=2)
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_caps_limit_at_hard_ceiling() -> None:
+    scheduler = make_scheduler()
+    task = DummyTask(id=1, name="t1", duration=100)
+    obs_list = ObservationList(
+        [make_obs(task, f"2024-01-01T00:{i:02d}:00", f"2024-01-01T00:{i:02d}:05") for i in range(5)]
+    )
+    scheduler._schedule.get_schedule = AsyncMock(return_value=obs_list)
+
+    result = await scheduler.get_schedule(limit=10_000)
+
+    # would return all 5 either way, so pin the clamp itself rather than the outcome
+    assert scheduler._MAX_SCHEDULE_LIMIT < 10_000
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_rejects_negative_limit() -> None:
+    scheduler = make_scheduler()
+    with pytest.raises(ValueError):
+        await scheduler.get_schedule(limit=-1)
+
+
+# ── SchedulerState publishing ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_open_publishes_scheduler_state(mocker) -> None:
+    from pyobs.modules import Module
+
+    scheduler = make_scheduler()
+    scheduler._comm.register_event = AsyncMock()
+    scheduler._comm.set_state = AsyncMock()
+    mocker.patch.object(Module, "open", AsyncMock())
+
+    await scheduler.open()
+
+    state = _state_for(scheduler._comm.set_state, IRoboticScheduler)
+    assert state.last_reschedule is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_worker_publishes_last_reschedule(mocker) -> None:
+    scheduler = make_scheduler(min_safety_time=1.0)
+    scheduler._need_update = True
+    scheduler._initial_update_done = True
+    scheduler._schedule.get_current_observation = AsyncMock(return_value=None)
+    scheduler._schedule.clear_schedule = AsyncMock()
+    scheduler._schedule.add_observations = AsyncMock()
+    scheduler._comm.set_state = AsyncMock()
+
+    task = DummyTask(id=1, name="t1", duration=100)
+    obs1 = make_obs(task, "2024-01-01T00:00:00", "2024-01-01T00:05:00")
+    scheduler._scheduler.schedule = make_async_gen([obs1])
+
+    call_count = 0
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError()
+
+    mocker.patch("pyobs.modules.robotic.scheduler.asyncio.sleep", side_effect=fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler._schedule_worker()
+
+    state = _state_for(scheduler._comm.set_state, IRoboticScheduler)
+    assert state.last_reschedule is not None


### PR DESCRIPTION
## Summary

Implements the pyobs-core side of #825: role-specific `IRobotic` (executor) / `IRoboticScheduler` (planner) interfaces, wired into `Mastermind` and `Scheduler`, per `specs/design/irobotic.md`.

- `IRobotic` (`Mastermind`): `RoboticState` pushed on `open`/`start`/`stop`, on every task transition (started/finished/failed), and whenever the next-up observation or its `cant_run_reason` actually changes — not just on transitions, so "waiting for weather" stays current while the system is idle/blocked rather than only refreshing when something starts.
- `IRoboticScheduler` (`Scheduler`): `get_schedule(limit=20)` returns pending/in-progress entries only, sorted by start time, capped at a hard server-side ceiling (`_MAX_SCHEDULE_LIMIT = 100`) regardless of the requested `limit`; raises `ValueError` on a negative `limit`. `SchedulerState.last_reschedule` published on `open`/`start`/`stop` and after each completed reschedule pass.
- `TaskStartedEvent`/`TaskFinishedEvent`/`TaskFailedEvent` now carry `obsnum` (backward compatible — optional field, defaults to `None`).
- No `running` field duplicated on either state dataclass; both interfaces inherit `IRunning`'s state via `IStartStop`.
- `RoboticTask.state` is a plain `str` (not `pyobs.robotic.observation.ObservationState`), so `pyobs.interfaces` doesn't gain an import-time dependency on `pyobs.robotic` (which itself imports `pyobs.interfaces`).

Design doc (`specs/design/irobotic.md`) updated alongside: fixed a base-class bug caught while implementing — `class Scheduler(Module, IStartStop, IRunnable, IRoboticScheduler)` is not a valid MRO (`IStartStop` can't be listed before a class that already inherits it; Python raises `TypeError: Cannot create a consistent method resolution order`, confirmed empirically). Dropped the now-redundant explicit `IStartStop`, matching the `IAutonomous`/`IRobotic` pattern already used on `Mastermind`.

Out of scope, per the design doc: the `pyobs-gui` widgets (`RoboticWidget`/`ScheduleWidget`), tracked separately in #825.

## Test plan

- [x] `ruff check` / `black --check` / `pyrefly check` clean on all touched files
- [x] New unit tests: `tests/interfaces/test_irobotic.py` (state dataclass round-trip serialization, `RoboticTask.from_observation`, `has_own_state()`)
- [x] New unit tests: `tests/modules/robotic/test_scheduler.py` (`get_schedule` filtering/sorting/limit/cap/`ValueError`, `SchedulerState` publishing)
- [x] New integration tests: `tests/integration/test_mastermind.py` (obsnum on events, `IRobotic` state on task start, `cant_run_reason` publishing)
- [x] Full existing suite green: `pytest` (1614 passed, 25 skipped, 7 pre-existing unrelated failures in `tests/cli/test_pyobsd.py` — confirmed present on `develop` before this change too, missing `pyobs` executable in this environment)
- [x] `pytest -m integration` on `tests/integration/test_mastermind.py`, `test_scheduler_mastermind.py`, `test_transit_mastermind.py` all green

https://claude.ai/code/session_01QrsaNDU9oSrXGHDQv3T2uG