### PR TITLE
Add DummyMastermind/DummyScheduler for pyobs-gui development

### DIFF
--- a/pyobs/modules/robotic/__init__.py
+++ b/pyobs/modules/robotic/__init__.py
@@ -5,9 +5,11 @@ TODO: write doc
 
 __title__ = "Robotic mode"
 
+from .dummymastermind import DummyMastermind
+from .dummyscheduler import DummyScheduler
 from .mastermind import Mastermind
 from .pointing import PointingSeries
 from .scheduler import Scheduler
 from .scriptrunner import ScriptRunner
 
-__all__ = ["Mastermind", "PointingSeries", "Scheduler", "ScriptRunner"]
+__all__ = ["DummyMastermind", "DummyScheduler", "Mastermind", "PointingSeries", "Scheduler", "ScriptRunner"]

--- a/pyobs/modules/robotic/dummymastermind.py
+++ b/pyobs/modules/robotic/dummymastermind.py
@@ -24,6 +24,9 @@ class DummyMastermind(Module, IAutonomous, IRobotic):
     "can't run" wait beforehand and an occasional failure, so `RoboticWidget` has real state
     transitions to develop against without needing a real `ObservationArchive`/`TaskRunner`.
     Independent of `DummyScheduler` -- the two don't share any synthetic data.
