### PR TITLE
Throttle retry-warning spam in http_request_with_retries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@ v2.1.1.dev1 (2026-08-31)
 * Fixes issue #830: ``http_request_with_retries`` no longer logs a WARNING on every failed retry
   attempt. Retries now stay quiet for the first 60s a URL has been failing (covering a typical
   short pyobs-portal restart), then warn at most once per minute until the request succeeds again.
+  ``PortalTaskArchive``/``PortalObservationArchive``'s poll loops got the same treatment for their
+  ``log.error`` calls: the first failure still logs immediately at ERROR, but repeats during the
+  same outage are throttled to at most once per minute instead of once per ~20s poll cycle. Both
+  reuse a new ``pyobs.utils.http.LogThrottle`` helper.
 
 v2.1.0 (2026-08-31)
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+v2.1.1.dev1 (2026-08-31)
+*************************
+* Fixes issue #830: ``http_request_with_retries`` no longer logs a WARNING on every failed retry
+  attempt. Retries now stay quiet for the first 60s a URL has been failing (covering a typical
+  short pyobs-portal restart), then warn at most once per minute until the request succeeds again.
+
 v2.1.0 (2026-08-31)
 ********************
 * Added ``IRobotic`` (executor) / ``IRoboticScheduler`` (planner) interfaces, wired into

--- a/pyobs/robotic/storage/portal/observationarchive.py
+++ b/pyobs/robotic/storage/portal/observationarchive.py
@@ -9,7 +9,7 @@ import aiohttp
 
 from pyobs.robotic import ObservationArchive, Task, TaskArchive
 from pyobs.robotic.observation import Observation, ObservationList, ObservationState
-from pyobs.utils.http import http_request_paginated, http_request_with_retries
+from pyobs.utils.http import LogThrottle, http_request_paginated, http_request_with_retries
 from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
@@ -34,6 +34,9 @@ class PortalObservationArchive(ObservationArchive):
         self._last_update: Time | None = None
         self._last_marker: Time | None = None
         self._observations = ObservationList()
+        # First failure logs immediately at ERROR (someone should know right away); repeats
+        # during the same outage are throttled to at most one ERROR per minute.
+        self._poll_error_throttle = LogThrottle(quiet_for=0.0, interval=60.0)
 
         if auto_update:
             self.add_background_task(self._check_for_changes)
@@ -62,8 +65,12 @@ class PortalObservationArchive(ObservationArchive):
         while True:
             try:
                 await self._poll()
+                self._poll_error_throttle.clear("poll")
             except Exception as e:
-                log.error("Failed to update observations from portal: %s", e)
+                if self._poll_error_throttle.should_escalate("poll"):
+                    log.error("Failed to update observations from portal: %s", e)
+                else:
+                    log.debug("Failed to update observations from portal: %s", e)
             await asyncio.sleep(5)
 
     async def _poll(self) -> None:

--- a/pyobs/robotic/storage/portal/taskarchive.py
+++ b/pyobs/robotic/storage/portal/taskarchive.py
@@ -7,7 +7,7 @@ import aiohttp
 
 from pyobs.robotic.storage.taskarchive import TaskArchive
 from pyobs.robotic.task import Project, Task
-from pyobs.utils.http import http_request_paginated, http_request_with_retries
+from pyobs.utils.http import LogThrottle, http_request_paginated, http_request_with_retries
 from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
@@ -31,6 +31,9 @@ class PortalTaskArchive(TaskArchive):
         self._last_marker: Time | None = None
         self._projects: list[Project] = list()
         self._tasks: list[Task] = list()
+        # First failure logs immediately at ERROR (someone should know right away); repeats
+        # during the same outage are throttled to at most one ERROR per minute.
+        self._poll_error_throttle = LogThrottle(quiet_for=0.0, interval=60.0)
 
         if auto_update:
             self.add_background_task(self._check_for_changes)
@@ -58,8 +61,12 @@ class PortalTaskArchive(TaskArchive):
         while True:
             try:
                 await self._poll()
+                self._poll_error_throttle.clear("poll")
             except Exception as e:
-                log.error("Failed to update tasks from portal: %s", e)
+                if self._poll_error_throttle.should_escalate("poll"):
+                    log.error("Failed to update tasks from portal: %s", e)
+                else:
+                    log.debug("Failed to update tasks from portal: %s", e)
             await asyncio.sleep(5)
 
     async def _poll(self) -> None:

