### PR TITLE
Take morning darks at the night's science exposure times (#831)

### DIFF
--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -185,18 +185,22 @@ class DarkBiasScript(Script):
             if self.archive is None or self.site is None:
                 self._cant_run_reason = "match_science_exptimes requires archive and site to be configured."
                 return False
-            night = self._resolve_night()
-            if night is None:
-                self._cant_run_reason = "No observer configured to derive the night from."
-                return False
-            # Task.create_script() re-validates a fresh Script (and Archive) on every call, so
-            # estimate_duration() can't reuse this instance's state later -- warm the module-level
-            # cache here instead, so its later (sync, archive-less) lookup can hit it.
+            # _resolve_night() can raise (e.g. night_obs()'s IERS lookup failing) -- guard it
+            # alongside the archive query so any failure here surfaces as "cannot run" rather
+            # than propagating out of can_run() as a hard exception.
             try:
+                night = self._resolve_night()
+                if night is None:
+                    self._cant_run_reason = "No observer configured to derive the night from."
+                    return False
+                # Task.create_script() re-validates a fresh Script (and Archive) on every call, so
+                # estimate_duration() can't reuse this instance's state later -- warm the
+                # module-level cache here instead, so its later (sync, archive-less) lookup can
+                # hit it.
                 await science_exptimes_for_night(self.archive, self.site, night)
             except Exception:
-                log.exception("Could not query archive for science exptimes.")
-                self._cant_run_reason = "Could not query archive for science exptimes."
+                log.exception("Could not determine night or query archive for science exptimes.")
+                self._cant_run_reason = "Could not determine night or query archive for science exptimes."
                 return False
 
         # seems alright
@@ -285,10 +289,10 @@ class DarkBiasScript(Script):
             return sum(self.count * (e + readout) for e in self.exptimes)
 
         if self.match_science_exptimes:
-            if self.site is not None:
+            if self.site is not None and self.archive is not None:
                 night = self._resolve_night()
                 if night is not None:
-                    cached = peek_cached_science_exptimes_for_night(self.site, night)
+                    cached = peek_cached_science_exptimes_for_night(self.archive, self.site, night)
                     if cached is not None:
                         exptimes = self._flatten_matching_exptimes(cached)
                         if exptimes:

--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from pyobs.interfaces import (
     IBinning,
@@ -13,11 +13,13 @@ from pyobs.interfaces import (
     IWindow,
 )
 from pyobs.robotic.scripts import Script
+from pyobs.robotic.utils.archive import Archive
+from pyobs.robotic.utils.calibration import science_exptimes_for_night
 from pyobs.utils.enums import ImageType
+from pyobs.utils.time import Time
 
 if TYPE_CHECKING:
     from pyobs.robotic.task import TaskData
-    from pyobs.utils.time import Time
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +32,35 @@ class DarkBiasScript(Script):
     )
     count: int = Field(default=20, description="Number of exposures to take.")
     exptime: float = Field(default=0, description="Exposure time in seconds. 0 takes a bias, anything else a dark.")
+    exptimes: list[float] | None = Field(
+        default=None, description="Explicit list of dark exposure times to take one series each of."
+    )
+    match_science_exptimes: bool = Field(
+        default=False,
+        description="Derive the dark exposure times from the night's science frames instead of a fixed list "
+        "(requires archive and site). Mutually exclusive with exptime/exptimes.",
+    )
+    archive: Archive | None = Field(
+        default=None, description="Archive to query for science exptimes. Required when match_science_exptimes=True."
+    )
+    site: str | None = Field(
+        default=None, description="Site code to query the archive for. Required when match_science_exptimes=True."
+    )
+    night: str | None = Field(
+        default=None,
+        description="Night to derive science exptimes for (Archive.list_frames(night=...) format). Defaults to "
+        "the night that just ended, derived from the current time.",
+    )
     binning: tuple[int, int] = Field(default=(1, 1), description="Detector binning as (x, y).")
+
+    @model_validator(mode="after")
+    def _validate_exptime_mode(self) -> Self:
+        modes_set = sum([self.exptimes is not None, self.match_science_exptimes])
+        if modes_set > 1:
+            raise ValueError("exptimes and match_science_exptimes are mutually exclusive.")
+        if modes_set == 1 and self.exptime != 0:
+            raise ValueError("exptime cannot be combined with exptimes or match_science_exptimes.")
+        return self
 
     async def can_run(self, data: TaskData | None) -> bool:
         """Whether this config can currently run.
@@ -43,17 +73,47 @@ class DarkBiasScript(Script):
             self._cant_run_reason = "No camera found."
             return False
 
+        # multi-exptime-from-science mode needs an archive, a site, and a way to resolve night
+        if self.match_science_exptimes:
+            if self.archive is None or self.site is None:
+                self._cant_run_reason = "match_science_exptimes requires archive and site to be configured."
+                return False
+            if self.night is None and self._observer is None:
+                self._cant_run_reason = "No observer configured to derive the night from."
+                return False
+
         # seems alright
         self._cant_run_reason = None
         return True
+
+    async def _resolve_exptimes(self) -> list[float]:
+        """Resolves the series of exposure times to take: explicit list, derived from the
+        night's science frames, or the single configured exptime (0 for a bias series)."""
+        if self.exptimes is not None:
+            return sorted(self.exptimes, reverse=True)
+
+        if self.match_science_exptimes:
+            if self.archive is None or self.site is None:
+                raise ValueError("match_science_exptimes requires archive and site to be configured.")
+            if self.night is not None:
+                night = self.night
+            elif self._observer is not None:
+                night = Time.now().night_obs(self._observer).isoformat()
+            else:
+                raise ValueError("No observer configured to derive the night from.")
+            by_combo = await science_exptimes_for_night(self.archive, self.site, night)
+            exptimes = sorted({e for values in by_combo.values() for e in values}, reverse=True)
+            if not exptimes:
+                log.warning("No science exptimes found for night %s; nothing to expose.", night)
+            return exptimes
+
+        return [self.exptime]
 
     async def run(self, data: TaskData | None) -> None:
         """Run script.
         Raises:
             InterruptedError: If interrupted
         """
-
-        image_type = ImageType.BIAS if self.exptime == 0 else ImageType.DARK
 
         async with self.comm.safe_proxy(self.camera, IBinning) as camera:
             if camera is not None:
@@ -68,30 +128,36 @@ class DarkBiasScript(Script):
                         cap.full_frame_x, cap.full_frame_y, cap.full_frame_width, cap.full_frame_height
                     )
 
-        # take image
-        async with self.comm.proxy(self.camera, IExposureTime) as camera:
-            await camera.set_exposure_time(self.exptime)
+        exptimes = await self._resolve_exptimes()
+        if len(exptimes) > 1:
+            log.info("Resolved dark exptimes for %s: %s", self.camera, exptimes)
+
+        image_type = ImageType.BIAS if exptimes == [0] else ImageType.DARK
         async with self.comm.proxy(self.camera, IImageType) as camera:
             await camera.set_image_type(image_type)
 
-        # image type for logger
-        if self.exptime == 0:
-            im_type = f"{self.count} biases"
+        for exptime in exptimes:
+            async with self.comm.proxy(self.camera, IExposureTime) as camera:
+                await camera.set_exposure_time(exptime)
 
-        else:
-            im_type = f"{self.count} darks ({self.exptime} s)"
-
-        log.info("Starting a series of %s with %s...", im_type, self.camera)
-        async with self.comm.proxy(self.camera, IData) as camera:
-            for i in range(self.count):
-                await camera.grab_data()
-        log.info("Finished series of %s with %s.", im_type, self.camera)
-        return
+            im_type = f"{self.count} biases" if exptime == 0 else f"{self.count} darks ({exptime} s)"
+            log.info("Starting a series of %s with %s...", im_type, self.camera)
+            async with self.comm.proxy(self.camera, IData) as camera:
+                for _ in range(self.count):
+                    await camera.grab_data()
+            log.info("Finished series of %s with %s.", im_type, self.camera)
 
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
-        """Estimate duration of the dark/bias series."""
+        """Estimate duration of the dark/bias series.
+
+        For match_science_exptimes, the exptime list isn't known without an async archive
+        query this sync method can't make; falls back to a single-series estimate using the
+        configured exptime (0 by default) as a rough placeholder.
+        """
         # TODO: get a better estimate for readout overhead
         readout = 5.0
+        if self.exptimes is not None:
+            return sum(self.count * (e + readout) for e in self.exptimes)
         return self.count * (self.exptime + readout)
 
 

--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated, Self
+from typing import TYPE_CHECKING, Annotated, ClassVar, Self
 
 from pydantic import Field, model_validator
 
@@ -26,6 +26,11 @@ log = logging.getLogger(__name__)
 
 class DarkBiasScript(Script):
     """Script for running darks or biases."""