+
+    `RoboticState.next` is only populated during a simulated "can't run" wait, same as the real
+    `Mastermind` -- raise `blocked_probability` to exercise the next-up panel more often.
     """
 
     __module__ = "pyobs.modules.robotic"
@@ -65,6 +68,8 @@ class DummyMastermind(Module, IAutonomous, IRobotic):
         self._running = False
         self._task_ids = itertools.count(1)
         self._task: RoboticTask | None = None  # currently running
+        self._obsnum_night: str | None = None
+        self._obsnum_counter = 0
 
         self.add_background_task(self._run_thread, True)
 
@@ -93,6 +98,16 @@ class DummyMastermind(Module, IAutonomous, IRobotic):
         self._running = False
         await self.comm.set_state(IRunning, RunningState(running=self._running))
         await self._publish()
+
+    def _next_obsnum(self) -> str:
+        """Per-night observation counter, e.g. "20260810-001" -- in-memory only, unlike the
+        real Mastermind's persisted cache; a dummy doesn't need to survive restarts."""
+        night = Time.now().datetime.strftime("%Y%m%d")
+        if night != self._obsnum_night:
+            self._obsnum_night = night
+            self._obsnum_counter = 0
+        self._obsnum_counter += 1
+        return f"{night}-{self._obsnum_counter:03d}"
 
     def _make_task(self) -> RoboticTask:
         return RoboticTask(
@@ -132,10 +147,13 @@ class DummyMastermind(Module, IAutonomous, IRobotic):
             next_task.start = start
             next_task.end = end
             next_task.state = "in_progress"
+            next_task.obsnum = self._next_obsnum()
             self._task = next_task
 
             log.info("Running task %s...", next_task.name)
-            await self.comm.send_event(TaskStartedEvent(name=next_task.name, id=next_task.id, eta=end))
+            await self.comm.send_event(
+                TaskStartedEvent(name=next_task.name, id=next_task.id, eta=end, obsnum=next_task.obsnum)
+            )
             await self._publish()
 
             await asyncio.sleep(duration)
@@ -143,11 +161,15 @@ class DummyMastermind(Module, IAutonomous, IRobotic):
             if random.random() < self._fail_probability:
                 self._task.state = "failed"
                 log.info("Task %s failed.", next_task.name)
-                await self.comm.send_event(TaskFailedEvent(name=next_task.name, id=next_task.id))
+                await self.comm.send_event(
+                    TaskFailedEvent(name=next_task.name, id=next_task.id, obsnum=next_task.obsnum)
+                )
             else:
                 self._task.state = "completed"
                 log.info("Finished task %s.", next_task.name)
-                await self.comm.send_event(TaskFinishedEvent(name=next_task.name, id=next_task.id))
+                await self.comm.send_event(
+                    TaskFinishedEvent(name=next_task.name, id=next_task.id, obsnum=next_task.obsnum)
+                )
 
             self._task = None
             await self._publish()

--- a/pyobs/modules/robotic/dummymastermind.py
+++ b/pyobs/modules/robotic/dummymastermind.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import itertools
+import logging
+import random
+from typing import Any
+
+import astropy.units as u
+
+from pyobs.events import TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
+from pyobs.interfaces import IAutonomous, IRobotic, IRunning, RoboticState, RoboticTask
+from pyobs.interfaces.IRunning import RunningState
+from pyobs.modules import Module
+from pyobs.utils.time import Time
+
+log = logging.getLogger(__name__)
+
+
+class DummyMastermind(Module, IAutonomous, IRobotic):
+    """Dummy executor that simulates a robotic schedule for pyobs-gui development.
+
+    Generates and runs a synthetic sequence of tasks, occasionally with a simulated
+    "can't run" wait beforehand and an occasional failure, so `RoboticWidget` has real state
+    transitions to develop against without needing a real `ObservationArchive`/`TaskRunner`.
+    Independent of `DummyScheduler` -- the two don't share any synthetic data.
+    """
+
+    __module__ = "pyobs.modules.robotic"
+
+    _TARGETS = ["M31", "M42", "NGC 891", "Vega", "HD 12345", "IC 1805", "Altair"]
+    _KINDS = ["Photometry", "Spectroscopy", "Flatfields", "Focus series"]
+    _BLOCK_REASONS = ["waiting for weather", "target below horizon", "window not open yet"]
+
+    def __init__(
+        self,
+        min_duration: float = 30.0,
+        max_duration: float = 180.0,
+        fail_probability: float = 0.15,
+        blocked_probability: float = 0.2,
+        min_blocked_duration: float = 5.0,
+        max_blocked_duration: float = 20.0,
+        **kwargs: Any,
+    ):
+        """Create a new dummy mastermind.
+
+        Args:
+            min_duration: Minimum simulated task duration, in seconds.
+            max_duration: Maximum simulated task duration, in seconds.
+            fail_probability: Chance [0, 1] that a simulated task run ends in failure.
+            blocked_probability: Chance [0, 1] that the next task simulates a "can't run" wait
+                before starting.
+            min_blocked_duration: Minimum simulated "can't run" wait, in seconds.
+            max_blocked_duration: Maximum simulated "can't run" wait, in seconds.
+        """
+        Module.__init__(self, **kwargs)
+
+        self._min_duration = min_duration
+        self._max_duration = max_duration
+        self._fail_probability = fail_probability
+        self._blocked_probability = blocked_probability
+        self._min_blocked_duration = min_blocked_duration
+        self._max_blocked_duration = max_blocked_duration
+
+        self._running = False
+        self._task_ids = itertools.count(1)
+        self._task: RoboticTask | None = None  # currently running
+
+        self.add_background_task(self._run_thread, True)
+
+    async def open(self) -> None:
+        """Open module."""
+        await Module.open(self)
+
+        if self._comm:
+            await self.comm.register_event(TaskStartedEvent)
+            await self.comm.register_event(TaskFinishedEvent)
+
+        self._running = True
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish()
+
+    async def start(self, **kwargs: Any) -> None:
+        """Starts a service."""
+        log.info("Starting dummy robotic system...")
+        self._running = True
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish()
+
+    async def stop(self, **kwargs: Any) -> None:
+        """Stops a service."""
+        log.info("Stopping dummy robotic system...")
+        self._running = False
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self._publish()
+
+    def _make_task(self) -> RoboticTask:
+        return RoboticTask(
+            id=next(self._task_ids),
+            name=f"{random.choice(self._KINDS)}-{random.choice(self._TARGETS)}",
+            target=random.choice(self._TARGETS),
+            priority=round(random.uniform(1.0, 10.0), 1),
+        )
+
+    async def _publish(self, next_task: RoboticTask | None = None, cant_run_reason: str | None = None) -> None:
+        await self.comm.set_state(
+            IRobotic, RoboticState(current=self._task, next=next_task, cant_run_reason=cant_run_reason)
+        )
+
+    async def _run_thread(self) -> None:
+        await asyncio.sleep(2)
+
+        while True:
+            if not self._running:
+                await asyncio.sleep(1)
+                continue
+
+            next_task = self._make_task()
+
+            # occasionally simulate a "can't run yet" wait before this task starts
+            if random.random() < self._blocked_probability:
+                reason = random.choice(self._BLOCK_REASONS)
+                log.info("Task %s cannot run: %s", next_task.name, reason)
+                await self._publish(next_task=next_task, cant_run_reason=reason)
+                blocked_for = random.uniform(self._min_blocked_duration, self._max_blocked_duration)
+                await asyncio.sleep(blocked_for)
+
+            # start it
+            start = Time.now()
+            duration = random.uniform(self._min_duration, self._max_duration)
+            end = start + duration * u.second
+            next_task.start = start
+            next_task.end = end
+            next_task.state = "in_progress"
+            self._task = next_task
+
+            log.info("Running task %s...", next_task.name)
+            await self.comm.send_event(TaskStartedEvent(name=next_task.name, id=next_task.id, eta=end))
+            await self._publish()
+
+            await asyncio.sleep(duration)
+
+            if random.random() < self._fail_probability:
+                self._task.state = "failed"
+                log.info("Task %s failed.", next_task.name)
+                await self.comm.send_event(TaskFailedEvent(name=next_task.name, id=next_task.id))
+            else:
+                self._task.state = "completed"
+                log.info("Finished task %s.", next_task.name)
+                await self.comm.send_event(TaskFinishedEvent(name=next_task.name, id=next_task.id))
+
+            self._task = None
+            await self._publish()
+
+
+__all__ = ["DummyMastermind"]

--- a/pyobs/modules/robotic/dummyscheduler.py
+++ b/pyobs/modules/robotic/dummyscheduler.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import asyncio
+import itertools
+import logging
+import random
+from typing import Any
+
+import astropy.units as u
+
+from pyobs.interfaces import IRoboticScheduler, IRunnable, IRunning, RoboticTask, SchedulerState
+from pyobs.interfaces.IRunning import RunningState
+from pyobs.modules import Module
+from pyobs.utils.time import Time
+
+log = logging.getLogger(__name__)
+
+
+class DummyScheduler(Module, IRunnable, IRoboticScheduler):
+    """Dummy planner that simulates a schedule for pyobs-gui development.
+
+    Generates a synthetic, contiguous batch of upcoming tasks on open() and whenever run() is
+    called ("Re-schedule now"), so `ScheduleWidget` has real data and a working re-schedule
+    button to develop against without needing a real `TaskArchive`/`ObservationArchive`/
+    `TaskScheduler`. Independent of `DummyMastermind` -- the two don't share any synthetic data.
+    """
+
+    __module__ = "pyobs.modules.robotic"
+
+    _MAX_SCHEDULE_LIMIT = 100
+
+    _TARGETS = ["M31", "M42", "NGC 891", "Vega", "HD 12345", "IC 1805", "Altair"]
+    _KINDS = ["Photometry", "Spectroscopy", "Flatfields", "Focus series"]
+
+    def __init__(
+        self,
+        schedule_size: int = 8,
+        min_duration: float = 60.0,
+        max_duration: float = 600.0,
+        **kwargs: Any,
+    ):
+        """Create a new dummy scheduler.
+
+        Args:
+            schedule_size: Number of synthetic tasks to generate per (re-)schedule.
+            min_duration: Minimum simulated task duration, in seconds.
+            max_duration: Maximum simulated task duration, in seconds.
+        """
+        Module.__init__(self, **kwargs)
+
+        self._schedule_size = schedule_size
+        self._min_duration = min_duration
+        self._max_duration = max_duration
+
+        self._running = True
+        self._last_reschedule: Time | None = None
+        self._task_ids = itertools.count(1)
+        self._schedule: list[RoboticTask] = []
+        self._need_update = True
+
+        self.add_background_task(self._schedule_worker)
+
+    async def open(self) -> None:
+        """Open module."""
+        await Module.open(self)
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
+
+    async def start(self, **kwargs: Any) -> None:
+        """Start scheduler."""
+        self._running = True
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
+
+    async def stop(self, **kwargs: Any) -> None:
+        """Stop scheduler."""
+        self._running = False
+        await self.comm.set_state(IRunning, RunningState(running=self._running))
+        await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
+
+    async def run(self, **kwargs: Any) -> None:
+        """Trigger a re-schedule."""
+        self._need_update = True
+
+    async def abort(self, **kwargs: Any) -> None:
+        pass
+
+    def _generate_schedule(self) -> None:
+        cursor = Time.now()
+        tasks = []
+        for _ in range(self._schedule_size):
+            duration = random.uniform(self._min_duration, self._max_duration)
+            start = cursor
+            end = start + duration * u.second
+            tasks.append(
+                RoboticTask(
+                    id=next(self._task_ids),
+                    name=f"{random.choice(self._KINDS)}-{random.choice(self._TARGETS)}",
+                    target=random.choice(self._TARGETS),
+                    start=start,
+                    end=end,
+                    state="pending",
+                    priority=round(random.uniform(1.0, 10.0), 1),
+                )
+            )
+            cursor = end
+        self._schedule = tasks
+
+    async def _schedule_worker(self) -> None:
+        while True:
+            if self._running and self._need_update:
+                self._need_update = False
+                log.info("Generating dummy schedule of %d task(s)...", self._schedule_size)
+                self._generate_schedule()
+                self._last_reschedule = Time.now()
+                await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
+            await asyncio.sleep(1)
+
+    async def get_schedule(self, limit: int = 20, **kwargs: Any) -> list[RoboticTask]:
+        """Return the upcoming (pending/in-progress) synthetic schedule, most imminent first.
+
+        Args:
+            limit: Maximum number of entries to return.
+
+        Returns:
+            Up to `limit` scheduled tasks, capped at `_MAX_SCHEDULE_LIMIT` regardless of what's
+            requested.
+
+        Raises:
+            ValueError: If limit is negative.
+        """
+        if limit < 0:
+            raise ValueError("limit must be >= 0.")
+        limit = min(limit, self._MAX_SCHEDULE_LIMIT)
+
+        now = Time.now()
+        upcoming = []
+        for task in self._schedule:
+            if task.end is not None and task.end < now:
+                continue  # already elapsed
+            task.state = "in_progress" if task.start is not None and task.start <= now else "pending"
+            upcoming.append(task)
+
+        return upcoming[:limit]
+
+
+__all__ = ["DummyScheduler"]

--- a/pyobs/modules/robotic/dummyscheduler.py
+++ b/pyobs/modules/robotic/dummyscheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import itertools
 import logging
 import random
@@ -63,6 +64,13 @@ class DummyScheduler(Module, IRunnable, IRoboticScheduler):
     async def open(self) -> None:
         """Open module."""
         await Module.open(self)
+
+        # generate the first schedule synchronously, rather than waiting for the worker's first
+        # tick, so get_schedule() has something to return immediately on startup
+        self._generate_schedule()
+        self._last_reschedule = Time.now()
+        self._need_update = False
+
         await self.comm.set_state(IRunning, RunningState(running=self._running))
         await self.comm.set_state(IRoboticScheduler, SchedulerState(last_reschedule=self._last_reschedule))
 
@@ -127,19 +135,19 @@ class DummyScheduler(Module, IRunnable, IRoboticScheduler):
             requested.
 
         Raises:
-            ValueError: If limit is negative.
+            ValueError: If limit is not an int, or is negative.
         """
