### PR TITLE
Add DummyStructuredConfig module implementing IStructuredConfig

### DIFF
--- a/pyobs/modules/utils/__init__.py
+++ b/pyobs/modules/utils/__init__.py
@@ -6,6 +6,7 @@ TODO: write doc
 __title__ = "Utility modules"
 
 from .dummymode import DummyMode
+from .dummystructuredconfig import DummyStructuredConfig
 from .fluentlogger import FluentLogger
 from .httpfilecache import HttpFileCache
 from .kiosk import Kiosk
@@ -13,4 +14,13 @@ from .matrix import Matrix
 from .telegram import Telegram
 from .trigger import Trigger
 
-__all__ = ["DummyMode", "FluentLogger", "HttpFileCache", "Kiosk", "Matrix", "Telegram", "Trigger"]
+__all__ = [
+    "DummyMode",
+    "DummyStructuredConfig",
+    "FluentLogger",
+    "HttpFileCache",
+    "Kiosk",
+    "Matrix",
+    "Telegram",
+    "Trigger",
+]

--- a/pyobs/modules/utils/dummystructuredconfig.py
+++ b/pyobs/modules/utils/dummystructuredconfig.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+import typing
+from typing import Annotated, Any
+
+from pyobs.interfaces import ConfigAppliedState, IStructuredConfig
+from pyobs.modules import Module
+from pyobs.utils.config_schema import dataclass_to_schema
+from pyobs.utils.enums import Unit
+
+log = logging.getLogger(__name__)
+
+
+class DummyOperatingMode(enum.Enum):
+    """Selectable mode for the dummy structured config's `mode` field."""
+
+    TRACK = "track"
+    PARK = "park"
+    SLEW = "slew"
+
+
+@dataclasses.dataclass
+class DummyNestedConfig:
+    """A nested sub-config, so the schema exercises `type="object"` with `nested`."""
+
+    label: str = "nested"
+    threshold: int = 5
+    active: bool = True
+
+
+@dataclasses.dataclass
+class DummyStructuredConfigData:
+    """Covers every `ConfigFieldSchema` type at least once: str, int, a float with a unit,
+    bool, an enum, and a nested dataclass."""
+
+    name: str = "dummy"
+    count: int = 1
+    offset: Annotated[float, Unit.ARCSEC] = 0.0
+    verbose: bool = False
+    mode: DummyOperatingMode = DummyOperatingMode.TRACK
+    nested: DummyNestedConfig = dataclasses.field(default_factory=DummyNestedConfig)
+
+
+def _from_dict(cls: type, data: Any) -> Any:
+    """Recursively build a dataclass instance from a nested dict, raising ValueError on any
+    schema mismatch (unknown field, wrong type, invalid enum value) per IStructuredConfig's
+    documented set_config contract."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a dict for {cls.__name__}, got {type(data).__name__}")
+
+    hints = typing.get_type_hints(cls, include_extras=True)
+    field_names = {f.name for f in dataclasses.fields(cls)}
+    unknown = set(data) - field_names
+    if unknown:
+        raise ValueError(f"Unknown field(s) for {cls.__name__}: {sorted(unknown)}")
+
+    kwargs: dict[str, Any] = {}
+    for name, value in data.items():
+        annotation = hints[name]
+        if typing.get_origin(annotation) is Annotated:
+            annotation = typing.get_args(annotation)[0]
+
+        if dataclasses.is_dataclass(annotation):
+            kwargs[name] = _from_dict(annotation, value)
+        elif isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+            try:
+                kwargs[name] = annotation(value)
+            except ValueError:
+                raise ValueError(f"Invalid value for {cls.__name__}.{name}: {value!r}") from None
+        elif annotation is float and isinstance(value, int) and not isinstance(value, bool):
+            kwargs[name] = float(value)
+        else:
+            if not isinstance(value, annotation) or (annotation is int and isinstance(value, bool)):
+                raise ValueError(
+                    f"Invalid type for {cls.__name__}.{name}: expected {annotation.__name__}, "
+                    f"got {type(value).__name__}"
+                )
+            kwargs[name] = value
+
+    return cls(**kwargs)
+
+
+def _to_dict(instance: Any) -> dict[str, Any]:
+    """Inverse of _from_dict: nested dataclasses become nested dicts, enums become their value."""
+    result: dict[str, Any] = {}
+    for f in dataclasses.fields(instance):
+        value = getattr(instance, f.name)
+        if dataclasses.is_dataclass(value):
+            result[f.name] = _to_dict(value)
+        elif isinstance(value, enum.Enum):
+            result[f.name] = value.value
+        else:
+            result[f.name] = value
+    return result
+
+
+class DummyStructuredConfig(Module, IStructuredConfig):
+    """A dummy module implementing IStructuredConfig, with no hardware behind it.
+
+    Exists so a schema-driven config widget (e.g. pyobs-gui's StructuredConfigWidget) has
+    something to actually run against for manual verification: at the time this was added,
+    the only other IStructuredConfig consumer anywhere was pyobs-iagvt's FTS module, which
+    isn't available in a headless/dummy-fleet dev setup."""
+
+    __module__ = "pyobs.modules.utils"
+
+    def __init__(self, **kwargs: Any):
+        """Creates a new dummy structured-config module."""
+        super().__init__(**kwargs)
+        self._config = DummyStructuredConfigData()
+
+    async def open(self) -> None:
+        """Open module."""
+        await Module.open(self)
+        await self.comm.set_capabilities(IStructuredConfig, dataclass_to_schema(DummyStructuredConfigData))
+        await self._publish_state()
+
+    async def set_config(self, config: dict[str, Any], **kwargs: Any) -> None:
+        """Apply a full structured config to this module.
+
+        Args:
+            config: Nested dict matching DummyStructuredConfigData's schema.
+
+        Raises:
+            ValueError: If config doesn't match the schema, or values fail validation.
+        """
+        self._config = _from_dict(DummyStructuredConfigData, config)
+        await self._publish_state()
+
+    async def _publish_state(self) -> None:
+        await self.comm.set_state(IStructuredConfig, ConfigAppliedState(config=_to_dict(self._config)))
+
+
+__all__ = ["DummyStructuredConfig", "DummyStructuredConfigData", "DummyNestedConfig", "DummyOperatingMode"]

--- a/tests/modules/utils/test_dummystructuredconfig.py
+++ b/tests/modules/utils/test_dummystructuredconfig.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pyobs.comm import Comm
+from pyobs.interfaces import IStructuredConfig
+from pyobs.modules import Module
+from pyobs.modules.utils.dummystructuredconfig import (
+    DummyNestedConfig,
+    DummyOperatingMode,
+    DummyStructuredConfig,
+    DummyStructuredConfigData,
+)
+
+
+def _state_for(mock: AsyncMock, interface: object) -> object:
+    """Find the most recent state object set_state() was called with for the given interface."""
+    for call in reversed(mock.await_args_list):
+        if call.args[0] is interface:
+            return call.args[1]
+    raise AssertionError(f"set_state was never called with {interface}")
+
+
+def make_module(**kwargs) -> DummyStructuredConfig:
+    comm = MagicMock(spec=Comm)
+    return DummyStructuredConfig(comm=comm, **kwargs)
+
+
+# ── __init__ ────────────────────────────────────────────────────────────────
+
+
+def test_init_default_config() -> None:
+    m = make_module()
+    assert m._config == DummyStructuredConfigData()
+
+
+# ── open ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_open_publishes_capabilities_and_state(mocker) -> None:
+    m = make_module()
+    m._comm.set_capabilities = AsyncMock()
+    m._comm.set_state = AsyncMock()
+    mocker.patch.object(Module, "open", AsyncMock())
+
+    await m.open()
+
+    m._comm.set_capabilities.assert_awaited_once()
+    interface, schema = m._comm.set_capabilities.await_args[0]
+    assert interface is IStructuredConfig
+    assert schema.fields["name"].type == "str"
+    assert schema.fields["count"].type == "int"
+    assert schema.fields["offset"].type == "float"
+    assert schema.fields["offset"].unit is not None
+    assert schema.fields["verbose"].type == "bool"
+    assert schema.fields["mode"].type == "enum"
+    assert schema.fields["mode"].options == ["track", "park", "slew"]
+    assert schema.fields["nested"].type == "object"
+    assert schema.fields["nested"].nested is not None
+    assert schema.fields["nested"].nested["threshold"].type == "int"
+
+    state = _state_for(m._comm.set_state, IStructuredConfig)
+    assert state.config == {
+        "name": "dummy",
+        "count": 1,
+        "offset": 0.0,
+        "verbose": False,
+        "mode": "track",
+        "nested": {"label": "nested", "threshold": 5, "active": True},
+    }
+
+
+# ── set_config ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_config_applies_and_publishes_state() -> None:
+    m = make_module()
+    m._comm.set_state = AsyncMock()
+
+    await m.set_config(
+        {
+            "name": "renamed",
+            "count": 7,
+            "offset": 12.5,
+            "verbose": True,
+            "mode": "slew",
+            "nested": {"label": "sub", "threshold": 42, "active": False},
+        }
+    )
+
+    assert m._config == DummyStructuredConfigData(
+        name="renamed",
+        count=7,
+        offset=12.5,
+        verbose=True,
+        mode=DummyOperatingMode.SLEW,
+        nested=DummyNestedConfig(label="sub", threshold=42, active=False),
+    )
+
+    state = _state_for(m._comm.set_state, IStructuredConfig)
+    assert state.config["name"] == "renamed"
+    assert state.config["mode"] == "slew"
+    assert state.config["nested"] == {"label": "sub", "threshold": 42, "active": False}
+
+
+@pytest.mark.asyncio
+async def test_set_config_partial_update_keeps_other_fields_at_default() -> None:
+    m = make_module()
+    m._comm.set_state = AsyncMock()
+
+    await m.set_config({"count": 99})
+
+    assert m._config.count == 99
+    assert m._config.name == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_set_config_int_accepts_float_with_whole_value() -> None:
+    m = make_module()
+    m._comm.set_state = AsyncMock()
+
+    await m.set_config({"offset": 3})
+
+    assert m._config.offset == 3.0
+    assert isinstance(m._config.offset, float)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_config",
+    [
+        {"bogus_field": 1},
+        {"count": "not-an-int"},
+        {"count": True},
+        {"mode": "not-a-real-mode"},
+        {"nested": "not-a-dict"},
+        {"nested": {"threshold": "not-an-int"}},
+    ],
+)
+async def test_set_config_raises_value_error_on_mismatch(bad_config) -> None:
+    m = make_module()
+    m._comm.set_state = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await m.set_config(bad_config)
+
+    # rejected config must not have been partially applied
+    assert m._config == DummyStructuredConfigData()
+    m._comm.set_state.assert_not_awaited()


