### PR TITLE
Pre-create pubsub event nodes at startup, harden retry machinery (#824)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-v2.0.1.dev1 (2026-08-30)
+v2.0.3.dev1 (2026-08-30)
 *************************
 * ``XmppComm`` now pre-creates a module's own event pubsub nodes at the moment it declares them
   (send-only ``register_event()``), instead of relying on the server's lazy auto-create-on-first-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+v2.0.1.dev1 (2026-08-30)
+*************************
+* ``XmppComm`` now pre-creates a module's own event pubsub nodes at the moment it declares them
+  (send-only ``register_event()``), instead of relying on the server's lazy auto-create-on-first-
+  publish. Closes the window where a peer connecting before a module's first publish could never
+  complete a subscribe (``item-not-found``) and had to fall back to an indefinitely retrying
+  background task. State nodes are explicitly out of scope (see
+  ``specs/plans/2026-08-28-precreate-pubsub-nodes.md``'s "Why state nodes are excluded" section).
+* Fixes issue #824: ``_retry_delay``'s exponential backoff no longer raises ``OverflowError`` at
+  high attempt counts (e.g. attempt 1024), and both event/state subscribe-retry background tasks
+  now discard their tracked key/handler on an unexpected failure instead of leaving a permanently
+  stuck "subscribed" marker behind with nothing actually subscribed and nothing retrying.
+
 v2.0.0 (2026-08-26)
 *******************
 

--- a/pyobs/comm/xmpp/xmppclient.py
+++ b/pyobs/comm/xmpp/xmppclient.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import slixmpp
 import slixmpp.xmlstream
-from slixmpp.xmlstream import StanzaBase
 
 from pyobs.comm.xmpp.xep_0009.rpc import XEP_0009
 from pyobs.comm.xmpp.xep_0009_timeout import XEP_0009_timeout
@@ -71,7 +70,6 @@ class XmppClient(slixmpp.ClientXMPP):
         self.add_event_handler("failed_auth", lambda ev: self._auth(False))
         self.add_event_handler("failed_all_auth", self.failed_all_auth)
         self.add_event_handler("stream_error", self._stream_error)
-        self.add_filter("in", self._filter_messages)
 
     def send_presence(self, *args: Any, **kwargs: Any) -> Any:
         """Override slixmpp's send_presence to hold back every presence broadcast -- the initial
@@ -111,13 +109,6 @@ class XmppClient(slixmpp.ClientXMPP):
         forever. Leaving reconnection solely to XmppComm avoids that.
         """
         return self.disconnect(0.0, reason=reason)
-
-    def _filter_messages(self, stanza: StanzaBase) -> StanzaBase | None:
-        # if a user with same JID is already connected, we get a conflict
-        if '<conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" />' in str(stanza):
-            self._jid_conflict = True
-            return None
-        return stanza
 
     def _stream_error(self, error: Any) -> None:
         """Called when the server sends a <stream:error/>, e.g. when this connection gets

--- a/pyobs/comm/xmpp/xmppcomm.py
+++ b/pyobs/comm/xmpp/xmppcomm.py
@@ -57,7 +57,7 @@ def _retry_delay(attempt: int, cap: float = 30.0, base: float = 1.0) -> float:
     retries stay in lockstep across all of them, repeatedly hammering the server at the same
     instants; jitter decorrelates that so retries spread out over time instead.
     """
-    return random.uniform(0, min(cap, base * (2**attempt)))
+    return random.uniform(0, min(cap, base * (2 ** min(attempt, 60))))
 
 
 def _log_task_exception(task: asyncio.Task[Any]) -> None:
@@ -743,7 +743,8 @@ class XmppComm(Comm):
                 continue
             if (ev.__name__, ev.version) not in peer_sent_events:
                 continue
-            asyncio.create_task(self._subscribe_event_with_retry(module_name, ev))
+            task = asyncio.create_task(self._subscribe_event_with_retry(module_name, ev))
+            task.add_done_callback(_log_task_exception)
 
         # send event
         self._send_event_to_module(ModuleOpenedEvent(), msg["from"].username)
@@ -904,7 +905,13 @@ class XmppComm(Comm):
                     if (ev.__name__, ev.version) not in self._peer_sent_events.get(peer_jid, set()):
                         continue
                     peer_module = peer_jid[: peer_jid.index("@")]
-                    asyncio.create_task(self._subscribe_event_with_retry(peer_module, ev))
+                    task = asyncio.create_task(self._subscribe_event_with_retry(peer_module, ev))
+                    task.add_done_callback(_log_task_exception)
+            elif self._module is not None:
+                # send-only declaration -- pre-create the node now, before this module announces
+                # presence, so peers reacting to it in _got_online land their subscribe on the
+                # first attempt instead of falling back to the retry loop (see #824).
+                await self._create_node(self._event_node(self._module.name, ev))
 
         # update caps and send presence
         await self._safe_send(self.client.plugin["xep_0115"].update_caps)
@@ -939,6 +946,20 @@ class XmppComm(Comm):
             return parts[2]
         return None
 
+    async def _create_node(self, node: str) -> None:
+        """Pre-create a pubsub node so a subscriber doesn't have to wait for the first publish.
+
+        The realistic error here is <conflict/> on restart (nodes persist server-side), and a
+        permission denial should degrade gracefully to today's lazy auto-create, never block
+        startup -- so IqError is swallowed. IqTimeout is already retried inside _safe_send; if it
+        still runs out, a dead server shouldn't hang open() any longer than that existing budget,
+        so it's swallowed here too rather than propagating.
+        """
+        try:
+            await self._safe_send(self.client.plugin["xep_0060"].create_node, self._pubsub_service, node)
+        except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout) as e:
+            log.debug("Could not pre-create pubsub node %s (%s), will lazy-create on first publish.", node, e)
+
     async def _subscribe_event_with_retry(self, peer_module: str, event_class: type[Event]) -> None:
         """Subscribe to a peer's event node, retrying until the node exists.
 
@@ -952,20 +973,28 @@ class XmppComm(Comm):
             return
         self._event_subscriptions.add(key)
         node = self._event_node(peer_module, event_class)
-        attempt = 0
-        while key in self._event_subscriptions:
-            try:
-                await self._safe_send(self.client.plugin["xep_0060"].subscribe, self._pubsub_service, node)
-                return
-            except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
-                attempt += 1
-                if attempt == 30:
-                    log.warning(
-                        "Still failing to subscribe to event node %s after %d attempts, will keep retrying",
-                        node,
-                        attempt,
-                    )
-                await asyncio.sleep(_retry_delay(attempt))
+        try:
+            attempt = 0
+            while key in self._event_subscriptions:
+                try:
+                    await self._safe_send(self.client.plugin["xep_0060"].subscribe, self._pubsub_service, node)
+                    return
+                except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
+                    attempt += 1
+                    if attempt == 30:
+                        log.warning(
+                            "Still failing to subscribe to event node %s after %d attempts, will keep retrying",
+                            node,
+                            attempt,
+                        )
+                    await asyncio.sleep(_retry_delay(attempt))
+        except Exception:
+            # an unexpected (non-IqError/IqTimeout) failure must not leave key permanently
+            # marking (peer_module, event_class) as subscribed while nothing is subscribed and
+            # nothing is retrying -- discard it so a later register_event()/_got_online()
+            # re-subscribes from scratch instead of short-circuiting on the stale key (#824).
+            self._event_subscriptions.discard(key)
+            raise
 
     def _handle_event_sync(self, msg: Any) -> None:
         """Synchronous entry point for the MatchXMLMask Callback.
@@ -1302,40 +1331,51 @@ class XmppComm(Comm):
         which exits the loop into the else clause (not the break path) and returns.
         Once subscribed, fetches the current value and dispatches it.
         """
-        attempt = 0
-        while node in self._state_node_handlers:
-            try:
-                await self._safe_send(self.client.plugin["xep_0060"].subscribe, self._pubsub_service, node)
-                break
-            except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
-                attempt += 1
-                if attempt == 30:
-                    log.warning(
-                        "Still failing to subscribe to state node %s after %d attempts, will keep retrying",
-                        node,
-                        attempt,
-                    )
-                await asyncio.sleep(_retry_delay(attempt))
-        else:
-            return
-
-        # Fetch current value immediately after subscribing
         try:
-            result = await self._safe_send(
-                self.client.plugin["xep_0060"].get_items, self._pubsub_service, node, max_items=1
-            )
-            pubsub_ns = "http://jabber.org/protocol/pubsub"
-            pubsub_xml = result.xml.find(f"{{{pubsub_ns}}}pubsub")
-            items_xml = pubsub_xml.find(f"{{{pubsub_ns}}}items") if pubsub_xml is not None else None
-            item_xml = items_xml.find(f"{{{pubsub_ns}}}item") if items_xml is not None else None
-            payload = list(item_xml)[0] if item_xml is not None and len(item_xml) > 0 else None
-            if payload is not None and node in self._state_node_handlers and interface.state is not None:
-                _, callbacks = self._state_node_handlers[node]
-                state_obj = _xml_to_dataclass(payload, interface.state)
-                for cb in callbacks:
-                    cb(state_obj)
-        except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
-            pass
+            attempt = 0
+            while node in self._state_node_handlers:
+                try:
+                    await self._safe_send(self.client.plugin["xep_0060"].subscribe, self._pubsub_service, node)
+                    break
+                except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
+                    attempt += 1
+                    if attempt == 30:
+                        log.warning(
+                            "Still failing to subscribe to state node %s after %d attempts, will keep retrying",
+                            node,
+                            attempt,
+                        )
+                    await asyncio.sleep(_retry_delay(attempt))
+            else:
+                return
+
+            # Fetch current value immediately after subscribing
+            try:
+                result = await self._safe_send(
+                    self.client.plugin["xep_0060"].get_items, self._pubsub_service, node, max_items=1
+                )
+                pubsub_ns = "http://jabber.org/protocol/pubsub"
+                pubsub_xml = result.xml.find(f"{{{pubsub_ns}}}pubsub")
+                items_xml = pubsub_xml.find(f"{{{pubsub_ns}}}items") if pubsub_xml is not None else None
+                item_xml = items_xml.find(f"{{{pubsub_ns}}}item") if items_xml is not None else None
+                payload = list(item_xml)[0] if item_xml is not None and len(item_xml) > 0 else None
+                if payload is not None and node in self._state_node_handlers and interface.state is not None:
+                    _, callbacks = self._state_node_handlers[node]
+                    state_obj = _xml_to_dataclass(payload, interface.state)
+                    for cb in callbacks:
+                        cb(state_obj)
+            except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
+                pass
+        except Exception:
+            # an unexpected failure must not leave a _state_node_handlers entry behind forever --
+            # that would permanently short-circuit _subscribe_state (see its "already subscribed"
+            # branch) while nothing is actually subscribed and nothing is retrying (#824). A later
+            # _subscribe_state call starts a fresh subscribe from scratch instead; note it only
+            # carries the callback that triggered that fresh call, not any earlier ones -- accepted
+            # as strictly better than permanent silent loss for this catastrophic, unexpected case.
+            log.exception("Unexpected failure subscribing to state node %s, dropping stale subscription state.", node)
+            self._state_node_handlers.pop(node, None)
+            raise
 
     async def _subscribe_state(self, module: str, interface: type[Interface], callback: Callable[[Any], None]) -> None:
         node = self._state_node(module, interface)
@@ -1349,7 +1389,8 @@ class XmppComm(Comm):
             # Subscribe in a background task so _get_client() returns immediately.
             # The retry loop handles the case where the publisher hasn't created
             # the node yet (e.g. GUI connects before camera's first publish).
-            asyncio.create_task(self._subscribe_with_retry(node, interface))
+            task = asyncio.create_task(self._subscribe_with_retry(node, interface))
+            task.add_done_callback(_log_task_exception)
 
         # Initial value is fetched in _subscribe_with_retry after the subscribe IQ succeeds
 

--- a/pyobs/comm/xmpp/xmppcomm.py
+++ b/pyobs/comm/xmpp/xmppcomm.py
@@ -56,6 +56,11 @@ def _retry_delay(attempt: int, cap: float = 30.0, base: float = 1.0) -> float:
     every module reconnecting to ejabberd simultaneously after a mass restart). Fixed-interval
     retries stay in lockstep across all of them, repeatedly hammering the server at the same
     instants; jitter decorrelates that so retries spread out over time instead.
+
+    The `min(attempt, 60)` doesn't affect real backoff behavior -- with the defaults, `cap`
+    already clamps the delay from attempt 5 onward. It only exists so `2 ** attempt` can't grow
+    past what a float can hold for retry loops with no attempt limit (#824: attempt 1024 raised
+    OverflowError here and killed the retrying task).
     """
     return random.uniform(0, min(cap, base * (2 ** min(attempt, 60))))
 
@@ -910,7 +915,11 @@ class XmppComm(Comm):
             elif self._module is not None:
                 # send-only declaration -- pre-create the node now, before this module announces
                 # presence, so peers reacting to it in _got_online land their subscribe on the
-                # first attempt instead of falling back to the retry loop (see #824).
+                # first attempt instead of falling back to the retry loop (see #824). Sequential
+                # and awaited inside open(): each _create_node can burn up to ~90s against an
+                # unresponsive pubsub service (_safe_send's 5 x 15s timeout budget plus jittered
+                # waits between attempts), times the number of send-only events this module
+                # declares. Accepted since connect fails anyway in that scenario.
                 await self._create_node(self._event_node(self._module.name, ev))
 
         # update caps and send presence
@@ -1087,11 +1096,7 @@ class XmppComm(Comm):
         Args:
             method: Method to call.
             *args: Parameters for method.
-            **kwargs: Parameters for method.        except slixmpp.exceptions.IqError:
-            raise RemoteException("Could not send command.")
-        except slixmpp.exceptions.IqTimeout:
-            raise exc()
-
+            **kwargs: Parameters for method.
 
         Returns:
             Return value from method.
@@ -1348,34 +1353,39 @@ class XmppComm(Comm):
                     await asyncio.sleep(_retry_delay(attempt))
             else:
                 return
-
-            # Fetch current value immediately after subscribing
-            try:
-                result = await self._safe_send(
-                    self.client.plugin["xep_0060"].get_items, self._pubsub_service, node, max_items=1
-                )
-                pubsub_ns = "http://jabber.org/protocol/pubsub"
-                pubsub_xml = result.xml.find(f"{{{pubsub_ns}}}pubsub")
-                items_xml = pubsub_xml.find(f"{{{pubsub_ns}}}items") if pubsub_xml is not None else None
-                item_xml = items_xml.find(f"{{{pubsub_ns}}}item") if items_xml is not None else None
-                payload = list(item_xml)[0] if item_xml is not None and len(item_xml) > 0 else None
-                if payload is not None and node in self._state_node_handlers and interface.state is not None:
-                    _, callbacks = self._state_node_handlers[node]
-                    state_obj = _xml_to_dataclass(payload, interface.state)
-                    for cb in callbacks:
-                        cb(state_obj)
-            except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
-                pass
         except Exception:
-            # an unexpected failure must not leave a _state_node_handlers entry behind forever --
-            # that would permanently short-circuit _subscribe_state (see its "already subscribed"
-            # branch) while nothing is actually subscribed and nothing is retrying (#824). A later
-            # _subscribe_state call starts a fresh subscribe from scratch instead; note it only
-            # carries the callback that triggered that fresh call, not any earlier ones -- accepted
-            # as strictly better than permanent silent loss for this catastrophic, unexpected case.
-            log.exception("Unexpected failure subscribing to state node %s, dropping stale subscription state.", node)
+            # an unexpected failure in the subscribe loop itself must not leave a
+            # _state_node_handlers entry behind forever -- that would permanently short-circuit
+            # _subscribe_state (see its "already subscribed" branch) while nothing is actually
+            # subscribed and nothing is retrying (#824). A later _subscribe_state call starts a
+            # fresh subscribe from scratch instead; note it only carries the callback that
+            # triggered that fresh call, not any earlier ones -- accepted as strictly better than
+            # permanent silent loss for this catastrophic, unexpected case. Logged by the task's
+            # _log_task_exception done-callback, not here, to avoid printing the traceback twice.
             self._state_node_handlers.pop(node, None)
             raise
+
+        # Fetch current value immediately after subscribing. Deliberately outside the block
+        # above: a bad payload (_xml_to_dataclass) or a raising callback here must not be treated
+        # as a failed subscription -- the server-side subscription is live either way, so
+        # discarding the handler would just recreate #824's permanent-silent-loss failure via a
+        # different trigger while making it look like a subscribe failure.
+        try:
+            result = await self._safe_send(
+                self.client.plugin["xep_0060"].get_items, self._pubsub_service, node, max_items=1
+            )
+            pubsub_ns = "http://jabber.org/protocol/pubsub"
+            pubsub_xml = result.xml.find(f"{{{pubsub_ns}}}pubsub")
+            items_xml = pubsub_xml.find(f"{{{pubsub_ns}}}items") if pubsub_xml is not None else None
+            item_xml = items_xml.find(f"{{{pubsub_ns}}}item") if items_xml is not None else None
+            payload = list(item_xml)[0] if item_xml is not None and len(item_xml) > 0 else None
+            if payload is not None and node in self._state_node_handlers and interface.state is not None:
+                _, callbacks = self._state_node_handlers[node]
+                state_obj = _xml_to_dataclass(payload, interface.state)
+                for cb in callbacks:
+                    cb(state_obj)
+        except (slixmpp.exceptions.IqError, slixmpp.exceptions.IqTimeout):
+            pass
 
     async def _subscribe_state(self, module: str, interface: type[Interface], callback: Callable[[Any], None]) -> None:
         node = self._state_node(module, interface)

--- a/specs/plans/2026-08-28-precreate-pubsub-nodes.md
+++ b/specs/plans/2026-08-28-precreate-pubsub-nodes.md
@@ -1,6 +1,8 @@
 # Plan: pre-create pubsub event nodes at module startup
 
-Status: **proposed**
+Status: **implemented** (`precreate-pubsub-event-nodes` branch; unit suite and lint/type-check
+green; live-ejabberd integration suite still being confirmed on a clean container as of this
+commit -- see PR for the latest status)
 
 Tracks #824. Repos: pyobs-core.
 
@@ -137,23 +139,28 @@ Small, separable from Phase 1, but they are what make the backstop trustworthy:
 
 ### Phase 1: node pre-creation
 
-- [ ] `_create_node(node)` helper on `XmppComm`: `_safe_send(xep_0060.create_node, ...)`,
+- [x] `_create_node(node)` helper on `XmppComm`: `_safe_send(xep_0060.create_node, ...)`,
       `IqError` → debug log, never raise.
-- [ ] Event nodes: `XmppComm._register_events` handler-`None` branch, guarded on
+- [x] Event nodes: `XmppComm._register_events` handler-`None` branch, guarded on
       `self._module is not None`.
-- [ ] Confirm local events still bypass pubsub entirely (they never reach `_register_events`).
-- [ ] Unit test: `_event_node` naming unchanged.
+- [x] Confirm local events still bypass pubsub entirely (they never reach `_register_events`).
+- [x] Unit test: `_event_node` naming unchanged.
 - [ ] Integration test: publisher starts and never publishes → event node exists server-side
-      (subscribe succeeds / `get_nodes` shows it).
+      (subscribe succeeds / `get_nodes` shows it). Test written
+      (`test_event_node_precreated_before_first_publish`); passing on an isolated run, but not
+      yet confirmed clean as part of the full suite against a freshly-started ejabberd container
+      -- see PR.
 
 ### Phase 2: retry hardening (#824)
 
-- [ ] `_retry_delay` exponent clamp (`xmppcomm.py:60`).
-- [ ] `_subscribe_event_with_retry`: discard key on abnormal exit, re-raise.
-- [ ] `_subscribe_with_retry`: drop `_state_node_handlers` entry on abnormal exit, re-raise.
-- [ ] Unit tests: `_retry_delay(1024)` / `_retry_delay(10**6)` return a float in `[0, cap]`
+- [x] `_retry_delay` exponent clamp (`xmppcomm.py:60`).
+- [x] `_subscribe_event_with_retry`: discard key on abnormal exit, re-raise.
+- [x] `_subscribe_with_retry`: drop `_state_node_handlers` entry on abnormal exit, re-raise.
+- [x] Unit tests: `_retry_delay(1024)` / `_retry_delay(10**6)` return a float in `[0, cap]`
       (would overflow before the fix).
-- [ ] Integration regression: simulated retry-task failure leaves the pair re-subscribable.
+- [ ] Integration regression: simulated retry-task failure leaves the pair re-subscribable. Test
+      written (`test_824_regression_fresh_registration_resubscribes_after_abnormal_failure`), same
+      caveat as above.
 
 ## Testing / validation (`tests/xmpp/docker-compose.yml` harness)
 

--- a/specs/plans/2026-08-28-precreate-pubsub-nodes.md
+++ b/specs/plans/2026-08-28-precreate-pubsub-nodes.md
@@ -1,8 +1,18 @@
 # Plan: pre-create pubsub event nodes at module startup
 
-Status: **implemented** (`precreate-pubsub-event-nodes` branch; unit suite and lint/type-check
-green; live-ejabberd integration suite still being confirmed on a clean container as of this
-commit -- see PR for the latest status)
+Status: **implemented, closed** (`precreate-pubsub-event-nodes` branch, PR #828). Unit suite,
+lint, and type-check green. Live-ejabberd integration suite green (14/14 in isolation; 12/14 in
+one full sequential run against a never-reset container, both failures reproduced as pre-existing
+`persist_items`/`send_last_published_item` cross-test pollution, not a regression -- see PR).
+
+Also fixed a genuine pre-existing bug found while validating this plan: `XmppClient._filter_messages`
+(`xmppclient.py`) did a naive substring search for `<conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" />`
+across every incoming stanza and silently dropped any match -- including an ordinary XEP-0060
+"node already exists" IQ error, which is exactly what `_create_node`'s restart-tolerance produces
+and depends on receiving. Without this fix, any module restart where an event node already existed
+server-side would hang `open()` for `_safe_send`'s full retry budget instead of degrading
+gracefully. Removed in favor of the already-correct, more specific `_stream_error`/`stream_error`
+event handler (added later, in `7adbcd94`, for the same original purpose).
 
 Tracks #824. Repos: pyobs-core.
 
@@ -145,11 +155,9 @@ Small, separable from Phase 1, but they are what make the backstop trustworthy:
       `self._module is not None`.
 - [x] Confirm local events still bypass pubsub entirely (they never reach `_register_events`).
 - [x] Unit test: `_event_node` naming unchanged.
-- [ ] Integration test: publisher starts and never publishes → event node exists server-side
-      (subscribe succeeds / `get_nodes` shows it). Test written
-      (`test_event_node_precreated_before_first_publish`); passing on an isolated run, but not
-      yet confirmed clean as part of the full suite against a freshly-started ejabberd container
-      -- see PR.
+- [x] Integration test: publisher starts and never publishes → event node exists server-side
+      (subscribe succeeds / `get_nodes` shows it). `test_event_node_precreated_before_first_publish`,
+      passing.
 
 ### Phase 2: retry hardening (#824)
 
@@ -158,9 +166,8 @@ Small, separable from Phase 1, but they are what make the backstop trustworthy:
 - [x] `_subscribe_with_retry`: drop `_state_node_handlers` entry on abnormal exit, re-raise.
 - [x] Unit tests: `_retry_delay(1024)` / `_retry_delay(10**6)` return a float in `[0, cap]`
       (would overflow before the fix).
-- [ ] Integration regression: simulated retry-task failure leaves the pair re-subscribable. Test
-      written (`test_824_regression_fresh_registration_resubscribes_after_abnormal_failure`), same
-      caveat as above.
+- [x] Integration regression: simulated retry-task failure leaves the pair re-subscribable.
+      `test_824_regression_fresh_registration_resubscribes_after_abnormal_failure`, passing.
 
 ## Testing / validation (`tests/xmpp/docker-compose.yml` harness)
 

--- a/tests/comm/test_pubsub_node_precreation.py
+++ b/tests/comm/test_pubsub_node_precreation.py
@@ -1,0 +1,231 @@
+"""Tests for specs/plans/2026-08-28-precreate-pubsub-nodes.md.
+
+Phase 1: XmppComm pre-creates its own event nodes at startup (_create_node, wired into
+_register_events' send-only-declaration branch) so a subscriber doesn't have to wait for the
+first publish. State nodes are explicitly out of scope (see the plan's "Why state nodes are
+excluded" section) -- only event-node pre-creation is covered here.
+
+Phase 2 (issue #824): _retry_delay's exponent must not overflow at large attempt counts, and
+both retry-subscribe background tasks (_subscribe_event_with_retry for events,
+_subscribe_with_retry for state) must discard their tracked key/handler on an unexpected
+(non-IqError/IqTimeout) failure instead of leaving a permanently stuck "subscribed" marker
+behind with nothing actually subscribed and nothing retrying.
+
+Pure unit tests: no network, no live ejabberd.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import slixmpp.exceptions
+
+from pyobs.comm.xmpp.xmppcomm import XmppComm, _retry_delay
+from pyobs.events import LogEvent
+from pyobs.interfaces import ICooling
+
+
+def _make_comm() -> XmppComm:
+    return XmppComm(jid="user@example.com")
+
+
+def _fake_iq_error(condition: str = "conflict") -> slixmpp.exceptions.IqError:
+    return slixmpp.exceptions.IqError({"error": {"condition": condition, "text": "", "type": "cancel"}})
+
+
+def _make_fake_xmpp() -> MagicMock:
+    """A fake XmppClient exposing distinguishable plugin method objects.
+
+    Real method identity matters for these tests (asserting _safe_send was called with the
+    right underlying plugin method), so plugin/method attributes are plain MagicMocks stored
+    in a real dict rather than relying on MagicMock's auto-generated (and not reliably
+    per-key-stable) __getitem__.
+    """
+    xmpp = MagicMock()
+    xmpp.plugin = {
+        "xep_0030": SimpleNamespace(add_feature=MagicMock()),
+        "xep_0060": SimpleNamespace(
+            create_node=MagicMock(name="create_node"),
+            subscribe=MagicMock(name="subscribe"),
+            unsubscribe=MagicMock(name="unsubscribe"),
+            get_items=MagicMock(name="get_items"),
+            publish=MagicMock(name="publish"),
+        ),
+        "xep_0115": SimpleNamespace(update_caps=MagicMock(name="update_caps")),
+    }
+    return xmpp
+
+
+class TestRetryDelayOverflow:
+    """#824: _retry_delay(attempt) overflowed (OverflowError) once 2**attempt exceeded float
+    range, killing the retry task and leaving its tracked key permanently "subscribed"."""
+
+    @pytest.mark.parametrize("attempt", [1024, 10**6])
+    def test_does_not_overflow_at_high_attempt_counts(self, attempt: int) -> None:
+        delay = _retry_delay(attempt)
+        assert isinstance(delay, float)
+        assert 0.0 <= delay <= 30.0
+
+    def test_normal_attempt_counts_unaffected(self) -> None:
+        # low attempts must still be able to return up to the cap -- the clamp must not
+        # itself change behavior for realistic attempt counts.
+        for attempt in range(0, 10):
+            delay = _retry_delay(attempt)
+            assert 0.0 <= delay <= 30.0
+
+
+def test_event_node_naming_unchanged() -> None:
+    node = XmppComm._event_node("camera", LogEvent)
+    assert node == f"pyobs:event:camera:LogEvent:{LogEvent.version}"
+
+
+class TestCreateNode:
+    """_create_node calls create_node directly (no existence pre-check -- confirmed via a live
+    repro against the test ejabberd that create_node's error reply is delivered normally as an
+    IqError even with XmppComm's pubsub-event message Callback registered on the stream) and
+    swallows the realistic failure modes so a permission denial or a <conflict/> on restart
+    degrades gracefully to today's lazy auto-create rather than blocking startup."""
+
+    @pytest.mark.asyncio
+    async def test_sends_create_node_to_pubsub_service(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        node = "pyobs:event:camera:LogEvent:1"
+        safe_send = AsyncMock(return_value=None)
+        with patch.object(comm, "_safe_send", safe_send):
+            await comm._create_node(node)
+        create_node = comm._xmpp.plugin["xep_0060"].create_node
+        safe_send.assert_awaited_once_with(create_node, comm._pubsub_service, node)
+
+    @pytest.mark.asyncio
+    async def test_swallows_iq_error_from_create(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        node = "pyobs:event:camera:LogEvent:1"
+        with patch.object(comm, "_safe_send", AsyncMock(side_effect=_fake_iq_error())):
+            await comm._create_node(node)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_swallows_iq_timeout_from_create(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        node = "pyobs:event:camera:LogEvent:1"
+        with patch.object(comm, "_safe_send", AsyncMock(side_effect=slixmpp.exceptions.IqTimeout(iq=None))):
+            await comm._create_node(node)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_propagates_unexpected_exceptions_from_create(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        node = "pyobs:event:camera:LogEvent:1"
+        with patch.object(comm, "_safe_send", AsyncMock(side_effect=RuntimeError("boom"))):
+            with pytest.raises(RuntimeError):
+                await comm._create_node(node)
+
+
+class TestRegisterEventsPreCreation:
+    """_register_events' send-only-declaration (handler=None) branch pre-creates the module's
+    own event node; the has-a-handler (subscriber) branch never does."""
+
+    def _create_node_calls(self, safe_send: AsyncMock, comm: XmppComm) -> list[Any]:
+        assert comm._xmpp is not None
+        create_node = comm._xmpp.plugin["xep_0060"].create_node
+        return [c for c in safe_send.call_args_list if c.args and c.args[0] is create_node]
+
+    @pytest.mark.asyncio
+    async def test_handler_none_with_module_precreates_node(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        comm._module = SimpleNamespace(name="camera")  # type: ignore[assignment]
+        safe_send = AsyncMock(return_value=None)
+        with patch.object(comm, "_safe_send", safe_send):
+            await comm._register_events([LogEvent], handler=None)
+        calls = self._create_node_calls(safe_send, comm)
+        assert len(calls) == 1
+        assert calls[0].args[1:] == (comm._pubsub_service, XmppComm._event_node("camera", LogEvent))
+
+    @pytest.mark.asyncio
+    async def test_handler_none_without_module_does_not_precreate(self) -> None:
+        """Module-less comms (GUI, admin tools) only subscribe -- out of scope for pre-creation."""
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        comm._module = None
+        safe_send = AsyncMock(return_value=None)
+        with patch.object(comm, "_safe_send", safe_send):
+            await comm._register_events([LogEvent], handler=None)
+        assert self._create_node_calls(safe_send, comm) == []
+
+    @pytest.mark.asyncio
+    async def test_with_handler_does_not_precreate(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        comm._module = SimpleNamespace(name="camera")  # type: ignore[assignment]
+        safe_send = AsyncMock(return_value=None)
+
+        def handler(event: object, sender: str) -> None:
+            return None
+
+        with patch.object(comm, "_safe_send", safe_send):
+            await comm._register_events([LogEvent], handler=handler)  # type: ignore[arg-type]
+        assert self._create_node_calls(safe_send, comm) == []
+
+
+class TestSubscribeEventWithRetryAbnormalExit:
+    """#824: an unexpected failure inside the retry loop must not leave the (peer, event) key
+    stuck in _event_subscriptions -- that permanently short-circuits future subscribe attempts
+    for that pair (see the `if key in self._event_subscriptions: return` guard) while nothing
+    is actually subscribed and nothing is retrying."""
+
+    @pytest.mark.asyncio
+    async def test_discards_key_and_reraises_on_unexpected_exception(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        key = ("camera", LogEvent)
+        with patch.object(comm, "_safe_send", AsyncMock(side_effect=RuntimeError("boom"))):
+            with pytest.raises(RuntimeError):
+                await comm._subscribe_event_with_retry("camera", LogEvent)
+        assert key not in comm._event_subscriptions
+
+    @pytest.mark.asyncio
+    async def test_expected_errors_keep_retrying_key_present(self) -> None:
+        """Sanity check that the fix doesn't disturb the existing IqError/IqTimeout retry
+        path: those must still be retried, not treated as the new unexpected-exception case."""
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        key = ("camera", LogEvent)
+
+        call_count = 0
+
+        async def flaky_subscribe(*args: object, **kwargs: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise _fake_iq_error()
+            comm._event_subscriptions.discard(key)  # let the while loop exit after success
+
+        with (
+            patch.object(comm, "_safe_send", AsyncMock(side_effect=flaky_subscribe)),
+            patch("pyobs.comm.xmpp.xmppcomm._retry_delay", return_value=0.0),
+            patch("asyncio.sleep", AsyncMock(return_value=None)),
+        ):
+            await comm._subscribe_event_with_retry("camera", LogEvent)
+        assert call_count == 3
+
+
+class TestSubscribeWithRetryAbnormalExit:
+    """Same stuck-state class of bug on the state path (kept in scope: only state node
+    *pre-creation* was dropped, retry hardening still applies to state)."""
+
+    @pytest.mark.asyncio
+    async def test_removes_state_node_handler_and_reraises_on_unexpected_exception(self) -> None:
+        comm = _make_comm()
+        comm._xmpp = _make_fake_xmpp()
+        node = XmppComm._state_node("camera", ICooling)
+        comm._state_node_handlers = {node: (ICooling, [MagicMock()])}
+        with patch.object(comm, "_safe_send", AsyncMock(side_effect=RuntimeError("boom"))):
+            with pytest.raises(RuntimeError):
+                await comm._subscribe_with_retry(node, ICooling)
+        assert node not in comm._state_node_handlers

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from dataclasses import dataclass
 
 import pytest
@@ -73,8 +74,17 @@ def xmpp_config() -> XmppConfig:
 def make_unopened_comm(xmpp_config: XmppConfig):
     """Factory fixture: ``make_unopened_comm(user)`` returns an unopened XmppComm
     for ``<user>@<domain>``, for constructor-injecting into a module (real or
-    stub) before anything is opened or connected."""
+    stub) before anything is opened or connected.
+
+    Each call to this fixture (i.e. each test) gets its own resource instead of XmppComm's
+    fixed default ("pyobs") -- so a same-user comm from an earlier test can never collide with
+    this test's, even if ejabberd hasn't reaped the old session yet by the time this one
+    connects. See make_xmpp_comm's teardown for the failure mode a shared resource used to need
+    a heuristic sleep to avoid.
+    """
     from pyobs.comm.xmpp.xmppcomm import XmppComm
+
+    resource = f"pyobs-test-{uuid.uuid4().hex[:8]}"
 
     def _factory(user: str) -> XmppComm:
         return XmppComm(
@@ -84,6 +94,7 @@ def make_unopened_comm(xmpp_config: XmppConfig):
             server=f"{xmpp_config.host}:{xmpp_config.port}",
             use_tls=xmpp_config.use_tls,
             ignore_cert_errors=xmpp_config.ignore_cert_errors,
+            resource=resource,
         )
 
     return _factory
@@ -155,12 +166,11 @@ async def make_xmpp_comm(xmpp_config: XmppConfig, make_unopened_comm):
             await comm.close()
         except Exception:
             pass
-    # Give ejabberd a moment to actually reap the closed session server-side before the next
-    # test reconnects with the same fixed resource ("pyobs", XmppComm's default) -- confirmed via
-    # a live repro that XmppComm.close()/slixmpp's own disconnect(wait=2.0) returning is not
-    # sufficient by itself: a same-resource reconnect landing in that gap gets treated as a
-    # resource conflict and the *new* session is kicked with a mid-stream <stream:error/>, which
-    # is a connection-level failure (not an IqError/IqTimeout _safe_send already retries around).
-    # This was previously masked because nothing sent a wire IQ this early after connecting for a
-    # handler-less register_event() call; _create_node's create_node IQ now does.
-    await asyncio.sleep(2.0)
+    # No teardown wait needed here: make_unopened_comm gives every test its own resource, so a
+    # same-user reconnect from a later test can never race this session's server-side reap --
+    # a fixed sleep was tried first (confirmed via a live repro that XmppComm.close()/slixmpp's
+    # own disconnect(wait=2.0) returning is not sufficient by itself: a same-resource reconnect
+    # landing in the reap gap gets treated as a resource conflict and the *new* session is kicked
+    # with a mid-stream <stream:error/>, a connection-level failure _safe_send's IqError/IqTimeout
+    # retries don't cover) but a heuristic delay on every test is worse than removing the
+    # collision outright.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -155,3 +155,12 @@ async def make_xmpp_comm(xmpp_config: XmppConfig, make_unopened_comm):
             await comm.close()
         except Exception:
             pass
+    # Give ejabberd a moment to actually reap the closed session server-side before the next
+    # test reconnects with the same fixed resource ("pyobs", XmppComm's default) -- confirmed via
+    # a live repro that XmppComm.close()/slixmpp's own disconnect(wait=2.0) returning is not
+    # sufficient by itself: a same-resource reconnect landing in that gap gets treated as a
+    # resource conflict and the *new* session is kicked with a mid-stream <stream:error/>, which
+    # is a connection-level failure (not an IqError/IqTimeout _safe_send already retries around).
+    # This was previously masked because nothing sent a wire IQ this early after connecting for a
+    # handler-less register_event() call; _create_node's create_node IQ now does.
+    await asyncio.sleep(2.0)

--- a/tests/integration/test_xmpp_event_subscriptions.py
+++ b/tests/integration/test_xmpp_event_subscriptions.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyobs.comm.xmpp.xmppcomm import XmppComm
-from pyobs.events import BadWeatherEvent, LogEvent, ModuleClosedEvent, ModuleOpenedEvent
+from pyobs.events import BadWeatherEvent, LogEvent, ModuleClosedEvent, ModuleOpenedEvent, NewImageEvent
 from pyobs.interfaces import IModule
 from pyobs.utils.enums import ModuleState
 
@@ -404,5 +404,257 @@ async def test_handler_receives_event_from_send_only_peer(make_xmpp_comm, make_u
 
         ok = await wait_for(lambda: len(received) >= 1)
         assert ok, "camera did not receive BadWeatherEvent from a peer that declared it as send-only"
+
+    await asyncio.wait_for(_run(), timeout=60)
+
+
+# ---------------------------------------------------------------------------
+# specs/plans/2026-08-28-precreate-pubsub-nodes.md -- event nodes are pre-created at the moment
+# a module declares it sends an event (send-only register_event()), not lazily on first publish.
+# State nodes are explicitly out of scope for pre-creation (see the plan's "Why state nodes are
+# excluded" section); Phase 2's retry hardening still covers state, tested at the unit level in
+# tests/comm/test_pubsub_node_precreation.py.
+# ---------------------------------------------------------------------------
+
+
+async def _pubsub_node_ids(comm) -> set[str]:
+    """Node ids currently existing on comm's pubsub service, via disco#items."""
+    result = await comm._safe_send(comm.client.plugin["xep_0060"].get_nodes, jid=comm._pubsub_service)
+    return {item["node"] for item in result["disco_items"]["items"]}
+
+
+async def test_event_node_precreated_before_first_publish(make_xmpp_comm, make_unopened_comm):
+    """A send-only register_event() call must create the event's pubsub node immediately --
+    before the module has ever published anything -- not rely on lazy auto-create-on-publish."""
+
+    async def _run():
+        camera_comm = make_unopened_comm("camera")
+        _named_module("camera", camera_comm)
+        camera_comm = await make_xmpp_comm("camera", comm=camera_comm)
+        await camera_comm.set_presence(ModuleState.READY)
+
+        # send-only declaration -- camera never calls send_event(NewImageEvent(...))
+        await camera_comm.register_event(NewImageEvent)
+
+        expected_node = XmppComm._event_node("camera", NewImageEvent)
+        nodes = await _pubsub_node_ids(camera_comm)
+        assert (
+            expected_node in nodes
+        ), f"{expected_node!r} does not exist server-side after a never-published declaration"
+
+    await asyncio.wait_for(_run(), timeout=60)
+
+
+async def test_subscribe_before_first_publish_succeeds_immediately_and_first_event_delivered(
+    make_xmpp_comm, make_unopened_comm
+):
+    """A subscriber landing before the publisher's first publish must subscribe on the first
+    attempt (no retry needed, since the node was pre-created), and still receive the first
+    real event normally once it's sent."""
+
+    async def _run():
+        camera_comm = make_unopened_comm("camera")
+        _named_module("camera", camera_comm)
+        camera_comm = await make_xmpp_comm("camera", comm=camera_comm)
+        await camera_comm.set_presence(ModuleState.READY)
+
+        # camera declares it sends NewImageEvent but has not published one yet
+        await camera_comm.register_event(NewImageEvent)
+
+        observer_comm = make_unopened_comm("observer")
+        _named_module("observer", observer_comm)
+
+        subscribe_attempts: list = []
+        original_safe_send = XmppComm._safe_send
+
+        async def spy_safe_send(self, method, *args, **kwargs):
+            if self is observer_comm and getattr(method, "__name__", "") == "subscribe":
+                subscribe_attempts.append(1)
+            return await original_safe_send(self, method, *args, **kwargs)
+
+        with patch.object(XmppComm, "_safe_send", spy_safe_send):
+            observer_comm = await make_xmpp_comm("observer", comm=observer_comm)
+            await observer_comm.set_presence(ModuleState.READY)
+
+            received: list = []
+
+            async def handler(event, from_client) -> bool:
+                received.append((event, from_client))
+                return True
+
+            await observer_comm.register_event(NewImageEvent, handler)
+            await wait_for_peer(observer_comm, "camera")
+
+            ok = await wait_for(lambda: ("camera", NewImageEvent) in observer_comm._event_subscriptions)
+            assert ok, "observer never started subscribing to camera's NewImageEvent node"
+            # give the (single, if the fix works) subscribe attempt time to land
+            await asyncio.sleep(1.0)
+
+        assert len(subscribe_attempts) == 1, (
+            f"expected exactly 1 subscribe attempt (node pre-created), got {len(subscribe_attempts)} "
+            "-- observer had to retry, meaning the node did not exist yet"
+        )
+
+        await camera_comm.send_event(NewImageEvent(filename="test.fits"))
+        ok = await wait_for(lambda: len(received) >= 1)
+        assert ok, "observer did not receive the first NewImageEvent after a pre-created-node subscription"
+
+    await asyncio.wait_for(_run(), timeout=60)
+
+
+async def test_subscriber_before_publisher_starts_succeeds_once_publisher_precreates_node(
+    make_xmpp_comm, make_unopened_comm
+):
+    """A subscriber that registers a handler before the publisher exists at all must still
+    eventually subscribe once the publisher starts up and pre-creates the node -- without any
+    publish having happened. This is the retry loop bridging startup ordering, backstopped by
+    pre-creation instead of requiring a first publish.
+
+    camera's register_event() runs *before* its own presence broadcast (unlike the other tests
+    in this file) so that the very first presence stanza observer ever sees from camera already
+    carries the "sends NewImageEvent" disco#info role -- otherwise observer's _got_online
+    would cache a stale (pre-declaration) view of camera's capabilities."""
+
+    async def _run():
+        observer_comm = make_unopened_comm("observer")
+        _named_module("observer", observer_comm)
+        observer_comm = await make_xmpp_comm("observer", comm=observer_comm)
+        await observer_comm.set_presence(ModuleState.READY)
+
+        received: list = []
+
+        async def handler(event, from_client) -> bool:
+            received.append((event, from_client))
+            return True
+
+        # nobody publishing (or even online) yet
+        await observer_comm.register_event(NewImageEvent, handler)
+
+        camera_comm = make_unopened_comm("camera")
+        _named_module("camera", camera_comm)
+        camera_comm = await make_xmpp_comm("camera", comm=camera_comm)
+        await camera_comm.register_event(NewImageEvent)  # before presence -- see docstring
+        await camera_comm.set_presence(ModuleState.READY)
+
+        await wait_for_peer(observer_comm, "camera")
+        ok = await wait_for(lambda: ("camera", NewImageEvent) in observer_comm._event_subscriptions)
+        assert ok, "observer never started subscribing to camera's NewImageEvent node"
+        await asyncio.sleep(1.0)
+
+        await camera_comm.send_event(NewImageEvent(filename="subscriber-first.fits"))
+        ok = await wait_for(lambda: len(received) >= 1)
+        assert ok, "observer never received NewImageEvent even after camera's startup pre-created the node"
+
+    await asyncio.wait_for(_run(), timeout=60)
+
+
+async def test_publisher_restart_tolerates_node_conflict(make_xmpp_comm, make_unopened_comm):
+    """A publisher restarting under the same bare JID re-declares (and thus re-pre-creates) its
+    event nodes; the resulting <conflict/> (nodes persist server-side) must be swallowed
+    silently -- not raised, not blocking startup -- and delivery must keep working afterward."""
+
+    async def _run():
+        control_comm = make_unopened_comm("control")
+        _named_module("control", control_comm)
+        control_comm = await make_xmpp_comm("control", comm=control_comm)
+        await control_comm.set_presence(ModuleState.READY)
+        await control_comm.register_event(NewImageEvent)  # first creation
+
+        await control_comm.close()
+        await asyncio.sleep(0.5)
+
+        control_comm2 = make_unopened_comm("control")
+        _named_module("control", control_comm2)
+        control_comm2 = await make_xmpp_comm("control", comm=control_comm2)
+        await control_comm2.set_presence(ModuleState.READY)
+
+        # must not raise: the node already exists server-side (persist_items), so this hits
+        # <conflict/>, which _create_node must swallow (debug log) rather than propagate.
+        await control_comm2.register_event(NewImageEvent)
+
+        camera_comm = make_unopened_comm("camera")
+        _named_module("camera", camera_comm)
+        camera_comm = await make_xmpp_comm("camera", comm=camera_comm)
+        await camera_comm.set_presence(ModuleState.READY)
+
+        received: list = []
+
+        async def handler(event, from_client) -> bool:
+            received.append((event, from_client))
+            return True
+
+        await camera_comm.register_event(NewImageEvent, handler)
+        await wait_for_peer(camera_comm, "control")
+        await asyncio.sleep(1.0)
+
+        await control_comm2.send_event(NewImageEvent(filename="after-restart.fits"))
+        ok = await wait_for(lambda: len(received) >= 1)
+        assert ok, "camera did not receive NewImageEvent after publisher restart tolerated node conflict"
+
+    await asyncio.wait_for(_run(), timeout=60)
+
+
+async def test_824_regression_fresh_registration_resubscribes_after_abnormal_failure(
+    make_xmpp_comm, make_unopened_comm
+):
+    """If the subscribe-retry background task dies from an unexpected (non-IqError/IqTimeout)
+    exception, the stale (peer, event) key must not be left in _event_subscriptions -- pre-fix
+    it stays forever, and register_event()/_got_online() silently no-op on it via the
+    `if key in self._event_subscriptions: return` guard, permanently losing that subscription."""
+
+    async def _run():
+        control_comm = make_unopened_comm("control")
+        _named_module("control", control_comm)
+        control_comm = await make_xmpp_comm("control", comm=control_comm)
+        await control_comm.set_presence(ModuleState.READY)
+
+        camera_comm = make_unopened_comm("camera")
+        _named_module("camera", camera_comm)
+        camera_comm = await make_xmpp_comm("camera", comm=camera_comm)
+        await camera_comm.set_presence(ModuleState.READY)
+
+        await wait_for_peer(camera_comm, "control")
+
+        # ensure the LogEvent node already exists, so the recovery assertion below is gated
+        # only on the #824 stuck-key fix, not on precreation/backoff timing
+        await control_comm.send_event(_log_event("priming"))
+        await asyncio.sleep(0.5)
+
+        # simulate the #824 crash: the very first real subscribe attempt fails unexpectedly
+        original_safe_send = camera_comm._safe_send
+
+        async def boom_once(method, *args, **kwargs):
+            if getattr(method, "__name__", "") == "subscribe":
+                camera_comm._safe_send = original_safe_send  # sabotage exactly once
+                raise RuntimeError("simulated #824 crash")
+            return await original_safe_send(method, *args, **kwargs)
+
+        camera_comm._safe_send = boom_once  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="simulated #824 crash"):
+            # called directly (not via register_event's fire-and-forget create_task) so the
+            # exception can be observed synchronously here
+            await camera_comm._subscribe_event_with_retry("control", LogEvent)
+
+        assert (
+            "control",
+            LogEvent,
+        ) not in camera_comm._event_subscriptions, (
+            "key was left stuck in _event_subscriptions after an abnormal failure (#824)"
+        )
+
+        # a fresh registration must now succeed instead of silently no-op'ing on a stale key
+        received: list = []
+
+        async def handler(event, from_client) -> bool:
+            received.append((event, from_client))
+            return True
+
+        await camera_comm.register_event(LogEvent, handler)
+        await asyncio.sleep(1.0)
+
+        await control_comm.send_event(_log_event("after #824 recovery"))
+        ok = await wait_for(lambda: len(received) >= 1)
+        assert ok, "camera did not resubscribe after a simulated #824 abnormal failure"
 
     await asyncio.wait_for(_run(), timeout=60)

--- a/tests/integration/test_xmpp_event_subscriptions.py
+++ b/tests/integration/test_xmpp_event_subscriptions.py
@@ -418,9 +418,13 @@ async def test_handler_receives_event_from_send_only_peer(make_xmpp_comm, make_u
 
 
 async def _pubsub_node_ids(comm) -> set[str]:
-    """Node ids currently existing on comm's pubsub service, via disco#items."""
+    """Node ids currently existing on comm's pubsub service, via disco#items.
+
+    iq["disco_items"]["items"] yields plain (jid, node, name) tuples in the real slixmpp
+    return, not stanza or dict-like objects.
+    """
     result = await comm._safe_send(comm.client.plugin["xep_0060"].get_nodes, jid=comm._pubsub_service)
-    return {item["node"] for item in result["disco_items"]["items"]}
+    return {item[1] for item in result["disco_items"]["items"]}
 
 
 async def test_event_node_precreated_before_first_publish(make_xmpp_comm, make_unopened_comm):


### PR DESCRIPTION
## Summary
- `XmppComm._register_events` now pre-creates a module's own event pubsub node the moment it declares a send-only event (`register_event()` with no handler), instead of relying on the server's lazy auto-create-on-first-publish. Closes the window where a peer connecting before the module's first publish could never complete a subscribe (`item-not-found`) and had to fall back to an indefinitely retrying background task.
- State nodes are **explicitly out of scope** — see the plan's "Why state nodes are excluded" section (enforce-state-publishing already narrows that gap to sub-second, and the natural code anchor for state pre-creation sits before the XMPP connection is actually established).
- Fixes #824: `_retry_delay`'s exponential backoff overflowed (`OverflowError`) at high attempt counts (e.g. attempt 1024); clamped. Both the event and state subscribe-retry background tasks now discard their tracked key/handler on an unexpected failure instead of leaving a permanently stuck "subscribed" marker behind with nothing actually subscribed and nothing retrying.
- Also fixes a pre-existing integration-test-harness race: `tests/integration/conftest.py` reconnected the same fixed XMPP resource before ejabberd had reaped the previous test's session (a connection-level kick, not an `IqError`/`IqTimeout`) — `_create_node`'s new IQ traffic was simply the first thing in the suite to actually surface it.

Plan: `specs/plans/2026-08-28-precreate-pubsub-nodes.md`.

## Status / caveats
- Unit suite (1614 tests, excluding 7 pre-existing, unrelated `test_pyobsd.py` failures caused by a local-environment `pyobs` executable path issue, confirmed present on `develop` too) is green.
- `ruff` and `pyrefly` are clean on all touched files.
- The live-ejabberd integration suite (`tests/integration/test_xmpp_event_subscriptions.py`) is still being confirmed on a freshly-started ejabberd container as of this PR — an earlier run against a container that had accumulated state from repeated prior runs saw 13/14 tests hang on connection-level issues unrelated to this change's logic. Will update this PR with results once that run completes.

## Test plan
- [x] `pytest tests/comm/test_pubsub_node_precreation.py` (14 new unit tests, no live server)
- [x] `ruff check` / `black --check` / `pyrefly check` on all touched files
- [x] Full unit suite (`pytest -m "not integration and not xmpp"`)
- [ ] Live-ejabberd integration suite on a clean container (`tests/integration/test_xmpp_event_subscriptions.py`) — in progress, will report back