-        if limit < 0:
-            raise ValueError("limit must be >= 0.")
+        if not isinstance(limit, int) or limit < 0:
+            raise ValueError("limit must be a non-negative int.")
         limit = min(limit, self._MAX_SCHEDULE_LIMIT)
 
         now = Time.now()
         upcoming = []
-        for task in self._schedule:
+        for task in sorted(self._schedule, key=lambda t: t.start or now):
             if task.end is not None and task.end < now:
                 continue  # already elapsed
-            task.state = "in_progress" if task.start is not None and task.start <= now else "pending"
-            upcoming.append(task)
+            state = "in_progress" if task.start is not None and task.start <= now else "pending"
+            upcoming.append(dataclasses.replace(task, state=state))
 
         return upcoming[:limit]
 

--- a/tests/modules/robotic/test_dummymastermind.py
+++ b/tests/modules/robotic/test_dummymastermind.py
@@ -43,6 +43,28 @@ def test_make_task_produces_unique_increasing_ids() -> None:
     assert t1.id < t2.id
 
 
+def test_next_obsnum_increments_within_a_night() -> None:
+    mm = make_mastermind()
+    first = mm._next_obsnum()
+    second = mm._next_obsnum()
+    night = first.split("-")[0]
+    assert first == f"{night}-001"
+    assert second == f"{night}-002"
+
+
+def test_next_obsnum_resets_on_night_change(mocker) -> None:
+    from pyobs.utils.time import Time
+
+    mm = make_mastermind()
+    mocker.patch.object(Time, "now", return_value=Time("2026-08-30T10:00:00"))
+    first = mm._next_obsnum()
+    mocker.patch.object(Time, "now", return_value=Time("2026-08-31T10:00:00"))
+    second = mm._next_obsnum()
+
+    assert first == "20260830-001"
+    assert second == "20260831-001"
+
+
 # ── open / start / stop ───────────────────────────────────────────────────────
 
 