### PR DESCRIPTION
## Summary

Nothing in pyobs-core implements `IStructuredConfig` today — the only consumer anywhere is
pyobs-iagvt's FTS module (`pyobs_iagvt/modules/fts.py`), which isn't available in a
headless/dummy-fleet dev setup. This adds a dummy module purely so the in-progress pyobs-gui
`StructuredConfigWidget` (pyobs-gui#154) has something to manually run against and verify — the
same gap already left `PR pyobs-gui#157`'s manual-smoke-test checkbox unchecked ("headless, no
live fleet").

`pyobs/modules/utils/dummystructuredconfig.py` — `DummyStructuredConfig(Module, IStructuredConfig)`,
config dataclass covering every `ConfigFieldSchema` type at least once:

| Field | Type | Schema `type` |
|---|---|---|
| `name` | `str` | `str` |
| `count` | `int` | `int` |
| `offset` | `Annotated[float, Unit.ARCSEC]` | `float` (with `unit`) |
| `verbose` | `bool` | `bool` |
| `mode` | `DummyOperatingMode` (real `enum.Enum`: `track`/`park`/`slew`) | `enum` |
| `nested` | `DummyNestedConfig` (str/int/bool sub-dataclass) | `object` w/ `nested` |

`capabilities` is published via `dataclass_to_schema(DummyStructuredConfigData)` on `open()`
(mirroring how e.g. `DummyMode` publishes `ModeCapabilities`); `set_config()` deserializes the
incoming nested dict via a small recursive `_from_dict` helper (rejecting unknown fields, wrong
types, and invalid enum values with `ValueError`, per the interface's documented contract) and
republishes a fresh `ConfigAppliedState`.

No demo/dummy-fleet YAML config exists anywhere in this repo to add an entry to — skipped per
scope (didn't invent a new fleet-config mechanism).

## Test plan

- [x] `black --check` clean
- [x] `ruff check` clean
- [x] `pyrefly check` on the touched source files: 0 errors (the repo's `pyrefly.toml` only
      includes `pyobs/`, not `tests/` — consistent with existing test files like
      `test_dummymode.py`, which also isn't pyrefly-clean when force-checked directly)
- [x] `pytest -q`: 1741 passed, 25 skipped, 1 pre-existing unrelated failure
      (`tests/mixins/test_fitsheader.py::test_add_fits_headers_adds_frame_number_when_enabled`,
      a `PermissionError` writing to `/opt/pyobs/storage/modules/...` — reproduces identically on
      `develop` with this branch's changes stashed out, so unrelated to this PR)
- [x] New tests in `tests/modules/utils/test_dummystructuredconfig.py`: capabilities schema shape,
      `set_config` apply + state publish, partial updates, int-accepts-whole-float coercion, and
      `ValueError` on unknown field / wrong type / bad enum value / non-dict nested value (config
      left unmodified and no state published on rejection)

Supports pyobs-gui#154 (does not close it — different repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)