+
+    # Placeholder used by estimate_duration() for match_science_exptimes when nothing is cached
+    # yet -- ADR 0015's default reference dark exptime, a closer approximation to a real series
+    # than the always-0 self.exptime this mode is validated to carry.
+    _FALLBACK_MATCH_EXPTIME: ClassVar[float] = 600.0
 
     camera: Annotated[str, IData, IBinning, IWindow, IExposureTime, IImageType] = Field(
         description="Name of the camera module to expose with."
@@ -60,6 +65,11 @@ class DarkBiasScript(Script):
             raise ValueError("exptimes and match_science_exptimes are mutually exclusive.")
         if modes_set == 1 and self.exptime != 0:
             raise ValueError("exptime cannot be combined with exptimes or match_science_exptimes.")
+        if self.exptimes is not None and 0 in self.exptimes:
+            raise ValueError(
+                "exptimes cannot include 0 -- bias is always its own single series (exptime=0), "
+                "run as a separate DarkBiasScript."
+            )
         return self
 
     def _resolve_night(self) -> str | None:
@@ -70,6 +80,21 @@ class DarkBiasScript(Script):
         if self._observer is not None:
             return Time.now().night_obs(self._observer).isoformat()
         return None
+
+    def _binning_str(self) -> str:
+        return f"{self.binning[0]}x{self.binning[1]}"
+
+    def _flatten_matching_exptimes(self, by_combo: dict[tuple[str, str], list[float]]) -> list[float]:
+        """Narrows science_exptimes_for_night's per-(instrument, binning) result to this
+        script's own binning, and unions across instruments at that binning.
+
+        This script exposes at one binning (self.binning) for one camera; unioning across
+        every instrument/binning combination indiscriminately would hand it exptimes no science
+        frame at its own binning ever used. Filtering by instrument too isn't possible here --
+        the archive's INSTRUME code isn't available as a DarkBiasScript config field.
+        """
+        binning = self._binning_str()
+        return sorted({e for (_, b), values in by_combo.items() if b == binning for e in values}, reverse=True)
 
     async def can_run(self, data: TaskData | None) -> bool:
         """Whether this config can currently run.
@@ -118,9 +143,13 @@ class DarkBiasScript(Script):
             if night is None:
                 raise ValueError("No observer configured to derive the night from.")
             by_combo = await science_exptimes_for_night(self.archive, self.site, night)
-            exptimes = sorted({e for values in by_combo.values() for e in values}, reverse=True)
+            exptimes = self._flatten_matching_exptimes(by_combo)
             if not exptimes:
-                log.warning("No science exptimes found for night %s; nothing to expose.", night)
+                log.warning(
+                    "No science exptimes found for night %s at binning %s; nothing to expose.",
+                    night,
+                    self._binning_str(),
+                )
             return exptimes
 
         return [self.exptime]
@@ -145,6 +174,11 @@ class DarkBiasScript(Script):
                     )
 
         exptimes = await self._resolve_exptimes()
+        if not exptimes:
+            # match_science_exptimes found nothing to take darks at -- _resolve_exptimes()
+            # already logged why; leave the camera's image type/exptime untouched rather than
+            # switching it to DARK for a series that never runs
+            return
         if len(exptimes) > 1:
             log.info("Resolved dark exptimes for %s: %s", self.camera, exptimes)
 
@@ -168,23 +202,25 @@ class DarkBiasScript(Script):
 
         For match_science_exptimes, this sync method can't query the archive itself; it reads
         whatever can_run()'s prior (async) call already cached for this site/night, via
-        peek_cached_science_exptimes_for_night(). Falls back to a single-series placeholder
-        estimate (using the configured exptime, 0 by default) if nothing is cached yet -- e.g.
-        can_run() hasn't run for this site/night within the cache's TTL.
+        peek_cached_science_exptimes_for_night(). Falls back to a placeholder single-series
+        estimate at _FALLBACK_MATCH_EXPTIME if nothing is cached yet -- e.g. can_run() hasn't
+        run for this site/night within the cache's TTL.
         """
         # TODO: get a better estimate for readout overhead
         readout = 5.0
         if self.exptimes is not None:
             return sum(self.count * (e + readout) for e in self.exptimes)
 
-        if self.match_science_exptimes and self.site is not None:
-            night = self._resolve_night()
-            if night is not None:
-                cached = peek_cached_science_exptimes_for_night(self.site, night)
-                if cached is not None:
-                    exptimes = {e for values in cached.values() for e in values}
-                    if exptimes:
-                        return sum(self.count * (e + readout) for e in exptimes)
+        if self.match_science_exptimes:
+            if self.site is not None:
+                night = self._resolve_night()
+                if night is not None:
+                    cached = peek_cached_science_exptimes_for_night(self.site, night)
+                    if cached is not None:
+                        exptimes = self._flatten_matching_exptimes(cached)
+                        if exptimes:
+                            return sum(self.count * (e + readout) for e in exptimes)
+            return self.count * (self._FALLBACK_MATCH_EXPTIME + readout)
 
         return self.count * (self.exptime + readout)
 

--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -25,7 +25,80 @@ log = logging.getLogger(__name__)
 
 
 class DarkBiasScript(Script):
-    """Script for running darks or biases."""
+    """Script for running darks or biases.
+
+    Exactly one of three mutually exclusive modes selects what is exposed:
+
+    - ``exptime`` (default ``0``): a single series -- ``0`` takes a bias, anything
+      else takes one dark series at that exposure time. This is the classic,
+      unchanged behavior.
+    - ``exptimes``: an explicit list of exposure times, one dark series each, run
+      longest-first. ``0`` is not allowed inside the list -- a bias is always its
+      own single series.
+    - ``match_science_exptimes``: derive the series from the night's science
+      frames instead of a fixed list. Requires ``archive`` and ``site``; the night
+      is taken from ``night`` if given, else derived from the observer injected by
+      the scheduler (the night that just ended). Science exptimes below
+      ``dark_min_exptime`` (5 s, per ADR 0015) are dropped, near-duplicates are
+      tolerance-grouped (1 %), and only exptimes used at the script's own
+      ``binning`` are kept -- the script exposes at exactly one binning and never
+      loops over binnings.
+
+    Example configs:
+
+    Single bias (default)::
+
+        class: pyobs.robotic.scripts.calibration.darkbias.DarkBiasScript
+        camera: cam1
+        count: 20
+        exptime: 0
+
+    Explicit dark exptimes::
+
+        class: pyobs.robotic.scripts.calibration.darkbias.DarkBiasScript
+        camera: cam1
+        count: 10
+        exptimes: [30.0, 300.0, 600.0]
+        binning: [1, 1]
+
+    Match the night's science exptimes (local archive)::
+
+        class: pyobs.robotic.scripts.calibration.darkbias.DarkBiasScript
+        camera: cam1
+        count: 10
+        match_science_exptimes: true
+        site: bsh
+        archive:
+          class: pyobs.robotic.utils.archive.local_archive.LocalArchive
+          root: /data/archive
+        binning: [1, 1]
+
+    Match the night's science exptimes (pyobs-archive server)::
+
+        class: pyobs.robotic.scripts.calibration.darkbias.DarkBiasScript
+        camera: cam1
+        count: 10
+        match_science_exptimes: true
+        site: bsh
+        night: 2026-09-01   # optional; defaults to the just-ended night via the observer
+        archive:
+          class: pyobs.robotic.utils.archive.pyobs_archive.PyobsArchive
+          url: https://archive.example.org
+          token: <token>
+        binning: [1, 1]
+
+    Notes:
+
+    - ``estimate_duration()`` sums over all series; for ``match_science_exptimes``
+      it reads the result ``can_run()`` already cached (5 min TTL), falling back
+      to a 600 s placeholder per series when nothing is cached yet.
+    - For ``match_science_exptimes`` the binning match is a string comparison
+      against the archive's ``list_options()`` ``binnings`` values ("NxM"). This
+      always matches for ``LocalArchive``; for ``PyobsArchive`` it depends on the
+      pyobs-archive server returning that format.
+    - If no science exptimes are found for the night/binning, nothing is exposed
+      and a warning is logged.
+    """
 
     # Placeholder used by estimate_duration() for match_science_exptimes when nothing is cached
     # yet -- ADR 0015's default reference dark exptime, a closer approximation to a real series

--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -14,7 +14,7 @@ from pyobs.interfaces import (
 )
 from pyobs.robotic.scripts import Script
 from pyobs.robotic.utils.archive import Archive
-from pyobs.robotic.utils.calibration import science_exptimes_for_night
+from pyobs.robotic.utils.calibration import peek_cached_science_exptimes_for_night, science_exptimes_for_night
 from pyobs.utils.enums import ImageType
 from pyobs.utils.time import Time
 
@@ -62,6 +62,15 @@ class DarkBiasScript(Script):
             raise ValueError("exptime cannot be combined with exptimes or match_science_exptimes.")
         return self
 
+    def _resolve_night(self) -> str | None:
+        """Resolves the night to query for match_science_exptimes: the configured override, or
+        derived from the current time via the injected observer. None if neither is available."""
+        if self.night is not None:
+            return self.night
+        if self._observer is not None:
+            return Time.now().night_obs(self._observer).isoformat()
+        return None
+
     async def can_run(self, data: TaskData | None) -> bool:
         """Whether this config can currently run.
         Returns:
@@ -78,8 +87,18 @@ class DarkBiasScript(Script):
             if self.archive is None or self.site is None:
                 self._cant_run_reason = "match_science_exptimes requires archive and site to be configured."
                 return False
-            if self.night is None and self._observer is None:
+            night = self._resolve_night()
+            if night is None:
                 self._cant_run_reason = "No observer configured to derive the night from."
+                return False
+            # Task.create_script() re-validates a fresh Script (and Archive) on every call, so
+            # estimate_duration() can't reuse this instance's state later -- warm the module-level
+            # cache here instead, so its later (sync, archive-less) lookup can hit it.
+            try:
+                await science_exptimes_for_night(self.archive, self.site, night)
+            except Exception:
+                log.exception("Could not query archive for science exptimes.")
+                self._cant_run_reason = "Could not query archive for science exptimes."
                 return False
 
         # seems alright
@@ -95,11 +114,8 @@ class DarkBiasScript(Script):
         if self.match_science_exptimes:
             if self.archive is None or self.site is None:
                 raise ValueError("match_science_exptimes requires archive and site to be configured.")
-            if self.night is not None:
-                night = self.night
-            elif self._observer is not None:
-                night = Time.now().night_obs(self._observer).isoformat()
-            else:
+            night = self._resolve_night()
+            if night is None:
                 raise ValueError("No observer configured to derive the night from.")
             by_combo = await science_exptimes_for_night(self.archive, self.site, night)
             exptimes = sorted({e for values in by_combo.values() for e in values}, reverse=True)
@@ -150,14 +166,26 @@ class DarkBiasScript(Script):
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         """Estimate duration of the dark/bias series.
 
-        For match_science_exptimes, the exptime list isn't known without an async archive
-        query this sync method can't make; falls back to a single-series estimate using the
-        configured exptime (0 by default) as a rough placeholder.
+        For match_science_exptimes, this sync method can't query the archive itself; it reads
+        whatever can_run()'s prior (async) call already cached for this site/night, via
+        peek_cached_science_exptimes_for_night(). Falls back to a single-series placeholder
+        estimate (using the configured exptime, 0 by default) if nothing is cached yet -- e.g.
+        can_run() hasn't run for this site/night within the cache's TTL.
         """
         # TODO: get a better estimate for readout overhead
         readout = 5.0
         if self.exptimes is not None:
             return sum(self.count * (e + readout) for e in self.exptimes)
+
+        if self.match_science_exptimes and self.site is not None:
+            night = self._resolve_night()
+            if night is not None:
+                cached = peek_cached_science_exptimes_for_night(self.site, night)
+                if cached is not None:
+                    exptimes = {e for values in cached.values() for e in values}
+                    if exptimes:
+                        return sum(self.count * (e + readout) for e in exptimes)
+
         return self.count * (self.exptime + readout)
 
 

--- a/pyobs/robotic/utils/archive/archive.py
+++ b/pyobs/robotic/utils/archive/archive.py
@@ -20,6 +20,7 @@ class FrameInfo:
         self.filter_name: str | None = None
         self.binning: int | None = None
         self.dateobs: str | None = None
+        self.exptime: float | None = None
 
 
 class Archive(PolymorphicBaseModel, metaclass=ABCMeta):
@@ -41,6 +42,7 @@ class Archive(PolymorphicBaseModel, metaclass=ABCMeta):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> dict[str, list[Any]]: ...
 
     @abstractmethod
@@ -57,6 +59,7 @@ class Archive(PolymorphicBaseModel, metaclass=ABCMeta):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> list[FrameInfo]: ...
 
     @abstractmethod

--- a/pyobs/robotic/utils/archive/local_archive.py
+++ b/pyobs/robotic/utils/archive/local_archive.py
@@ -9,6 +9,7 @@ from pydantic import PrivateAttr
 
 from pyobs.images import Image
 from pyobs.utils.enums import ImageType
+from pyobs.utils.exptime_grouping import exptimes_close
 from pyobs.utils.time import Time
 
 from .archive import Archive, FrameInfo
@@ -47,6 +48,7 @@ class LocalArchive(Archive):
                 "telescope",
                 "rlevel",
                 "obsnum",
+                "exptime",
             ]
         }
         for filename in filenames:
@@ -61,6 +63,7 @@ class LocalArchive(Archive):
             columns["telescope"].append(hdr["TELID"] if "TELID" in hdr else None)
             columns["rlevel"].append(hdr["RLEVEL"] if "RLEVEL" in hdr else None)
             columns["obsnum"].append(str(hdr["OBSNUM"]) if "OBSNUM" in hdr else None)
+            columns["exptime"].append(float(hdr["EXPTIME"]) if "EXPTIME" in hdr else None)
         columns["filename"] = filenames
         self._data = pd.DataFrame(columns)
 
@@ -77,6 +80,7 @@ class LocalArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> pd.DataFrame:
         data = self._data
         if start is not None:
@@ -101,6 +105,8 @@ class LocalArchive(Archive):
             data = data[data["rlevel"] == rlevel]
         if obsnum is not None:
             data = data[data["obsnum"] == obsnum]
+        if exptime is not None:
+            data = data[data["exptime"].apply(lambda e: e is not None and exptimes_close(e, exptime))]
         return data
 
     async def list_options(
@@ -116,9 +122,21 @@ class LocalArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> dict[str, list[Any]]:
         data = self._filter_data(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
+            start,
+            end,
+            night,
+            site,
+            telescope,
+            instrument,
+            image_type,
+            binning,
+            filter_name,
+            rlevel,
+            obsnum=obsnum,
+            exptime=exptime,
         )
         return {
             "binnings": list(data["binning"].unique()),
@@ -127,6 +145,7 @@ class LocalArchive(Archive):
             "instruments": list(data["instrument"].unique()),
             "sites": list(data["site"].unique()),
             "telescopes": list(data["telescope"].unique()),
+            "exptimes": [e for e in data["exptime"].unique() if e is not None],
         }
 
     async def list_frames(
@@ -142,9 +161,21 @@ class LocalArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> list[FrameInfo]:
         data = self._filter_data(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
+            start,
+            end,
+            night,
+            site,
+            telescope,
+            instrument,
+            image_type,
+            binning,
+            filter_name,
+            rlevel,
+            obsnum=obsnum,
+            exptime=exptime,
         )
         infos: list[FrameInfo] = []
         for _, row in data.iterrows():
@@ -154,6 +185,7 @@ class LocalArchive(Archive):
             info.filter_name = row["filter"]
             info.binning = row["binning"]
             info.dateobs = row["date-obs"]
+            info.exptime = row["exptime"]
             infos.append(info)
         return infos
 

--- a/pyobs/robotic/utils/archive/pyobs_archive.py
+++ b/pyobs/robotic/utils/archive/pyobs_archive.py
@@ -1,7 +1,7 @@
 import io
 import logging
 import urllib.parse
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 import aiohttp
 from pydantic import PrivateAttr
@@ -23,7 +23,7 @@ class PyobsArchiveFrameInfoDict(TypedDict):
     FILTER: str
     binning: str
     url: str
-    EXPTIME: float
+    EXPTIME: NotRequired[float]
 
 
 class PyobsArchiveFrameInfo(FrameInfo):
@@ -136,8 +136,13 @@ class PyobsArchive(Archive):
                     frames.extend(new_frames)
                     if len(frames) >= res["count"]:
                         if exptime is not None:
-                            # server-side EXPTIME filtering may not exist/be tolerant; re-filter
-                            # client-side so an unsupported or exact-only param doesn't matter
+                            # Server-side EXPTIME filtering may not exist or may be exact-only;
+                            # re-filter client-side to apply the tolerance regardless. This only
+                            # recovers near-matches the server itself returned -- an exact-only
+                            # server has already dropped them before we get here, so it still
+                            # matters that the server side supports (or ignores) EXPTIME. Harmless
+                            # today since science_exptimes_for_night() never passes exptime= to
+                            # list_frames().
                             frames = [f for f in frames if f.exptime is not None and exptimes_close(f.exptime, exptime)]
                         return frames
                     params["offset"] += len(new_frames)

--- a/pyobs/robotic/utils/archive/pyobs_archive.py
+++ b/pyobs/robotic/utils/archive/pyobs_archive.py
@@ -8,6 +8,7 @@ from pydantic import PrivateAttr
 
 from pyobs.images import Image
 from pyobs.utils.enums import ImageType
+from pyobs.utils.exptime_grouping import exptimes_close
 from pyobs.utils.time import Time
 
 from .archive import Archive, FrameInfo
@@ -22,6 +23,7 @@ class PyobsArchiveFrameInfoDict(TypedDict):
     FILTER: str
     binning: str
     url: str
+    EXPTIME: float
 
 
 class PyobsArchiveFrameInfo(FrameInfo):
@@ -36,6 +38,7 @@ class PyobsArchiveFrameInfo(FrameInfo):
         self.filter_name = self.info["FILTER"]
         self.binning = int(self.info["binning"][0])
         self.url = self.info["url"]
+        self.exptime = self.info.get("EXPTIME")
 
 
 class PyobsArchive(Archive):
@@ -67,10 +70,22 @@ class PyobsArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> dict[str, list[Any]]:
         url = urllib.parse.urljoin(self.url, "frames/aggregate/")
         params = self._build_query(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
+            start,
+            end,
+            night,
+            site,
+            telescope,
+            instrument,
+            image_type,
+            binning,
+            filter_name,
+            rlevel,
+            obsnum=obsnum,
+            exptime=exptime,
         )
         async with aiohttp.ClientSession() as session:
             async with session.get(url, params=params, headers=self._headers, timeout=self._timeout) as response:
@@ -91,10 +106,22 @@ class PyobsArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> list[FrameInfo]:
         url = urllib.parse.urljoin(self.url, "frames/")
         params = self._build_query(
-            start, end, night, site, telescope, instrument, image_type, binning, filter_name, rlevel, obsnum=obsnum
+            start,
+            end,
+            night,
+            site,
+            telescope,
+            instrument,
+            image_type,
+            binning,
+            filter_name,
+            rlevel,
+            obsnum=obsnum,
+            exptime=exptime,
         )
         frames: list[FrameInfo] = []
         params["offset"] = 0
@@ -108,6 +135,10 @@ class PyobsArchive(Archive):
                     new_frames = [PyobsArchiveFrameInfo(frame) for frame in res["results"]]
                     frames.extend(new_frames)
                     if len(frames) >= res["count"]:
+                        if exptime is not None:
+                            # server-side EXPTIME filtering may not exist/be tolerant; re-filter
+                            # client-side so an unsupported or exact-only param doesn't matter
+                            frames = [f for f in frames if f.exptime is not None and exptimes_close(f.exptime, exptime)]
                         return frames
                     params["offset"] += len(new_frames)
 
@@ -124,6 +155,7 @@ class PyobsArchive(Archive):
         filter_name: str | None = None,
         rlevel: int | None = None,
         obsnum: str | None = None,
+        exptime: float | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {}
         if start is not None:
@@ -148,6 +180,8 @@ class PyobsArchive(Archive):
             params["RLEVEL"] = rlevel
         if obsnum is not None:
             params["OBSNUM"] = obsnum
+        if exptime is not None:
+            params["EXPTIME"] = exptime
         return params
 
     async def download_frames(self, infos: list[FrameInfo]) -> list[Image]:

--- a/pyobs/robotic/utils/calibration.py
+++ b/pyobs/robotic/utils/calibration.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
+import time as _time
+
 from pyobs.robotic.utils.archive import Archive
 from pyobs.utils.enums import ImageType
 from pyobs.utils.exptime_grouping import group_exptimes
+
+# Task.create_script() re-validates a Script (and any nested Archive field) fresh from its raw
+# config dict on every call -- can_run()/estimate_duration() never see the same Archive instance
+# twice, so caching can't key on archive identity. Keying on (site, night, ...) instead lets
+# DarkBiasScript's can_run() (async) warm this once per scheduling pass and estimate_duration()
+# (sync, can't query the archive itself) read the cached result moments later.
+_CACHE_TTL = 300.0  # seconds
+
+_CacheKey = tuple[str, str, float, float | None]
+_CacheEntry = tuple[float, dict[tuple[str, str], list[float]]]
+_cache: dict[_CacheKey, _CacheEntry] = {}
+
+
+def _cache_key(site: str, night: str, tolerance: float, min_exptime: float | None) -> _CacheKey:
+    return site, night, tolerance, min_exptime
 
 
 async def science_exptimes_for_night(
@@ -16,6 +33,8 @@ async def science_exptimes_for_night(
 
     Used to decide which exptimes a morning DarkBiasScript run should take darks at, so
     calibration masters exist for the exptimes actually needed rather than one fixed value.
+    Caches its result for a few minutes per (site, night, tolerance, min_exptime), so repeated
+    calls within one scheduling pass don't re-query the archive.
 
     Args:
         archive: Archive to list the night's OBJECT frames from.
@@ -30,6 +49,12 @@ async def science_exptimes_for_night(
         Distinct, tolerance-grouped science exptimes, keyed per (instrument, binning) --
         mirrors the per-combination looping Reduction.__call__ does for calibration masters.
     """
+    key = _cache_key(site, night, tolerance, min_exptime)
+    cached = _cache.get(key)
+    now = _time.monotonic()
+    if cached is not None and now - cached[0] < _CACHE_TTL:
+        return cached[1]
+
     options = await archive.list_options(night=night, site=site, image_type=ImageType.OBJECT, rlevel=0)
 
     result: dict[tuple[str, str], list[float]] = {}
@@ -49,7 +74,31 @@ async def science_exptimes_for_night(
             if raw_exptimes:
                 result[instrument, binning] = group_exptimes(raw_exptimes, tolerance)
 
+    _cache[key] = (now, result)
     return result
 
 
-__all__ = ["science_exptimes_for_night"]
+def clear_cache() -> None:
+    """Clears science_exptimes_for_night's cache. For tests; production code relies on the TTL."""
+    _cache.clear()
+
+
+def peek_cached_science_exptimes_for_night(
+    site: str,
+    night: str,
+    tolerance: float = 0.01,
+    min_exptime: float | None = 5.0,
+) -> dict[tuple[str, str], list[float]] | None:
+    """Synchronous, cache-only lookup for science_exptimes_for_night's result.
+
+    Never queries the archive. Returns None if nothing has been cached yet for this key (no
+    prior science_exptimes_for_night() call) or the cached entry has expired. Used by
+    DarkBiasScript.estimate_duration(), which is sync and can't await the real query itself.
+    """
+    cached = _cache.get(_cache_key(site, night, tolerance, min_exptime))
+    if cached is None or _time.monotonic() - cached[0] >= _CACHE_TTL:
+        return None
+    return cached[1]
+
+
+__all__ = ["science_exptimes_for_night", "peek_cached_science_exptimes_for_night", "clear_cache"]

--- a/pyobs/robotic/utils/calibration.py
+++ b/pyobs/robotic/utils/calibration.py
@@ -8,18 +8,23 @@ from pyobs.utils.exptime_grouping import group_exptimes
 
 # Task.create_script() re-validates a Script (and any nested Archive field) fresh from its raw
 # config dict on every call -- can_run()/estimate_duration() never see the same Archive instance
-# twice, so caching can't key on archive identity. Keying on (site, night, ...) instead lets
-# DarkBiasScript's can_run() (async) warm this once per scheduling pass and estimate_duration()
-# (sync, can't query the archive itself) read the cached result moments later.
+# twice, so caching can't key on Python object identity, and can't key on the archive's full
+# config either (a stateful Archive subclass mutating a field between calls -- a request counter,
+# a warmed connection handle -- would turn every call into a cache miss). Keying on (site, night,
+# ..., archive class) instead lets DarkBiasScript's can_run() (async) warm this once per
+# scheduling pass and estimate_duration() (sync, can't query the archive itself) read the cached
+# result moments later. This still lets two *differently configured* archives of the same class
+# (e.g. two PyobsArchive pointed at different URLs) serving the same site/night collide within
+# the TTL -- unlikely in practice (one process, one site, two archive backends), not solved here.
 _CACHE_TTL = 300.0  # seconds
 
-_CacheKey = tuple[str, str, float, float | None]
+_CacheKey = tuple[str, str, float, float | None, type["Archive"]]
 _CacheEntry = tuple[float, dict[tuple[str, str], list[float]]]
 _cache: dict[_CacheKey, _CacheEntry] = {}
 
 
-def _cache_key(site: str, night: str, tolerance: float, min_exptime: float | None) -> _CacheKey:
-    return site, night, tolerance, min_exptime
+def _cache_key(archive: Archive, site: str, night: str, tolerance: float, min_exptime: float | None) -> _CacheKey:
+    return site, night, tolerance, min_exptime, type(archive)
 
 
 async def science_exptimes_for_night(
@@ -49,7 +54,7 @@ async def science_exptimes_for_night(
         Distinct, tolerance-grouped science exptimes, keyed per (instrument, binning) --
         mirrors the per-combination looping Reduction.__call__ does for calibration masters.
     """
-    key = _cache_key(site, night, tolerance, min_exptime)
+    key = _cache_key(archive, site, night, tolerance, min_exptime)
     cached = _cache.get(key)
     now = _time.monotonic()
     if cached is not None and now - cached[0] < _CACHE_TTL:
@@ -84,6 +89,7 @@ def clear_cache() -> None:
 
 
 def peek_cached_science_exptimes_for_night(
+    archive: Archive,
     site: str,
     night: str,
     tolerance: float = 0.01,
@@ -94,8 +100,10 @@ def peek_cached_science_exptimes_for_night(
     Never queries the archive. Returns None if nothing has been cached yet for this key (no
     prior science_exptimes_for_night() call) or the cached entry has expired. Used by
     DarkBiasScript.estimate_duration(), which is sync and can't await the real query itself.
+    ``archive`` must be configured the same way as the one passed to that prior call, or the
+    cache key won't match -- see _cache_key.
     """
-    cached = _cache.get(_cache_key(site, night, tolerance, min_exptime))
+    cached = _cache.get(_cache_key(archive, site, night, tolerance, min_exptime))
     if cached is None or _time.monotonic() - cached[0] >= _CACHE_TTL:
         return None
     return cached[1]

--- a/pyobs/robotic/utils/calibration.py
+++ b/pyobs/robotic/utils/calibration.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pyobs.robotic.utils.archive import Archive
+from pyobs.utils.enums import ImageType
+from pyobs.utils.exptime_grouping import group_exptimes
+
+
+async def science_exptimes_for_night(
+    archive: Archive,
+    site: str,
+    night: str,
+    tolerance: float = 0.01,
+    min_exptime: float | None = 5.0,
+) -> dict[tuple[str, str], list[float]]:
+    """Derives the distinct exposure times science frames used on a given night.
+
+    Used to decide which exptimes a morning DarkBiasScript run should take darks at, so
+    calibration masters exist for the exptimes actually needed rather than one fixed value.
+
+    Args:
+        archive: Archive to list the night's OBJECT frames from.
+        site: Site code to filter frames by.
+        night: Night to derive exptimes for, in Archive.list_frames(night=...)'s format.
+        tolerance: Relative tolerance for collapsing near-duplicate exptimes into one group.
+        min_exptime: Exptimes below this are dropped entirely before grouping -- per ADR
+            0015's dark_min_exptime, calibration treats them as bias-only and never needs a
+            dark master for them. Pass 0 or None to keep every exptime.
+
+    Returns:
+        Distinct, tolerance-grouped science exptimes, keyed per (instrument, binning) --
+        mirrors the per-combination looping Reduction.__call__ does for calibration masters.
+    """
+    options = await archive.list_options(night=night, site=site, image_type=ImageType.OBJECT, rlevel=0)
+
+    result: dict[tuple[str, str], list[float]] = {}
+    for instrument in options.get("instruments", []):
+        for binning in options.get("binnings", []):
+            frames = await archive.list_frames(
+                night=night,
+                site=site,
+                instrument=instrument,
+                binning=binning,
+                image_type=ImageType.OBJECT,
+                rlevel=0,
+            )
+            raw_exptimes = [f.exptime for f in frames if f.exptime is not None]
+            if min_exptime:
+                raw_exptimes = [e for e in raw_exptimes if e >= min_exptime]
+            if raw_exptimes:
+                result[instrument, binning] = group_exptimes(raw_exptimes, tolerance)
+
+    return result
+
+
+__all__ = ["science_exptimes_for_night"]

--- a/pyobs/utils/exptime_grouping.py
+++ b/pyobs/utils/exptime_grouping.py
@@ -1,0 +1,51 @@
+"""Shared relative-tolerance exposure-time matching/grouping.
+
+Used by the archive's exptime filter (single-value tolerance match) and by
+science_exptimes_for_night's night-exptime grouping (bucketing many raw values);
+#832's per-exptime dark-master grouping reuses this rather than reimplementing it.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Iterable
+
+
+def exptimes_close(a: float, b: float, tolerance: float = 0.01) -> bool:
+    """Whether two exposure times are within a relative tolerance of each other.
+
+    Args:
+        a: First exposure time, in seconds.
+        b: Second exposure time, in seconds.
+        tolerance: Relative tolerance, e.g. 0.01 for 1%.
+
+    Returns:
+        True if a and b are within tolerance of each other.
+    """
+    if a == b:
+        return True
+    if b == 0:
+        return False
+    return abs(a - b) <= tolerance * abs(b)
+
+
+def group_exptimes(values: Iterable[float], tolerance: float = 0.01) -> list[float]:
+    """Collapses exposure times within a relative tolerance of each other into groups.
+
+    Args:
+        values: Raw exposure times to group.
+        tolerance: Relative tolerance for two values to belong to the same group.
+
+    Returns:
+        One representative exptime (the group's median) per group, sorted ascending.
+    """
+    groups: list[list[float]] = []
+    for value in sorted(values):
+        if groups and exptimes_close(value, statistics.median(groups[-1]), tolerance):
+            groups[-1].append(value)
+        else:
+            groups.append([value])
+    return [statistics.median(group) for group in groups]
+
+
+__all__ = ["exptimes_close", "group_exptimes"]

--- a/pyobs/utils/exptime_grouping.py
+++ b/pyobs/utils/exptime_grouping.py
@@ -14,6 +14,9 @@ from collections.abc import Iterable
 def exptimes_close(a: float, b: float, tolerance: float = 0.01) -> bool:
     """Whether two exposure times are within a relative tolerance of each other.
 
+    Symmetric: the tolerance is relative to whichever of a/b is larger, so
+    exptimes_close(a, b, t) == exptimes_close(b, a, t) always.
+
     Args:
         a: First exposure time, in seconds.
         b: Second exposure time, in seconds.
@@ -24,13 +27,19 @@ def exptimes_close(a: float, b: float, tolerance: float = 0.01) -> bool:
     """
     if a == b:
         return True
-    if b == 0:
-        return False
-    return abs(a - b) <= tolerance * abs(b)
+    return abs(a - b) <= tolerance * max(abs(a), abs(b))
 
 
 def group_exptimes(values: Iterable[float], tolerance: float = 0.01) -> list[float]:
     """Collapses exposure times within a relative tolerance of each other into groups.
+
+    A single left-to-right pass over the sorted values: each value joins the previous group if
+    it's within tolerance of that group's current median, else starts a new group. This is not
+    a transitive-closure/clustering guarantee -- e.g. group_exptimes([100.0, 100.9, 101.8], 0.01)
+    can split 100.9 and 101.8 into different groups even though they're pairwise within
+    tolerance, because the group's median drifts as values are added. Fine for the discrete,
+    well-separated exptimes real detectors actually use; a caller that needs a stronger
+    (union-find) grouping guarantee should not rely on this.
 
     Args:
         values: Raw exposure times to group.

--- a/specs/adrs/0015-dark-master-strict-exptime-matching-reference-scale-down-only.md
+++ b/specs/adrs/0015-dark-master-strict-exptime-matching-reference-scale-down-only.md
@@ -1,6 +1,6 @@
 # Dark masters: strict per-exposure-time matching, reference master scales down only
 
-status: proposed
+status: accepted
 date: 2026-09-01
 
 ## Context and Problem Statement

--- a/specs/plans/2026-09-01-morning-darks-match-science-exptimes.md
+++ b/specs/plans/2026-09-01-morning-darks-match-science-exptimes.md
@@ -1,6 +1,6 @@
 # Plan: take morning darks at the night's science exposure times
 
-Status: **proposed**
+Status: implemented
 
 Tracks issue #831. Robotic/archive half of the dark-exptime-matching work; the reduction half is
 `2026-09-01-per-exptime-dark-masters.md` (issue #832), which depends on the archive changes here.
@@ -120,18 +120,24 @@ discoverable without reading the script source.
 
 ## Acceptance criteria
 
-- [ ] `FrameInfo.exptime` populated by both `PyobsArchive` and `LocalArchive`; `list_frames()`/
+- [x] `FrameInfo.exptime` populated by both `PyobsArchive` and `LocalArchive`; `list_frames()`/
       `list_options()` accept and honor an `exptime` filter in both implementations.
-- [ ] `list_options()` returns an `exptimes` key in both implementations.
-- [ ] `science_exptimes_for_night()` returns the distinct, tolerance-grouped science exptimes
+- [x] `list_options()` returns an `exptimes` key in both implementations. `LocalArchive` computes
+      it directly; `PyobsArchive.list_options()` passes the server's `frames/aggregate/` response
+      through unchanged, so its `exptimes` key depends on the pyobs-archive server adding one —
+      not verifiable from this repo alone.
+- [x] `science_exptimes_for_night()` returns the distinct, tolerance-grouped science exptimes
       for a site+night, keyed per instrument/binning, excluding exptimes below `min_exptime`
       (default 5 s) unless `min_exptime=0`/`None` is passed.
-- [ ] `DarkBiasScript` runs one dark series per exptime (explicit list or
+- [x] `DarkBiasScript` runs one dark series per exptime (explicit list or
       `match_science_exptimes`-derived) while the single-`exptime` path is unchanged; mutual
       exclusivity between `exptime`/`exptimes`/`match_science_exptimes` is validated, not silently
       resolved by picking one.
-- [ ] `estimate_duration()` reflects the multi-series total.
-- [ ] Tests: `exptime` filter in both archive implementations (including tolerance behavior),
+- [x] `estimate_duration()` reflects the multi-series total for the explicit `exptimes` list.
+      `match_science_exptimes` falls back to a single-series placeholder estimate (using the
+      configured `exptime`, 0 by default) since the method is sync and can't run the archive
+      query needed to know the real series — a known gap, not solved by this plan.
+- [x] Tests: `exptime` filter in both archive implementations (including tolerance behavior),
       `science_exptimes_for_night()` grouping (exact matches, near-duplicates within/outside
       tolerance, empty night, exptimes below/above `min_exptime`), `DarkBiasScript` run/estimate
       with multiple exptimes, mutual-exclusivity validation.

--- a/specs/steering/fleet-open-items.md
+++ b/specs/steering/fleet-open-items.md
@@ -1,6 +1,6 @@
 # Fleet open items: open issues and plans across the pyobs fleet
 
-Status: standing snapshot — checked on 2026-09-01.
+Status: standing snapshot — checked on 2026-09-01 (11:14 CEST).
 
 Fleet-wide view of what's open across the pyobs project fleet (see
 `specs/steering/pyobs-project-tiers.md` for the fleet definition). This is a **derived view**, not
@@ -17,24 +17,21 @@ open pending a release to `main`), never annotate them.** Only open items live h
 
 Repos: the whole pyobs fleet.
 
-## Open issues (16, checked 2026-09-01)
+## Open issues (13, checked 2026-09-01 11:14 CEST)
 
 One row per issue — same layout for every repo.
 
 | Repo | # | Title | Notes |
 |---|---|---|---|
-| pyobs-core | [#838](https://github.com/pyobs/pyobs-core/issues/838) | `DummyCamera` exposures complete but contain no visible stars: Moffat2D amplitude is never mapped | *bug* — follow-up to #829; `_simulate_image`'s `params_map` maps `x_0`/`y_0` but not `amplitude`, so `make_model_image` renders every source at amplitude 1.0, invisible under the noise floor; the Gaia-flux column from the sources table is never used. Fix is mapping `amplitude` (from flux) in `params_map`; open question left to us: total flux vs. peak value |
-| pyobs-core | [#837](https://github.com/pyobs/pyobs-core/issues/837) | A child module's `vfs` config is silently replaced by the parent's under `MultiModule` | *bug* — `Object.get_object` (`pyobs/object.py`) checks `config_or_object_get_param(config, "_vfs")` (underscore) but YAML configs key the constructor param `vfs` (no underscore), so a child's own `vfs`/`timezone`/`observer` is never detected as already-set and gets overwritten by the parent's. 10-line repro in the issue. Workaround: define `vfs` at the `MultiModule` top level only |
 | pyobs-core | [#832](https://github.com/pyobs/pyobs-core/issues/832) | Dark masters per exposure time: match science frames by exptime, scale only a reference (600s) dark | *assigned: thusser* — reduction half of #831; scaling-policy question resolved by ADR `0015-dark-master-strict-exptime-matching-reference-scale-down-only.md` (strict default, reference scales down only); plan `2026-09-01-per-exptime-dark-masters.md` below (*proposed*); pyobs-pipeline#13 is the downstream consumer of the new `Calibration`/`Reduction` config knobs + `MasterCalibCreated.exptime` |
-| pyobs-core | [#831](https://github.com/pyobs/pyobs-core/issues/831) | Take morning darks at the exposure times used for science frames during the night | *assigned: thusser* — robotic/observing half (reduction half is #832); plan `2026-09-01-morning-darks-match-science-exptimes.md` below (*proposed*) |
 | pyobs-core | [#819](https://github.com/pyobs/pyobs-core/issues/819) | Proposal: additive interface versioning (`IDome`, `IDomeV2`, ...) | design doc landed 2026-08-28 and sanity-checked against `develop`; no plan yet |
 | pyobs-core | [#739](https://github.com/pyobs/pyobs-core/issues/739) | Record installed pyobs package versions in FITS headers | *enhancement* — per-package version keywords; approach undecided |
 | pyobs-pipeline | [#13](https://github.com/pyobs/pyobs-pipeline/issues/13) | Support per-exposure-time dark masters: config knobs + exposure time in period UI | *enhancement, assigned: thusser* — app-side support for pyobs-core #831/#832: builder form fields for the new `Calibration`/`Reduction` options, exposure time shown in the period-detail calibs list; blocked on a pyobs-core rev containing #831/#832 (pin bump or temporary editable-path override) |
 | pyobs-brot | [#61](https://github.com/pyobs/pyobs-brot/issues/61) | `set_offsets_altaz` times out (120s) repeatedly during autoguiding on MONET South | *bug, assigned: thusser* — three consecutive settle-wait timeouts during a 2026-08-24 autoguiding run on monets1m2; needs mount-side telemetry/drive-fault investigation |
 | pyobs-brot | [#60](https://github.com/pyobs/pyobs-brot/issues/60) | Bump astropy pin to allow 8.x | *assigned: thusser* — pin (`astropy<8,>=7.0.1`) forces a downgrade when installed alongside pyobs-portal (locked to `astropy==8.0.1`); on south/monet's portal image, `uv run`'s re-sync undoes the downgrade on every container start (multi-minute startup tax, re-fetches astropy over the network). Needs test-suite check before widening to `<9` |
 | pyobs-gui | [#154](https://github.com/pyobs/pyobs-gui/issues/154) | Add generic `IStructuredConfig` widget — schema-driven form auto-built from `ConfigSchema` | *enhancement* — one generic widget covers every `IStructuredConfig` module (schema-driven editors + live `ConfigAppliedState` + `set_config()`); plan `2026-08-28-structuredconfig-widget.md` below (*proposed*) |
-| pyobs-gui | [#150](https://github.com/pyobs/pyobs-gui/issues/150) | Main widgets vs. sidebar widgets — automatic tab pages for multi-widget modules | *assigned: thusser* — split widget concept into main vs. sidebar categories; affects page assembly; draft plan `2026-08-28-gui-main-vs-sidebar-widgets.md`, revised 2026-09-01 (`sidebar_preferred` promotion rule, universal sidebar container, `paired_sidebar_widget`); follow-up plan `2026-09-01-gui-video-widget-split.md` (both pyobs-gui specs, below) |
-| pyobs-portal | [#116](https://github.com/pyobs/pyobs-portal/issues/116) | Add instrument config app for script builder (camera/telescope capabilities) | *assigned: thusser* — static instrument capability data so the script builder works without live modules |
+| pyobs-portal | [#128](https://github.com/pyobs/pyobs-portal/issues/128) | Script builder: nested scripts in a `SequentialRunner` show as raw-YAML textareas, not forms | *bug* — nested polymorphic scripts (`SequentialRunner.scripts`, `ParallelRunner.scripts`, `ConditionalRunner.true`/`.false`, `CasesRunner.cases`) skip the class-dropdown + nested-form control when stored under a re-exported short class path; `ScriptBuilder._resolveClass()` (`$aliases`) only canonicalizes the root script class. Fix direction: apply `$aliases` resolution to nested classes too (in `buildPolymorphicControl` or canonicalize on load) + regression test with an aliased nested class |
+| pyobs-portal | [#116](https://github.com/pyobs/pyobs-portal/issues/116) | Add instrument config app for script builder (camera/telescope capabilities) | *assigned: thusser* — static instrument capability data so the script builder works without live modules; plan `2026-09-01-portal-instrument-config-app.md` below (*proposed*) |
 | pyobs-web-admin | [#74](https://github.com/pyobs/pyobs-web-admin/issues/74) | Add fullscreen button for logs | *assigned: thusser* — both log views render at a fixed height with no enlarge option |
 | pyobs-archive | [#57](https://github.com/pyobs/pyobs-archive/issues/57) | Consider a Keycloak-role-synced archive-admin flag (deferred from #56) | |
 | pyobs-weather | [#6](https://github.com/pyobs/pyobs-weather/issues/6) | Historic data | *enhancement* |
@@ -44,14 +41,14 @@ One row per issue — same layout for every repo.
 
 ### pyobs-core `specs/plans/`
 
-- [2026-09-01-morning-darks-match-science-exptimes.md](../plans/2026-09-01-morning-darks-match-science-exptimes.md) —
-  *proposed* (#831). Archive API needs an `exptime` field/filter (`FrameInfo`, `PyobsArchive`,
-  `LocalArchive`), a helper to derive the previous night's science exposure times, and a
-  `DarkBiasScript` option to take darks at each one.
 - [2026-09-01-per-exptime-dark-masters.md](../plans/2026-09-01-per-exptime-dark-masters.md) —
-  *proposed* (#832, depends on #831 above). Per-exptime master darks (filename/cache/progress
-  carry `exptime`), match-or-scale-reference-only-or-error policy at calibration time per ADR
-  `0015`.
+  *proposed* (#832, depends on #831 — implemented). Per-exptime master darks
+  (filename/cache/progress carry `exptime`), match-or-scale-reference-only-or-error policy at
+  calibration time per ADR `0015`.
+- [2026-09-01-portal-instrument-config-app.md](../plans/2026-09-01-portal-instrument-config-app.md) —
+  *proposed* (pyobs-portal#116). New `instruments` Django app for pyobs-portal: per-type
+  capability models (camera/telescope/filter wheels), admin-editable via a scoped
+  `instrument-config` group, read-only nested API for the script builder.
 - [2026-07-27-gui-widget-plugins-and-packaging.md](../plans/2026-07-27-gui-widget-plugins-and-packaging.md) —
   *draft* (pyobs-gui). Widget plugin mechanism + `pyside6-deploy` packaging; loading mechanism
   decided + spiked, widget-selection mechanism still open.
@@ -63,9 +60,10 @@ One row per issue — same layout for every repo.
   async-context-manager change, missing-await fixes) not yet done, three open questions need
   Tim's input.
 - [2026-08-28-observation-portal-keycloak-auth.md](../plans/2026-08-28-observation-portal-keycloak-auth.md) —
-  *proposed* (observation-portal, pyobs-auth; revised 2026-08-31 — see "Direction change").
-  Attach observation-portal (MONET fork) to Keycloak as a `pyobs-auth` client, additive next to
-  local username/password auth; supersedes Section 0 of the 2026-08-12 shared-auth plan.
+  *proposed*, revised 2026-08-31 (observation-portal; see "Direction change"). Attach
+  observation-portal (MONET fork) to OIDC via generic `mozilla-django-oidc` (no pyobs-auth
+  dependency, upstream-submittable), config-gated via `OIDC_ENABLED`, additive next to local
+  username/password auth; supersedes Section 0 of the 2026-08-12 shared-auth plan.
 
 ### Design docs still *proposed*
 
@@ -79,11 +77,8 @@ One row per issue — same layout for every repo.
 
 One line per plan — same layout for every repo.
 
-- **pyobs-gui** — [2026-08-28-gui-main-vs-sidebar-widgets.md](../../pyobs-gui/specs/2026-08-28-gui-main-vs-sidebar-widgets.md) —
-  main vs. sidebar widget split, automatic tab pages for multi-widget modules (#150) (*draft,
-  revised 2026-09-01*)
 - **pyobs-gui** — [2026-09-01-gui-video-widget-split.md](../../pyobs-gui/specs/2026-09-01-gui-video-widget-split.md) —
-  split `VideoWidget` into a main widget + paired sidebar widget, follow-up to the above (#150 D6)
+  split `VideoWidget` into a main widget + paired sidebar widget, follow-up to #150 D6
   (*draft*)
 - **pyobs-gui** — [2026-08-28-structuredconfig-widget.md](../../pyobs-gui/specs/2026-08-28-structuredconfig-widget.md) —
   generic schema-driven `IStructuredConfig` form widget (#154) (*proposed*)

--- a/tests/robotic/scripts/test_darkbias.py
+++ b/tests/robotic/scripts/test_darkbias.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import astropy.units as u
 import pytest
 
 from pyobs.robotic.scripts.calibration.darkbias import DarkBiasScript
 from pyobs.robotic.utils.archive import Archive, FrameInfo
+from pyobs.robotic.utils.calibration import clear_cache
 from pyobs.utils.enums import ImageType
 from tests.helpers import isinstance_class, make_proxy_cm
+
+
+@pytest.fixture(autouse=True)
+def _clear_exptime_cache() -> None:
+    clear_cache()
 
 
 class _FakeArchive(Archive):
@@ -282,9 +289,12 @@ async def test_can_run_true_with_explicit_night() -> None:
 
 @pytest.mark.asyncio
 async def test_can_run_true_with_observer_configured() -> None:
+    from astroplan import Observer
+
+    observer = Observer(longitude=9.94 * u.deg, latitude=51.56 * u.deg, elevation=150 * u.m)
     script = DarkBiasScript.model_validate(
         {"camera": "camera", "match_science_exptimes": True, "archive": _FakeArchive(), "site": "siteA"},
-        context={"comm": MagicMock(), "observer": MagicMock()},
+        context={"comm": MagicMock(), "observer": observer},
     )
     script._comm.has_proxy = AsyncMock(return_value=True)
 
@@ -342,3 +352,42 @@ async def test_no_science_exptimes_takes_nothing() -> None:
 
     camera.set_exposure_time.assert_not_called()
     camera.grab_data.assert_not_called()
+
+
+# ── match_science_exptimes: estimate_duration via can_run()'s cache warm-up ──
+
+
+@pytest.mark.asyncio
+async def test_estimate_duration_uses_cache_warmed_by_can_run() -> None:
+    archive = _FakeArchive(exptimes=[30.0, 600.0])
+    script = make_script(count=2, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+    script._comm.has_proxy = AsyncMock(return_value=True)
+    assert await script.can_run(None) is True
+
+    # a fresh instance, as Task.create_script() would produce -- no shared state with `script`,
+    # only the module-level cache can_run() warmed above
+    other = make_script(count=2, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+
+    assert other.estimate_duration(None) == 2 * (30.0 + 5.0) + 2 * (600.0 + 5.0)
+
+
+@pytest.mark.asyncio
+async def test_estimate_duration_falls_back_without_a_prior_can_run() -> None:
+    archive = _FakeArchive(exptimes=[30.0, 600.0])
+    script = make_script(count=2, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+
+    # exptime defaults to 0 -- placeholder estimate, not the real archive-derived series
+    assert script.estimate_duration(None) == 2 * (0.0 + 5.0)
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_when_archive_query_raises() -> None:
+    class _BrokenArchive(_FakeArchive):
+        async def list_options(self, **kwargs: Any) -> dict[str, list[Any]]:
+            raise RuntimeError("archive unreachable")
+
+    script = make_script(match_science_exptimes=True, archive=_BrokenArchive(), site="siteA", night="2024-01-01")
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is False
+    assert "archive" in script.cant_run_reason()

--- a/tests/robotic/scripts/test_darkbias.py
+++ b/tests/robotic/scripts/test_darkbias.py
@@ -19,9 +19,18 @@ def _clear_exptime_cache() -> None:
 
 
 class _FakeArchive(Archive):
-    """Stub archive returning a fixed set of OBJECT frame exptimes for one instrument/binning."""
+    """Stub archive returning fixed OBJECT frame exptimes, optionally per (instrument, binning).
+
+    `exptimes` seeds a single "cam1"/"1x1" combination. `exptimes_by_binning` (binning string ->
+    exptimes) overrides that for tests that need multiple instruments/binnings in play, to check
+    that DarkBiasScript only picks up the combination matching its own configured binning.
+    """
 
     exptimes: list[float] = []
+    exptimes_by_binning: dict[str, list[float]] | None = None
+
+    def _combos(self) -> dict[str, list[float]]:
+        return self.exptimes_by_binning if self.exptimes_by_binning is not None else {"1x1": self.exptimes}
 
     async def list_options(
         self,
@@ -38,7 +47,7 @@ class _FakeArchive(Archive):
         obsnum: Any = None,
         exptime: Any = None,
     ) -> dict[str, list[Any]]:
-        return {"instruments": ["cam1"], "binnings": ["1x1"]}
+        return {"instruments": ["cam1"], "binnings": list(self._combos().keys())}
 
     async def list_frames(
         self,
@@ -56,7 +65,7 @@ class _FakeArchive(Archive):
         exptime: Any = None,
     ) -> list[FrameInfo]:
         frames = []
-        for e in self.exptimes:
+        for e in self._combos().get(binning, []):
             info = FrameInfo()
             info.exptime = e
             frames.append(info)
@@ -249,6 +258,11 @@ def test_exptimes_alone_is_valid() -> None:
     make_script(exptimes=[30.0, 600.0])
 
 
+def test_exptimes_cannot_include_zero() -> None:
+    with pytest.raises(ValueError, match="cannot include 0"):
+        make_script(exptimes=[0, 30.0])
+
+
 # ── can_run: match_science_exptimes ──────────────────────────────────────────
 
 
@@ -342,6 +356,22 @@ async def test_runs_series_derived_from_science_exptimes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_only_uses_exptimes_from_its_own_binning() -> None:
+    # cam1 (this script's binning, 1x1) used 30s/600s; a different instrument/binning (2x2, not
+    # this script's) used 90s -- 90 must not leak in just because science_exptimes_for_night
+    # unions across every (instrument, binning) combination it found that night
+    archive = _FakeArchive(exptimes_by_binning={"1x1": [30.0, 600.0], "2x2": [90.0]})
+    script = make_script(count=1, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+    camera = make_camera()
+    setup_run_comm(script, camera)
+
+    await script.run(None)
+
+    calls = [c.args[0] for c in camera.set_exposure_time.call_args_list]
+    assert calls == [600.0, 30.0]
+
+
+@pytest.mark.asyncio
 async def test_no_science_exptimes_takes_nothing() -> None:
     archive = _FakeArchive(exptimes=[])
     script = make_script(count=1, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
@@ -350,6 +380,7 @@ async def test_no_science_exptimes_takes_nothing() -> None:
 
     await script.run(None)
 
+    camera.set_image_type.assert_not_called()
     camera.set_exposure_time.assert_not_called()
     camera.grab_data.assert_not_called()
 
@@ -376,8 +407,10 @@ async def test_estimate_duration_falls_back_without_a_prior_can_run() -> None:
     archive = _FakeArchive(exptimes=[30.0, 600.0])
     script = make_script(count=2, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
 
-    # exptime defaults to 0 -- placeholder estimate, not the real archive-derived series
-    assert script.estimate_duration(None) == 2 * (0.0 + 5.0)
+    # nothing cached yet -- placeholder estimate at _FALLBACK_MATCH_EXPTIME, not the real
+    # archive-derived series (and not the always-0 configured exptime, which would badly
+    # underestimate a real dark run)
+    assert script.estimate_duration(None) == 2 * (DarkBiasScript._FALLBACK_MATCH_EXPTIME + 5.0)
 
 
 @pytest.mark.asyncio

--- a/tests/robotic/scripts/test_darkbias.py
+++ b/tests/robotic/scripts/test_darkbias.py
@@ -1,12 +1,62 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from pyobs.robotic.scripts.calibration.darkbias import DarkBiasScript
+from pyobs.robotic.utils.archive import Archive, FrameInfo
 from pyobs.utils.enums import ImageType
 from tests.helpers import isinstance_class, make_proxy_cm
+
+
+class _FakeArchive(Archive):
+    """Stub archive returning a fixed set of OBJECT frame exptimes for one instrument/binning."""
+
+    exptimes: list[float] = []
+
+    async def list_options(
+        self,
+        start: Any = None,
+        end: Any = None,
+        night: Any = None,
+        site: Any = None,
+        telescope: Any = None,
+        instrument: Any = None,
+        image_type: Any = None,
+        binning: Any = None,
+        filter_name: Any = None,
+        rlevel: Any = None,
+        obsnum: Any = None,
+        exptime: Any = None,
+    ) -> dict[str, list[Any]]:
+        return {"instruments": ["cam1"], "binnings": ["1x1"]}
+
+    async def list_frames(
+        self,
+        start: Any = None,
+        end: Any = None,
+        night: Any = None,
+        site: Any = None,
+        telescope: Any = None,
+        instrument: Any = None,
+        image_type: Any = None,
+        binning: Any = None,
+        filter_name: Any = None,
+        rlevel: Any = None,
+        obsnum: Any = None,
+        exptime: Any = None,
+    ) -> list[FrameInfo]:
+        frames = []
+        for e in self.exptimes:
+            info = FrameInfo()
+            info.exptime = e
+            frames.append(info)
+        return frames
+
+    async def download_frames(self, frames: list[FrameInfo]) -> list[Any]:
+        return []
 
 
 def make_script(**kwargs) -> DarkBiasScript:
@@ -167,3 +217,128 @@ async def test_takes_correct_count() -> None:
 
     await script.run(None)
     assert camera.grab_data.call_count == 5
+
+
+# ── mutual exclusivity validation ────────────────────────────────────────────
+
+
+def test_exptimes_and_match_science_exptimes_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        make_script(exptimes=[30.0, 600.0], match_science_exptimes=True, archive=_FakeArchive(), site="siteA")
+
+
+def test_exptime_and_exptimes_cannot_be_combined() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        make_script(exptime=30.0, exptimes=[30.0, 600.0])
+
+
+def test_exptime_and_match_science_exptimes_cannot_be_combined() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        make_script(exptime=30.0, match_science_exptimes=True, archive=_FakeArchive(), site="siteA")
+
+
+def test_exptimes_alone_is_valid() -> None:
+    # should not raise
+    make_script(exptimes=[30.0, 600.0])
+
+
+# ── can_run: match_science_exptimes ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_without_archive_when_matching_science_exptimes() -> None:
+    script = make_script(match_science_exptimes=True, site="siteA")
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is False
+    assert "archive" in script.cant_run_reason()
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_without_site_when_matching_science_exptimes() -> None:
+    script = make_script(match_science_exptimes=True, archive=_FakeArchive())
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is False
+    assert "archive" in script.cant_run_reason()
+
+
+@pytest.mark.asyncio
+async def test_can_run_false_without_night_or_observer() -> None:
+    script = make_script(match_science_exptimes=True, archive=_FakeArchive(), site="siteA")
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is False
+    assert "observer" in script.cant_run_reason()
+
+
+@pytest.mark.asyncio
+async def test_can_run_true_with_explicit_night() -> None:
+    script = make_script(match_science_exptimes=True, archive=_FakeArchive(), site="siteA", night="2024-01-01")
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is True
+
+
+@pytest.mark.asyncio
+async def test_can_run_true_with_observer_configured() -> None:
+    script = DarkBiasScript.model_validate(
+        {"camera": "camera", "match_science_exptimes": True, "archive": _FakeArchive(), "site": "siteA"},
+        context={"comm": MagicMock(), "observer": MagicMock()},
+    )
+    script._comm.has_proxy = AsyncMock(return_value=True)
+
+    assert await script.can_run(None) is True
+
+
+# ── explicit exptimes list ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runs_series_longest_first() -> None:
+    script = make_script(count=2, exptimes=[30.0, 600.0, 60.0])
+    camera = make_camera()
+    setup_run_comm(script, camera)
+
+    await script.run(None)
+
+    calls = [c.args[0] for c in camera.set_exposure_time.call_args_list]
+    assert calls == [600.0, 60.0, 30.0]
+    camera.set_image_type.assert_called_once_with(ImageType.DARK)
+    assert camera.grab_data.call_count == 6  # 3 series * 2 exposures
+
+
+@pytest.mark.asyncio
+async def test_estimate_duration_sums_over_exptimes_list() -> None:
+    script = make_script(count=2, exptimes=[30.0, 600.0])
+    assert script.estimate_duration(None) == 2 * (30.0 + 5.0) + 2 * (600.0 + 5.0)
+
+
+# ── match_science_exptimes ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runs_series_derived_from_science_exptimes() -> None:
+    archive = _FakeArchive(exptimes=[45.0, 45.1, 600.0])
+    script = make_script(count=1, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+    camera = make_camera()
+    setup_run_comm(script, camera)
+
+    await script.run(None)
+
+    calls = [c.args[0] for c in camera.set_exposure_time.call_args_list]
+    assert calls == [600.0, 45.05]
+    camera.set_image_type.assert_called_once_with(ImageType.DARK)
+
+
+@pytest.mark.asyncio
+async def test_no_science_exptimes_takes_nothing() -> None:
+    archive = _FakeArchive(exptimes=[])
+    script = make_script(count=1, match_science_exptimes=True, archive=archive, site="siteA", night="2024-01-01")
+    camera = make_camera()
+    setup_run_comm(script, camera)
+
+    await script.run(None)
+
+    camera.set_exposure_time.assert_not_called()
+    camera.grab_data.assert_not_called()

--- a/tests/robotic/scripts/test_darkbias.py
+++ b/tests/robotic/scripts/test_darkbias.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import astropy.units as u
 import pytest
@@ -10,6 +10,7 @@ from pyobs.robotic.scripts.calibration.darkbias import DarkBiasScript
 from pyobs.robotic.utils.archive import Archive, FrameInfo
 from pyobs.robotic.utils.calibration import clear_cache
 from pyobs.utils.enums import ImageType
+from pyobs.utils.time import Time
 from tests.helpers import isinstance_class, make_proxy_cm
 
 
@@ -312,7 +313,11 @@ async def test_can_run_true_with_observer_configured() -> None:
     )
     script._comm.has_proxy = AsyncMock(return_value=True)
 
-    assert await script.can_run(None) is True
+    # Time.now() pulls in astropy's IERS auto-download; pin it to a fixed, bundled-IERS-coverage
+    # instant like every other Observer-based test in the repo, so the suite stays standalone.
+    with patch("pyobs.robotic.scripts.calibration.darkbias.Time") as mock_time:
+        mock_time.now.return_value = Time("2026-07-16T15:45:50")
+        assert await script.can_run(None) is True
 
 
 # ── explicit exptimes list ────────────────────────────────────────────────────

--- a/tests/robotic/utils/archive/test_local_archive.py
+++ b/tests/robotic/utils/archive/test_local_archive.py
@@ -29,8 +29,9 @@ def make_frame_headers(
     telescope: str = "tel1",
     rlevel: int = 91,
     obsnum: str = "42",
+    exptime: float | None = 600.0,
 ) -> dict[str, object]:
-    return {
+    headers: dict[str, object] = {
         "DATE-OBS": date_obs,
         "DAY-OBS": day_obs,
         "XBINNING": binning[0],
@@ -43,6 +44,9 @@ def make_frame_headers(
         "RLEVEL": rlevel,
         "OBSNUM": obsnum,
     }
+    if exptime is not None:
+        headers["EXPTIME"] = exptime
+    return headers
 
 
 # ── model_post_init / _update_root ──────────────────────────────────────────
@@ -203,6 +207,59 @@ async def test_list_frames_empty_when_nothing_matches(tmp_path: Path) -> None:
     frames = await archive.list_frames(filter_name="nonexistent")
 
     assert frames == []
+
+
+@pytest.mark.asyncio
+async def test_list_frames_parses_exptime(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=45.0))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames()
+
+    assert frames[0].exptime == 45.0
+
+
+@pytest.mark.asyncio
+async def test_list_frames_exptime_is_none_when_header_missing(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=None))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames()
+
+    assert frames[0].exptime is None
+
+
+@pytest.mark.asyncio
+async def test_list_frames_filters_by_exptime_within_tolerance(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=600.0))
+    write_fits(tmp_path / "b.fits", **make_frame_headers(exptime=602.0))
+    write_fits(tmp_path / "c.fits", **make_frame_headers(exptime=45.0))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames(exptime=600.0)
+
+    assert {f.exptime for f in frames} == {600.0, 602.0}
+
+
+@pytest.mark.asyncio
+async def test_list_frames_exptime_excludes_frames_without_exptime(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=None))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames(exptime=600.0)
+
+    assert frames == []
+
+
+@pytest.mark.asyncio
+async def test_list_options_returns_exptimes(tmp_path: Path) -> None:
+    write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=30.0))
+    write_fits(tmp_path / "b.fits", **make_frame_headers(exptime=600.0))
+    archive = LocalArchive(root=str(tmp_path))
+
+    options = await archive.list_options()
+
+    assert set(options["exptimes"]) == {30.0, 600.0}
 
 
 # ── download_frames / download_headers ──────────────────────────────────────

--- a/tests/robotic/utils/archive/test_pyobs_archive.py
+++ b/tests/robotic/utils/archive/test_pyobs_archive.py
@@ -46,8 +46,10 @@ def make_archive(**kwargs: object) -> PyobsArchive:
     return PyobsArchive(url="http://archive.example/", token="tok", **kwargs)
 
 
-def make_frame_dict(id: int = 1, basename: str = "img.fits", url: str = "download/1/") -> dict[str, Any]:
-    return {
+def make_frame_dict(
+    id: int = 1, basename: str = "img.fits", url: str = "download/1/", exptime: float | None = 600.0
+) -> dict[str, Any]:
+    d: dict[str, Any] = {
         "id": id,
         "basename": basename,
         "DATE_OBS": "2024-01-01T03:00:00.000",
@@ -55,6 +57,9 @@ def make_frame_dict(id: int = 1, basename: str = "img.fits", url: str = "downloa
         "binning": "1x1",
         "url": url,
     }
+    if exptime is not None:
+        d["EXPTIME"] = exptime
+    return d
 
 
 # ── model_post_init ──────────────────────────────────────────────────────────
@@ -70,7 +75,7 @@ def test_init_sets_headers_and_timeout() -> None:
 
 
 def test_frame_info_parses_fields() -> None:
-    info = PyobsArchiveFrameInfo(make_frame_dict(id=42, basename="x.fits"))
+    info = PyobsArchiveFrameInfo(make_frame_dict(id=42, basename="x.fits", exptime=45.0))
 
     assert info.id == 42
     assert info.filename == "x.fits"
@@ -78,6 +83,13 @@ def test_frame_info_parses_fields() -> None:
     assert info.binning == 1
     assert isinstance(info.dateobs, Time)
     assert info.url == "download/1/"
+    assert info.exptime == 45.0
+
+
+def test_frame_info_exptime_is_none_when_missing() -> None:
+    info = PyobsArchiveFrameInfo(make_frame_dict(exptime=None))
+
+    assert info.exptime is None
 
 
 # ── _build_query ─────────────────────────────────────────────────────────────
@@ -109,6 +121,11 @@ def test_build_query_includes_all_given_params() -> None:
     assert params["OBSNUM"] == "42"
     assert params["start"] == "2024-01-01T00:00:00.000"
     assert params["end"] == "2024-01-02T00:00:00.000"
+
+
+def test_build_query_includes_exptime() -> None:
+    params = PyobsArchive._build_query(exptime=600.0)
+    assert params["EXPTIME"] == 600.0
 
 
 def test_build_query_empty_when_nothing_given() -> None:
@@ -192,6 +209,41 @@ async def test_list_frames_raises_on_non_200(mocker) -> None:
 
     with pytest.raises(ValueError):
         await archive.list_frames()
+
+
+@pytest.mark.asyncio
+async def test_list_frames_filters_by_exptime_client_side(mocker) -> None:
+    # server doesn't (yet) honor EXPTIME filtering and returns everything; client-side
+    # re-filtering must still narrow the result down to matching exptimes
+    archive = make_archive()
+    response = MockResponse(
+        json={
+            "results": [
+                make_frame_dict(id=1, exptime=600.0),
+                make_frame_dict(id=2, exptime=602.0),
+                make_frame_dict(id=3, exptime=45.0),
+            ],
+            "count": 3,
+        }
+    )
+    mocker.patch("aiohttp.ClientSession.get", return_value=response)
+
+    frames = await archive.list_frames(exptime=600.0)
+
+    assert {f.id for f in frames} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_list_frames_no_exptime_filter_keeps_all(mocker) -> None:
+    archive = make_archive()
+    response = MockResponse(
+        json={"results": [make_frame_dict(id=1, exptime=600.0), make_frame_dict(id=2, exptime=45.0)], "count": 2}
+    )
+    mocker.patch("aiohttp.ClientSession.get", return_value=response)
+
+    frames = await archive.list_frames()
+
+    assert {f.id for f in frames} == {1, 2}
 
 
 # ── download_frames ──────────────────────────────────────────────────────────

--- a/tests/robotic/utils/test_calibration.py
+++ b/tests/robotic/utils/test_calibration.py
@@ -6,9 +6,18 @@ import pytest
 
 from pyobs.images import Image
 from pyobs.robotic.utils.archive import Archive, FrameInfo
-from pyobs.robotic.utils.calibration import science_exptimes_for_night
+from pyobs.robotic.utils.calibration import (
+    clear_cache,
+    peek_cached_science_exptimes_for_night,
+    science_exptimes_for_night,
+)
 from pyobs.utils.enums import ImageType
 from pyobs.utils.time import Time
+
+
+@pytest.fixture(autouse=True)
+def _clear_exptime_cache() -> None:
+    clear_cache()
 
 
 class _FakeArchive(Archive):
@@ -17,6 +26,7 @@ class _FakeArchive(Archive):
     instruments: list[str] = ["cam1"]
     binnings: list[str] = ["1x1"]
     exptimes_by_frame: list[float] = []
+    list_options_calls: int = 0
 
     async def list_options(
         self,
@@ -33,6 +43,7 @@ class _FakeArchive(Archive):
         obsnum: str | None = None,
         exptime: float | None = None,
     ) -> dict[str, list[Any]]:
+        self.list_options_calls += 1
         return {"instruments": self.instruments, "binnings": self.binnings}
 
     async def list_frames(
@@ -105,3 +116,62 @@ async def test_empty_night_returns_empty_dict() -> None:
     result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
 
     assert result == {}
+
+
+# ── caching ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_second_call_hits_cache_not_archive() -> None:
+    archive = _FakeArchive(exptimes_by_frame=[600.0])
+
+    await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+    await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+
+    assert archive.list_options_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_different_night_is_not_cached_together() -> None:
+    archive = _FakeArchive(exptimes_by_frame=[600.0])
+
+    await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+    await science_exptimes_for_night(archive, site="siteA", night="2024-01-02")
+
+    assert archive.list_options_calls == 2
+
+
+def test_peek_cache_returns_none_when_nothing_cached() -> None:
+    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None
+
+
+@pytest.mark.asyncio
+async def test_peek_cache_returns_value_after_a_real_call() -> None:
+    archive = _FakeArchive(exptimes_by_frame=[600.0])
+    expected = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+
+    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") == expected
+
+
+def test_peek_cache_returns_none_once_expired() -> None:
+    import time
+
+    from pyobs.robotic.utils import calibration
+
+    stale = time.monotonic() - calibration._CACHE_TTL - 1.0
+    calibration._cache[("siteA", "2024-01-01", 0.01, 5.0)] = (stale, {("cam1", "1x1"): [600.0]})
+
+    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None
+
+
+def test_clear_cache_empties_it() -> None:
+    import time
+
+    from pyobs.robotic.utils import calibration
+
+    calibration._cache[("siteA", "2024-01-01", 0.01, 5.0)] = (time.monotonic(), {})
+    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") == {}
+
+    clear_cache()
+
+    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None

--- a/tests/robotic/utils/test_calibration.py
+++ b/tests/robotic/utils/test_calibration.py
@@ -142,7 +142,8 @@ async def test_different_night_is_not_cached_together() -> None:
 
 
 def test_peek_cache_returns_none_when_nothing_cached() -> None:
-    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None
+    archive = _FakeArchive()
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") is None
 
 
 @pytest.mark.asyncio
@@ -150,7 +151,34 @@ async def test_peek_cache_returns_value_after_a_real_call() -> None:
     archive = _FakeArchive(exptimes_by_frame=[600.0])
     expected = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
 
-    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") == expected
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") == expected
+
+
+@pytest.mark.asyncio
+async def test_peek_cache_ignores_mutation_of_the_same_archive_instance() -> None:
+    """A stateful Archive field (like this fake's call counter) must not affect the cache key --
+    otherwise the very first real call, which mutates that field as a side effect, would already
+    miss its own cache entry on the next lookup."""
+    archive = _FakeArchive(exptimes_by_frame=[600.0])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+    assert archive.list_options_calls == 1
+
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") == result
+
+
+def test_peek_cache_is_shared_across_archive_instances_of_the_same_class() -> None:
+    archive_a = _FakeArchive(instruments=["cam1"])
+    archive_b = _FakeArchive(instruments=["cam2"])
+    import time
+
+    from pyobs.robotic.utils import calibration
+
+    key = calibration._cache_key(archive_a, "siteA", "2024-01-01", 0.01, 5.0)
+    calibration._cache[key] = (time.monotonic(), {("cam1", "1x1"): [600.0]})
+
+    # same class -> same key, even though instruments differ; documented limitation
+    assert peek_cached_science_exptimes_for_night(archive_b, "siteA", "2024-01-01") == {("cam1", "1x1"): [600.0]}
 
 
 def test_peek_cache_returns_none_once_expired() -> None:
@@ -158,10 +186,12 @@ def test_peek_cache_returns_none_once_expired() -> None:
 
     from pyobs.robotic.utils import calibration
 
+    archive = _FakeArchive()
     stale = time.monotonic() - calibration._CACHE_TTL - 1.0
-    calibration._cache[("siteA", "2024-01-01", 0.01, 5.0)] = (stale, {("cam1", "1x1"): [600.0]})
+    key = calibration._cache_key(archive, "siteA", "2024-01-01", 0.01, 5.0)
+    calibration._cache[key] = (stale, {("cam1", "1x1"): [600.0]})
 
-    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") is None
 
 
 def test_clear_cache_empties_it() -> None:
@@ -169,9 +199,11 @@ def test_clear_cache_empties_it() -> None:
 
     from pyobs.robotic.utils import calibration
 
-    calibration._cache[("siteA", "2024-01-01", 0.01, 5.0)] = (time.monotonic(), {})
-    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") == {}
+    archive = _FakeArchive()
+    key = calibration._cache_key(archive, "siteA", "2024-01-01", 0.01, 5.0)
+    calibration._cache[key] = (time.monotonic(), {})
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") == {}
 
     clear_cache()
 
-    assert peek_cached_science_exptimes_for_night("siteA", "2024-01-01") is None
+    assert peek_cached_science_exptimes_for_night(archive, "siteA", "2024-01-01") is None

--- a/tests/robotic/utils/test_calibration.py
+++ b/tests/robotic/utils/test_calibration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pyobs.images import Image
+from pyobs.robotic.utils.archive import Archive, FrameInfo
+from pyobs.robotic.utils.calibration import science_exptimes_for_night
+from pyobs.utils.enums import ImageType
+from pyobs.utils.time import Time
+
+
+class _FakeArchive(Archive):
+    """Stub archive serving a fixed set of OBJECT frames for science_exptimes_for_night."""
+
+    instruments: list[str] = ["cam1"]
+    binnings: list[str] = ["1x1"]
+    exptimes_by_frame: list[float] = []
+
+    async def list_options(
+        self,
+        start: Time | None = None,
+        end: Time | None = None,
+        night: str | None = None,
+        site: str | None = None,
+        telescope: str | None = None,
+        instrument: str | None = None,
+        image_type: ImageType | None = None,
+        binning: str | None = None,
+        filter_name: str | None = None,
+        rlevel: int | None = None,
+        obsnum: str | None = None,
+        exptime: float | None = None,
+    ) -> dict[str, list[Any]]:
+        return {"instruments": self.instruments, "binnings": self.binnings}
+
+    async def list_frames(
+        self,
+        start: Time | None = None,
+        end: Time | None = None,
+        night: str | None = None,
+        site: str | None = None,
+        telescope: str | None = None,
+        instrument: str | None = None,
+        image_type: ImageType | None = None,
+        binning: str | None = None,
+        filter_name: str | None = None,
+        rlevel: int | None = None,
+        obsnum: str | None = None,
+        exptime: float | None = None,
+    ) -> list[FrameInfo]:
+        frames = []
+        for e in self.exptimes_by_frame:
+            info = FrameInfo()
+            info.exptime = e
+            frames.append(info)
+        return frames
+
+    async def download_frames(self, frames: list[FrameInfo]) -> list[Image]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_groups_exptimes_per_instrument_binning() -> None:
+    archive = _FakeArchive(instruments=["cam1"], binnings=["1x1"], exptimes_by_frame=[30.0, 30.1, 600.0])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+
+    assert result == {("cam1", "1x1"): [30.05, 600.0]}
+
+
+@pytest.mark.asyncio
+async def test_multiple_instrument_binning_combinations() -> None:
+    archive = _FakeArchive(instruments=["cam1", "cam2"], binnings=["1x1"], exptimes_by_frame=[45.0])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+
+    assert set(result.keys()) == {("cam1", "1x1"), ("cam2", "1x1")}
+    assert result[("cam1", "1x1")] == [45.0]
+
+
+@pytest.mark.asyncio
+async def test_drops_exptimes_below_min_exptime() -> None:
+    archive = _FakeArchive(instruments=["cam1"], binnings=["1x1"], exptimes_by_frame=[2.0, 4.0, 30.0])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01", min_exptime=5.0)
+
+    assert result == {("cam1", "1x1"): [30.0]}
+
+
+@pytest.mark.asyncio
+async def test_min_exptime_none_keeps_every_exptime() -> None:
+    archive = _FakeArchive(instruments=["cam1"], binnings=["1x1"], exptimes_by_frame=[2.0, 30.0])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01", min_exptime=None)
+
+    assert result == {("cam1", "1x1"): [2.0, 30.0]}
+
+
+@pytest.mark.asyncio
+async def test_empty_night_returns_empty_dict() -> None:
+    archive = _FakeArchive(instruments=["cam1"], binnings=["1x1"], exptimes_by_frame=[])
+
+    result = await science_exptimes_for_night(archive, site="siteA", night="2024-01-01")
+
+    assert result == {}

--- a/tests/utils/test_exptime_grouping.py
+++ b/tests/utils/test_exptime_grouping.py
@@ -22,6 +22,11 @@ def test_exptimes_close_zero_target_only_matches_zero() -> None:
     assert exptimes_close(1.0, 0.0) is False
 
 
+def test_exptimes_close_is_symmetric() -> None:
+    assert exptimes_close(100.0, 101.0, tolerance=0.01) == exptimes_close(101.0, 100.0, tolerance=0.01)
+    assert exptimes_close(100.0, 101.01, tolerance=0.01) == exptimes_close(101.01, 100.0, tolerance=0.01)
+
+
 # ── group_exptimes ───────────────────────────────────────────────────────────
 
 

--- a/tests/utils/test_exptime_grouping.py
+++ b/tests/utils/test_exptime_grouping.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pyobs.utils.exptime_grouping import exptimes_close, group_exptimes
+
+# ── exptimes_close ───────────────────────────────────────────────────────────
+
+
+def test_exptimes_close_exact_match() -> None:
+    assert exptimes_close(600.0, 600.0) is True
+
+
+def test_exptimes_close_within_relative_tolerance() -> None:
+    assert exptimes_close(605.0, 600.0, tolerance=0.01) is True
+
+
+def test_exptimes_close_outside_relative_tolerance() -> None:
+    assert exptimes_close(650.0, 600.0, tolerance=0.01) is False
+
+
+def test_exptimes_close_zero_target_only_matches_zero() -> None:
+    assert exptimes_close(0.0, 0.0) is True
+    assert exptimes_close(1.0, 0.0) is False
+
+
+# ── group_exptimes ───────────────────────────────────────────────────────────
+
+
+def test_group_exptimes_collapses_near_duplicates() -> None:
+    groups = group_exptimes([30.0, 30.1, 29.9, 600.0, 601.0])
+    assert groups == [30.0, 600.5]
+
+
+def test_group_exptimes_keeps_distinct_values_separate() -> None:
+    groups = group_exptimes([10.0, 60.0, 600.0])
+    assert groups == [10.0, 60.0, 600.0]
+
+
+def test_group_exptimes_empty_input() -> None:
+    assert group_exptimes([]) == []
+
+
+def test_group_exptimes_single_value() -> None:
+    assert group_exptimes([45.0]) == [45.0]


### PR DESCRIPTION
## Summary
- Exposes `EXPTIME` on the archive API: `FrameInfo.exptime`, an `exptime` filter/tolerance param on `list_frames()`/`list_options()`, and an `exptimes` key in `list_options()`'s return, in both `PyobsArchive` and `LocalArchive`.
- Adds `pyobs.robotic.utils.calibration.science_exptimes_for_night()`, deriving the distinct (tolerance-grouped) exptimes a night's science frames used, per instrument/binning. Caches its result at module scope for 5 minutes, keyed by `(site, night, tolerance, min_exptime)`.
- Adds `pyobs.utils.exptime_grouping` (`exptimes_close`/`group_exptimes`), a shared relative-tolerance helper reused by the archive filter and the grouping helper (and intended for #832's per-exptime dark-master grouping later).
- Extends `DarkBiasScript` with `exptimes` (explicit list) and `match_science_exptimes` (derived), running one dark series per exptime, longest-first; the single-`exptime` default path (including bias, `exptime=0`) is unchanged. Mutual exclusivity between `exptime`/`exptimes`/`match_science_exptimes` is validated at construction.
- Exptimes below `dark_min_exptime` (default 5s, per ADR 0015) are dropped before grouping, since calibration treats them as bias-only and never needs a dark master for them.
- ADR `0015-dark-master-strict-exptime-matching-reference-scale-down-only.md` flipped from `proposed` to `accepted`; plan `2026-09-01-morning-darks-match-science-exptimes.md` flipped to `implemented`.

Scoped to issue #831 only (archive/robotic side). #832 (reduction/`Calibration` matching+scaling policy) is a separate follow-up plan, not touched here.

## `estimate_duration()` vs. `match_science_exptimes`
`Task.create_script()` re-validates a fresh `Script` (and `Archive`) instance on every `can_run()`/`estimate_duration()` call, so instance-level caching between them doesn't work. Instead, `science_exptimes_for_night()`'s cache lives at module scope: `can_run()` (async) warms it, and `estimate_duration()` (sync, can't query the archive itself) reads it via a new synchronous `peek_cached_science_exptimes_for_night()`. Falls back to a single-series placeholder estimate if nothing is cached yet (e.g. `can_run()` hasn't run for that site/night within the cache's 5-minute TTL). `can_run()` now also surfaces an unreachable archive as a cant-run reason instead of letting that failure surface later during `run()`.

## Other known gaps (called out in the plan's acceptance criteria, not solved by this PR)
- `PyobsArchive.list_options()`'s `exptimes` key depends on the pyobs-archive server actually returning one — not verifiable from this repo. `list_frames()` is safe either way: it re-filters by tolerance client-side regardless of server-side `EXPTIME` support.
- No CHANGELOG entry: the top-of-file version header (`v2.1.1.dev1`) is already stale relative to the just-released `v2.1.1` tag, a pre-existing gap unrelated to this PR — didn't want to guess a version number and add more noise there.

## Test plan
- [x] `pytest tests/` (excluding `integration`/`xmpp`): 1718 passed, 7 pre-existing/unrelated failures in `tests/cli/test_pyobsd.py` (local-environment `pyobs` executable lookup, present on `develop` too).
- [x] `ruff check` clean.
- [x] `pyrefly check` (CI's actual invocation, `pyobs/` only): 0 errors, same baseline suppressed/warning counts as `develop`.
- New tests: `tests/utils/test_exptime_grouping.py`, `tests/robotic/utils/test_calibration.py` (including cache hit/expiry/clear coverage), plus exptime coverage added to `tests/robotic/utils/archive/test_{local,pyobs}_archive.py` and `tests/robotic/scripts/test_darkbias.py` (including the cache-warm-up/fallback split for `estimate_duration()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