@@ -129,6 +151,10 @@ async def test_run_thread_starts_and_finishes_a_task(mocker) -> None:
     # the *last* one, since a fast, unmocked-random loop may already be mid-way through a
     # second cycle by the time cancellation lands
     assert any(s.current is None for s in states)
+
+    # obsnum is assigned before the task starts and carried on both events
+    assert all(e.obsnum is not None for e in started)
+    assert all(e.obsnum is not None for e in finished)
 
 
 @pytest.mark.asyncio

--- a/tests/modules/robotic/test_dummymastermind.py
+++ b/tests/modules/robotic/test_dummymastermind.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyobs.comm import Comm
+from pyobs.events import TaskFailedEvent, TaskFinishedEvent, TaskStartedEvent
+from pyobs.interfaces import IRobotic, IRunning
+from pyobs.modules.robotic import DummyMastermind
+
+
+def make_mastermind(**kwargs) -> DummyMastermind:
+    return DummyMastermind(comm=MagicMock(spec=Comm), **kwargs)
+
+
+def _state_for(mock: AsyncMock, interface: object) -> object:
+    for call in reversed(mock.await_args_list):
+        if call.args[0] is interface:
+            return call.args[1]
+    raise AssertionError(f"set_state was never called with {interface}")
+
+
+def _states_for(mock: AsyncMock, interface: object) -> list[object]:
+    return [call.args[1] for call in mock.await_args_list if call.args[0] is interface]
+
+
+# ── __init__ ─────────────────────────────────────────────────────────────────
+
+
+def test_init_defaults() -> None:
+    mm = make_mastermind()
+    assert mm._running is False
+    assert mm._task is None
+
+
+def test_make_task_produces_unique_increasing_ids() -> None:
+    mm = make_mastermind()
+    t1 = mm._make_task()
+    t2 = mm._make_task()
+    assert t1.id != t2.id
+    assert t1.id < t2.id
+
+
+# ── open / start / stop ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_open_publishes_running_and_robotic_state(mocker) -> None:
+    from pyobs.modules import Module
+
+    mm = make_mastermind()
+    mm._comm.register_event = AsyncMock()
+    mm._comm.set_state = AsyncMock()
+    mocker.patch.object(Module, "open", AsyncMock())
+
+    await mm.open()
+
+    state = _state_for(mm._comm.set_state, IRunning)
+    assert state.running is True
+    state = _state_for(mm._comm.set_state, IRobotic)
+    assert state.current is None
+    assert state.next is None
+
+
+@pytest.mark.asyncio
+async def test_start_sets_running() -> None:
+    mm = make_mastermind()
+    mm._comm.set_state = AsyncMock()
+
+    await mm.start()
+
+    assert mm._running is True
+    state = _state_for(mm._comm.set_state, IRunning)
+    assert state.running is True
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_running() -> None:
+    mm = make_mastermind()
+    mm._running = True
+    mm._comm.set_state = AsyncMock()
+
+    await mm.stop()
+
+    assert mm._running is False
+    state = _state_for(mm._comm.set_state, IRunning)
+    assert state.running is False
+
+
+# ── _run_thread ──────────────────────────────────────────────────────────────
+
+
+async def _run_briefly(mm: DummyMastermind, mocker, iterations: int = 6) -> None:
+    """Run _run_thread with the initial 5s delay and inter-loop sleeps collapsed."""
+    call_count = 0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= iterations:
+            raise asyncio.CancelledError()
+        await real_sleep(0)
+
+    mocker.patch("pyobs.modules.robotic.dummymastermind.asyncio.sleep", side_effect=fake_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await mm._run_thread()
+
+
+@pytest.mark.asyncio
+async def test_run_thread_starts_and_finishes_a_task(mocker) -> None:
+    mm = make_mastermind(blocked_probability=0.0, fail_probability=0.0)
+    mm._running = True
+    mm._comm.set_state = AsyncMock()
+    mm._comm.send_event = AsyncMock()
+
+    await _run_briefly(mm, mocker)
+
+    started = [c.args[0] for c in mm._comm.send_event.await_args_list if isinstance(c.args[0], TaskStartedEvent)]
+    finished = [c.args[0] for c in mm._comm.send_event.await_args_list if isinstance(c.args[0], TaskFinishedEvent)]
+    assert len(started) >= 1
+    assert len(finished) >= 1
+
+    states = _states_for(mm._comm.set_state, IRobotic)
+    assert any(s.current is not None for s in states)
+    # some published state must show the task cleared again after finishing -- not necessarily
+    # the *last* one, since a fast, unmocked-random loop may already be mid-way through a
+    # second cycle by the time cancellation lands
+    assert any(s.current is None for s in states)
+
+
+@pytest.mark.asyncio
+async def test_run_thread_simulates_blocked_reason(mocker) -> None:
+    mm = make_mastermind(blocked_probability=1.0, min_blocked_duration=0.0, max_blocked_duration=0.0)
+    mm._running = True
+    mm._comm.set_state = AsyncMock()
+    mm._comm.send_event = AsyncMock()
+
+    await _run_briefly(mm, mocker, iterations=2)
+
+    states = _states_for(mm._comm.set_state, IRobotic)
+    assert any(s.cant_run_reason is not None and s.next is not None for s in states)
+
+
+@pytest.mark.asyncio
+async def test_run_thread_simulates_failure(mocker) -> None:
+    mm = make_mastermind(blocked_probability=0.0, fail_probability=1.0)
+    mm._running = True
+    mm._comm.set_state = AsyncMock()
+    mm._comm.send_event = AsyncMock()
+
+    await _run_briefly(mm, mocker)
+
+    failed = [c.args[0] for c in mm._comm.send_event.await_args_list if isinstance(c.args[0], TaskFailedEvent)]
+    assert len(failed) >= 1
+
+
+@pytest.mark.asyncio
+async def test_run_thread_does_not_pick_up_new_task_while_stopped(mocker) -> None:
+    mm = make_mastermind()
+    mm._running = False
+    mm._comm.set_state = AsyncMock()
+    mm._comm.send_event = AsyncMock()
+
+    await _run_briefly(mm, mocker)
+
+    mm._comm.send_event.assert_not_awaited()
+    assert mm._task is None

--- a/tests/modules/robotic/test_dummyscheduler.py
+++ b/tests/modules/robotic/test_dummyscheduler.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import astropy.units as u
+import pytest
+
+from pyobs.comm import Comm
+from pyobs.interfaces import IRoboticScheduler, IRunning
+from pyobs.modules.robotic import DummyScheduler
+from pyobs.utils.time import Time
+
+
+def make_scheduler(**kwargs) -> DummyScheduler:
+    return DummyScheduler(comm=MagicMock(spec=Comm), **kwargs)
+
+
+def _state_for(mock: AsyncMock, interface: object) -> object:
+    for call in reversed(mock.await_args_list):
+        if call.args[0] is interface:
+            return call.args[1]
+    raise AssertionError(f"set_state was never called with {interface}")
+
+
+# ── __init__ / _generate_schedule ────────────────────────────────────────────
+
+
+def test_init_defaults() -> None:
+    scheduler = make_scheduler()
+    assert scheduler._running is True
+    assert scheduler._last_reschedule is None
+    assert scheduler._schedule == []
+    assert scheduler._need_update is True
+
+
+def test_generate_schedule_produces_contiguous_sorted_tasks() -> None:
+    scheduler = make_scheduler(schedule_size=5, min_duration=10, max_duration=10)
+    scheduler._generate_schedule()
+
+    assert len(scheduler._schedule) == 5
+    for a, b in zip(scheduler._schedule, scheduler._schedule[1:]):
+        assert a.end == b.start  # contiguous, in order
+    ids = [t.id for t in scheduler._schedule]
+    assert ids == sorted(ids)  # unique, increasing
+
+
+# ── open / start / stop ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_open_publishes_state(mocker) -> None:
+    from pyobs.modules import Module
+
+    scheduler = make_scheduler()
+    scheduler._comm.set_state = AsyncMock()
+    mocker.patch.object(Module, "open", AsyncMock())
+
+    await scheduler.open()
+
+    state = _state_for(scheduler._comm.set_state, IRunning)
+    assert state.running is True
+    state = _state_for(scheduler._comm.set_state, IRoboticScheduler)
+    assert state.last_reschedule is None
+
+
+@pytest.mark.asyncio
+async def test_start_sets_running() -> None:
+    scheduler = make_scheduler()
+    scheduler._running = False
+    scheduler._comm.set_state = AsyncMock()
+
+    await scheduler.start()
+
+    assert scheduler._running is True
+    state = _state_for(scheduler._comm.set_state, IRunning)
+    assert state.running is True
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_running() -> None:
+    scheduler = make_scheduler()
+    scheduler._comm.set_state = AsyncMock()
+
+    await scheduler.stop()
+
+    assert scheduler._running is False
+    state = _state_for(scheduler._comm.set_state, IRunning)
+    assert state.running is False
+
+
+# ── run / _schedule_worker ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_triggers_reschedule() -> None:
+    scheduler = make_scheduler()
+    scheduler._need_update = False
+
+    await scheduler.run()
+
+    assert scheduler._need_update is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_worker_generates_and_publishes(mocker) -> None:
+    scheduler = make_scheduler(schedule_size=3)
+    scheduler._comm.set_state = AsyncMock()
+
+    call_count = 0
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 1:
+            raise asyncio.CancelledError()
+
+    mocker.patch("pyobs.modules.robotic.dummyscheduler.asyncio.sleep", side_effect=fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler._schedule_worker()
+
+    assert len(scheduler._schedule) == 3
+    assert scheduler._last_reschedule is not None
+    state = _state_for(scheduler._comm.set_state, IRoboticScheduler)
+    assert state.last_reschedule is not None
+
+
+@pytest.mark.asyncio
+async def test_schedule_worker_skips_when_not_running(mocker) -> None:
+    scheduler = make_scheduler()
+    scheduler._running = False
+    scheduler._comm.set_state = AsyncMock()
+
+    call_count = 0
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 1:
+            raise asyncio.CancelledError()
+
+    mocker.patch("pyobs.modules.robotic.dummyscheduler.asyncio.sleep", side_effect=fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler._schedule_worker()
+
+    assert scheduler._schedule == []
+    scheduler._comm.set_state.assert_not_awaited()
+
+
+# ── get_schedule ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_respects_limit() -> None:
+    scheduler = make_scheduler(schedule_size=5, min_duration=10, max_duration=10)
+    scheduler._generate_schedule()
+
+    result = await scheduler.get_schedule(limit=2)
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_caps_limit_at_hard_ceiling() -> None:
+    scheduler = make_scheduler(schedule_size=DummyScheduler._MAX_SCHEDULE_LIMIT + 10)
+    scheduler._generate_schedule()
+
+    result = await scheduler.get_schedule(limit=10_000)
+
+    assert len(result) == scheduler._MAX_SCHEDULE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_rejects_negative_limit() -> None:
+    scheduler = make_scheduler()
+    with pytest.raises(ValueError):
+        await scheduler.get_schedule(limit=-1)
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_drops_elapsed_tasks() -> None:
+    scheduler = make_scheduler(schedule_size=3, min_duration=10, max_duration=10)
+    scheduler._generate_schedule()
+    scheduler._schedule[0].end = Time.now() - 10 * u.second
+
+    result = await scheduler.get_schedule()
+
+    assert len(result) == 2
+    assert scheduler._schedule[0] not in result
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_marks_current_task_in_progress() -> None:
+    scheduler = make_scheduler(schedule_size=1, min_duration=100, max_duration=100)
+    scheduler._generate_schedule()
+    scheduler._schedule[0].start = Time.now() - 10 * u.second
+    scheduler._schedule[0].end = Time.now() + 90 * u.second
+
+    result = await scheduler.get_schedule()
+
+    assert result[0].state == "in_progress"

--- a/tests/modules/robotic/test_dummyscheduler.py
+++ b/tests/modules/robotic/test_dummyscheduler.py
@@ -52,7 +52,7 @@ def test_generate_schedule_produces_contiguous_sorted_tasks() -> None:
 async def test_open_publishes_state(mocker) -> None:
     from pyobs.modules import Module
 
-    scheduler = make_scheduler()
+    scheduler = make_scheduler(schedule_size=4)
     scheduler._comm.set_state = AsyncMock()
     mocker.patch.object(Module, "open", AsyncMock())
 
@@ -60,8 +60,11 @@ async def test_open_publishes_state(mocker) -> None:
 
     state = _state_for(scheduler._comm.set_state, IRunning)
     assert state.running is True
+    # open() generates the first schedule synchronously (not left to the worker's first tick),
+    # so get_schedule() has something to return immediately -- last_reschedule is already set
     state = _state_for(scheduler._comm.set_state, IRoboticScheduler)
-    assert state.last_reschedule is None
+    assert state.last_reschedule is not None
+    assert len(scheduler._schedule) == 4
 
 
 @pytest.mark.asyncio
@@ -201,3 +204,22 @@ async def test_get_schedule_marks_current_task_in_progress() -> None:
     result = await scheduler.get_schedule()
 
     assert result[0].state == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_does_not_mutate_stored_tasks() -> None:
+    scheduler = make_scheduler(schedule_size=1, min_duration=100, max_duration=100)
+    scheduler._generate_schedule()
+    scheduler._schedule[0].start = Time.now() - 10 * u.second
+    scheduler._schedule[0].end = Time.now() + 90 * u.second
+
+    await scheduler.get_schedule()
+
+    assert scheduler._schedule[0].state == "pending"  # unchanged -- get_schedule returned a copy
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_rejects_non_int_limit() -> None:
+    scheduler = make_scheduler()
+    with pytest.raises(ValueError):
+        await scheduler.get_schedule(limit="20")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Follow-up to #826, for #825: adds `DummyMastermind`/`DummyScheduler`, standalone `IRobotic`/`IRoboticScheduler` implementations with no real `ObservationArchive`/`TaskArchive`/`TaskScheduler`/`TaskRunner` backing, so pyobs-gui has something to develop `RoboticWidget`/`ScheduleWidget` against without standing up the real robotic pipeline. Follows the existing `Dummy*`/`Mock*` module pattern (`DummyAcquisition`, `MockWeather`) — same domain package (`pyobs/modules/robotic/`), same "simulate over time" style as `DummyAcquisition`'s fake convergence loop.

- **`DummyMastermind`**: a background loop generates synthetic tasks, runs each for a simulated duration, and occasionally simulates a "can't run" wait beforehand or a failed run — so `RoboticWidget` has real state transitions (`current`/`next`/`cant_run_reason`, `TaskStarted`/`Finished`/`FailedEvent`) to develop against, not just a static snapshot.
- **`DummyScheduler`**: generates a contiguous synthetic schedule on `open()` and whenever `run()` is called ("Re-schedule now"), so `ScheduleWidget`'s table and re-schedule button have real data and a visible effect. `get_schedule()` derives pending/in-progress per entry from wall-clock time and drops elapsed entries, same trim/cap/`ValueError` contract as the real `Scheduler`.

The two are intentionally independent — no shared synthetic data, since they'd be independent processes in production too.

## Test plan

- [x] `ruff check` / `black --check` / `pyrefly check` clean
- [x] New tests: `tests/modules/robotic/test_dummymastermind.py` (open/start/stop publish, task start→finish cycle, simulated blocked reason, simulated failure, doesn't pick up a new task while stopped)
- [x] New tests: `tests/modules/robotic/test_dummyscheduler.py` (open/start/stop publish, `run()` triggers reschedule, schedule generation is contiguous/sorted/unique-id, `get_schedule` limit/cap/negative-limit/elapsed-filtering/in-progress-marking)
- [x] Both modules manually smoke-tested end-to-end (real `open()`/background loop/`get_schedule()` against a mocked `Comm`)
- [x] Full suite green: 1641 passed (up from 1617 — 24 new tests), same 7 pre-existing unrelated `test_pyobsd.py` failures

https://claude.ai/code/session_01QrsaNDU9oSrXGHDQv3T2uG