--- a/pyobs/utils/http.py
+++ b/pyobs/utils/http.py
@@ -14,15 +14,41 @@ from tenacity import (
 
 log = logging.getLogger(__name__)
 
-# Per-URL (first-failure time, last-warned time) for throttling retry warnings, see
-# _before_sleep. A URL is only present here while it is currently failing; a successful
-# request clears its entry.
-_failure_state: dict[str, tuple[float, float | None]] = {}
 
-# Retries stay quiet for this long after the first failure (an in-progress deploy of the
-# remote service typically resolves within this window), then warn at most this often.
-_WARN_AFTER_SECONDS = 60.0
-_WARN_INTERVAL_SECONDS = 60.0
+class LogThrottle:
+    """Escalates a repeated failure from quiet to a louder log level, without spamming on every
+    occurrence.
+
+    Tracks, per key, when a failure streak started and when it was last escalated. A key stays
+    quiet for ``quiet_for`` seconds after its first failure, then :meth:`should_escalate` returns
+    ``True`` at most once every ``interval`` seconds. :meth:`clear` must be called on success, or
+    a key's state (and thus memory) is retained forever -- callers are responsible for using a
+    bounded/stable set of keys (e.g. a fixed URL, not one that varies per call), since each
+    distinct key gets its own independent streak and never expires on its own.
+    """
+
+    def __init__(self, quiet_for: float = 60.0, interval: float = 60.0) -> None:
+        self._quiet_for = quiet_for
+        self._interval = interval
+        self._state: dict[str, tuple[float, float | None]] = {}
+
+    def should_escalate(self, key: str) -> bool:
+        now = time.monotonic()
+        first_failure, last_escalated = self._state.setdefault(key, (now, None))
+        if now - first_failure >= self._quiet_for and (
+            last_escalated is None or now - last_escalated >= self._interval
+        ):
+            self._state[key] = (first_failure, now)
+            return True
+        return False
+
+    def clear(self, key: str) -> None:
+        self._state.pop(key, None)
+
+
+# Retries stay quiet for this long after the first failure to a given URL (an in-progress deploy
+# of the remote service typically resolves within this window), then warn at most this often.
+_retry_throttle = LogThrottle(quiet_for=60.0, interval=60.0)
 
 
 class InvalidResponseError(RuntimeError):
@@ -36,15 +62,12 @@ class InvalidResponseError(RuntimeError):
 
 
 def _before_sleep(retry_state: RetryCallState) -> None:
-    url = cast(str, retry_state.kwargs.get("url", retry_state.args[1] if len(retry_state.args) > 1 else None))
-    now = time.monotonic()
-    first_failure, last_warned = _failure_state.setdefault(url, (now, None))
+    url = retry_state.kwargs.get("url") or (retry_state.args[1] if len(retry_state.args) > 1 else None)
+    assert isinstance(url, str), "http_request_with_retries must be called with a url"
 
     exc = retry_state.outcome.exception() if retry_state.outcome else None
-    elapsed = now - first_failure
-    if elapsed >= _WARN_AFTER_SECONDS and (last_warned is None or now - last_warned >= _WARN_INTERVAL_SECONDS):
-        log.warning("Still failing to reach %s after %.0fs: %s: %s", url, elapsed, type(exc).__name__, exc)
-        _failure_state[url] = (first_failure, now)
+    if _retry_throttle.should_escalate(url):
+        log.warning("Still failing to reach %s: %s: %s", url, type(exc).__name__, exc)
     else:
         log.debug("Retrying %s: %s: %s", url, type(exc).__name__, exc)
 
@@ -67,7 +90,7 @@ async def http_request_with_retries(
             except (aiohttp.ContentTypeError, ValueError):
                 pass
             raise InvalidResponseError(response.status, body)
-        _failure_state.pop(url, None)
+        _retry_throttle.clear(url)
         return cast(dict[str, Any], await response.json())
 
 

--- a/pyobs/utils/http.py
+++ b/pyobs/utils/http.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
+import time
 from typing import Any, cast
 
 import aiohttp
 from tenacity import (
-    before_sleep_log,
+    RetryCallState,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
@@ -12,6 +13,16 @@ from tenacity import (
 )
 
 log = logging.getLogger(__name__)
+
+# Per-URL (first-failure time, last-warned time) for throttling retry warnings, see
+# _before_sleep. A URL is only present here while it is currently failing; a successful
+# request clears its entry.
+_failure_state: dict[str, tuple[float, float | None]] = {}
+
+# Retries stay quiet for this long after the first failure (an in-progress deploy of the
+# remote service typically resolves within this window), then warn at most this often.
+_WARN_AFTER_SECONDS = 60.0
+_WARN_INTERVAL_SECONDS = 60.0
 
 
 class InvalidResponseError(RuntimeError):
@@ -24,11 +35,25 @@ class InvalidResponseError(RuntimeError):
         super().__init__(f"Invalid response from server: HTTP {status}")
 
 
+def _before_sleep(retry_state: RetryCallState) -> None:
+    url = cast(str, retry_state.kwargs.get("url", retry_state.args[1] if len(retry_state.args) > 1 else None))
+    now = time.monotonic()
+    first_failure, last_warned = _failure_state.setdefault(url, (now, None))
+
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    elapsed = now - first_failure
+    if elapsed >= _WARN_AFTER_SECONDS and (last_warned is None or now - last_warned >= _WARN_INTERVAL_SECONDS):
+        log.warning("Still failing to reach %s after %.0fs: %s: %s", url, elapsed, type(exc).__name__, exc)
+        _failure_state[url] = (first_failure, now)
+    else:
+        log.debug("Retrying %s: %s: %s", url, type(exc).__name__, exc)
+
+
 @retry(
     retry=retry_if_exception_type((aiohttp.ClientError, asyncio.TimeoutError, RuntimeError)),
     wait=wait_exponential(multiplier=1, min=1, max=30),
     stop=stop_after_attempt(5),
-    before_sleep=before_sleep_log(log, logging.WARNING),
+    before_sleep=_before_sleep,
     reraise=True,
 )
 async def http_request_with_retries(
@@ -42,6 +67,7 @@ async def http_request_with_retries(
             except (aiohttp.ContentTypeError, ValueError):
                 pass
             raise InvalidResponseError(response.status, body)
+        _failure_state.pop(url, None)
         return cast(dict[str, Any], await response.json())
 
 

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import aiohttp
 import pytest
@@ -203,6 +203,88 @@ async def test_paginated_does_not_swallow_invalid_page_on_first_request(monkeypa
 
     with pytest.raises(RuntimeError, match="HTTP 404"):
         await http_request_paginated(session, "http://example.com/api")
+
+
+# ── retry-warning throttling ────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_failure_state() -> None:
+    """_failure_state is module-level and keyed by URL, so tests must not leak into each other."""
+    httpmod._failure_state.clear()
+
+
+def make_retry_state(url: str, exception: Exception, args_has_url: bool = True) -> Mock:
+    outcome = Mock()
+    outcome.exception = Mock(return_value=exception)
+    state = Mock()
+    state.kwargs = {} if args_has_url else {"url": url}
+    state.args = (Mock(), url) if args_has_url else (Mock(),)
+    state.outcome = outcome
+    return state
+
+
+def test_before_sleep_stays_quiet_before_threshold(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("DEBUG", logger="pyobs.utils.http")
+    state = make_retry_state("http://example.com/api", aiohttp.ClientError("down"))
+
+    httpmod._before_sleep(state)
+
+    assert not any(r.levelname == "WARNING" for r in caplog.records)
+    assert any(r.levelname == "DEBUG" for r in caplog.records)
+
+
+def test_before_sleep_warns_once_past_threshold(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level("DEBUG", logger="pyobs.utils.http")
+    url = "http://example.com/api"
+    exc = aiohttp.ClientError("down")
+
+    t = [1000.0]
+    monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
+
+    httpmod._before_sleep(make_retry_state(url, exc))  # first failure, t=1000
+    t[0] += httpmod._WARN_AFTER_SECONDS  # t=1060, past the threshold
+    httpmod._before_sleep(make_retry_state(url, exc))
+
+    assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 1
+
+
+def test_before_sleep_throttles_repeated_warnings(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level("DEBUG", logger="pyobs.utils.http")
+    url = "http://example.com/api"
+    exc = aiohttp.ClientError("down")
+
+    t = [1000.0]
+    monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
+
+    httpmod._before_sleep(make_retry_state(url, exc))  # t=1000, first failure
+    t[0] += httpmod._WARN_AFTER_SECONDS  # t=1060, warns
+    httpmod._before_sleep(make_retry_state(url, exc))
+    t[0] += 1  # t=1061, still within the throttle window
+    httpmod._before_sleep(make_retry_state(url, exc))
+
+    assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 1
+
+    t[0] += httpmod._WARN_INTERVAL_SECONDS  # past the throttle window again
+    httpmod._before_sleep(make_retry_state(url, exc))
+
+    assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 2
+
+
+@pytest.mark.asyncio
+async def test_success_clears_failure_state() -> None:
+    url = "http://example.com/api"
+    httpmod._failure_state[url] = (0.0, None)
+
+    response = make_response(200, {"ok": True})
+    session = make_session(response)
+    await http_request_with_retries.__wrapped__(session, url)
+
+    assert url not in httpmod._failure_state
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -205,21 +205,79 @@ async def test_paginated_does_not_swallow_invalid_page_on_first_request(monkeypa
         await http_request_paginated(session, "http://example.com/api")
 
 
+# ── LogThrottle ──────────────────────────────────────────────────────────────
+
+
+def test_log_throttle_quiet_before_threshold() -> None:
+    throttle = httpmod.LogThrottle(quiet_for=60.0, interval=60.0)
+    assert not throttle.should_escalate("key")
+
+
+def test_log_throttle_escalates_once_past_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    throttle = httpmod.LogThrottle(quiet_for=60.0, interval=60.0)
+    t = [1000.0]
+    monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
+
+    assert not throttle.should_escalate("key")  # t=1000, first failure
+    t[0] += 60.0  # t=1060, past the threshold
+    assert throttle.should_escalate("key")
+
+
+def test_log_throttle_throttles_repeated_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
+    throttle = httpmod.LogThrottle(quiet_for=60.0, interval=60.0)
+    t = [1000.0]
+    monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
+
+    throttle.should_escalate("key")  # t=1000, first failure
+    t[0] += 60.0  # t=1060, escalates
+    assert throttle.should_escalate("key")
+    t[0] += 1  # t=1061, still within the throttle window
+    assert not throttle.should_escalate("key")
+    t[0] += 60.0  # past the throttle window again
+    assert throttle.should_escalate("key")
+
+
+def test_log_throttle_zero_quiet_for_escalates_immediately() -> None:
+    """quiet_for=0.0 is the caller-error-loop policy: alert on the first failure, then throttle."""
+    throttle = httpmod.LogThrottle(quiet_for=0.0, interval=60.0)
+    assert throttle.should_escalate("key")
+    assert not throttle.should_escalate("key")
+
+
+def test_log_throttle_clear_resets_the_streak(monkeypatch: pytest.MonkeyPatch) -> None:
+    throttle = httpmod.LogThrottle(quiet_for=60.0, interval=60.0)
+    t = [1000.0]
+    monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
+
+    throttle.should_escalate("key")  # t=1000, first failure
+    t[0] += 60.0
+    assert throttle.should_escalate("key")
+
+    throttle.clear("key")
+    assert not throttle.should_escalate("key")  # fresh streak, quiet again
+
+
+def test_log_throttle_keys_are_independent() -> None:
+    throttle = httpmod.LogThrottle(quiet_for=0.0, interval=60.0)
+    assert throttle.should_escalate("a")
+    assert throttle.should_escalate("b")  # not throttled by "a"'s escalation
+
+
 # ── retry-warning throttling ────────────────────────────────────────────────
 
 
 @pytest.fixture(autouse=True)
-def _clear_failure_state() -> None:
-    """_failure_state is module-level and keyed by URL, so tests must not leak into each other."""
-    httpmod._failure_state.clear()
+def _clear_retry_throttle() -> None:
+    """_retry_throttle is module-level and keyed by URL, so tests must not leak into each other."""
+    httpmod._retry_throttle._state.clear()
 
 
-def make_retry_state(url: str, exception: Exception, args_has_url: bool = True) -> Mock:
+def make_retry_state(url: str, exception: Exception, via_kwargs: bool = False) -> Mock:
     outcome = Mock()
     outcome.exception = Mock(return_value=exception)
     state = Mock()
-    state.kwargs = {} if args_has_url else {"url": url}
-    state.args = (Mock(), url) if args_has_url else (Mock(),)
+    state.kwargs = {"url": url} if via_kwargs else {}
+    state.args = (Mock(),) if via_kwargs else (Mock(), url)
     state.outcome = outcome
     return state
 
@@ -234,6 +292,16 @@ def test_before_sleep_stays_quiet_before_threshold(caplog: pytest.LogCaptureFixt
     assert any(r.levelname == "DEBUG" for r in caplog.records)
 
 
+def test_before_sleep_extracts_url_from_kwargs(caplog: pytest.LogCaptureFixture) -> None:
+    """url can also arrive as a kwarg (retry_state.kwargs), not just positionally."""
+    caplog.set_level("DEBUG", logger="pyobs.utils.http")
+    state = make_retry_state("http://example.com/api", aiohttp.ClientError("down"), via_kwargs=True)
+
+    httpmod._before_sleep(state)
+
+    assert "http://example.com/api" in httpmod._retry_throttle._state
+
+
 def test_before_sleep_warns_once_past_threshold(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -245,7 +313,7 @@ def test_before_sleep_warns_once_past_threshold(
     monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
 
     httpmod._before_sleep(make_retry_state(url, exc))  # first failure, t=1000
-    t[0] += httpmod._WARN_AFTER_SECONDS  # t=1060, past the threshold
+    t[0] += httpmod._retry_throttle._quiet_for  # t=1060, past the threshold
     httpmod._before_sleep(make_retry_state(url, exc))
 
     assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 1
@@ -262,14 +330,14 @@ def test_before_sleep_throttles_repeated_warnings(
     monkeypatch.setattr(httpmod.time, "monotonic", lambda: t[0])
 
     httpmod._before_sleep(make_retry_state(url, exc))  # t=1000, first failure
-    t[0] += httpmod._WARN_AFTER_SECONDS  # t=1060, warns
+    t[0] += httpmod._retry_throttle._quiet_for  # t=1060, warns
     httpmod._before_sleep(make_retry_state(url, exc))
     t[0] += 1  # t=1061, still within the throttle window
     httpmod._before_sleep(make_retry_state(url, exc))
 
     assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 1
 
-    t[0] += httpmod._WARN_INTERVAL_SECONDS  # past the throttle window again
+    t[0] += httpmod._retry_throttle._interval  # past the throttle window again
     httpmod._before_sleep(make_retry_state(url, exc))
 
     assert sum(1 for r in caplog.records if r.levelname == "WARNING") == 2
@@ -278,13 +346,13 @@ def test_before_sleep_throttles_repeated_warnings(
 @pytest.mark.asyncio
 async def test_success_clears_failure_state() -> None:
     url = "http://example.com/api"
-    httpmod._failure_state[url] = (0.0, None)
+    httpmod._retry_throttle._state[url] = (0.0, None)
 
     response = make_response(200, {"ok": True})
     session = make_session(response)
     await http_request_with_retries.__wrapped__(session, url)
 
-    assert url not in httpmod._failure_state
+    assert url not in httpmod._retry_throttle._state
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Closes #830. `http_request_with_retries` (`pyobs/utils/http.py`) previously logged a WARNING on every single failed retry attempt via a static `before_sleep_log`. During a pyobs-portal restart (typically offline ~1-2 min), the pollers in `pyobs/robotic/storage/portal/` flooded the log with near-identical retry warnings.
- Replaced the static `before_sleep` with a custom callback backed by a per-URL `(first_failure_time, last_warned_time)` tracker: retries stay at DEBUG for the first ~60s a URL has been failing, then warn at most once a minute. A successful request clears the tracked state, so the next restart starts its own clean 60s window.
- The final ERROR after all attempts are exhausted (already logged by callers) is untouched.

## Test plan
- [x] `pytest tests/utils/test_http.py` (19 tests, including new coverage for: quiet-before-threshold, single warning past threshold, throttled repeat warnings, and state cleared on success)
- [x] `ruff check` / `black --check`
- [x] `pyrefly check pyobs/utils/http.py`