### PR TITLE
Per-exposure-time dark masters, reference-master scale-down only (#832)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,22 @@
 v2.1.1.dev1 (2026-08-31)
 *************************
+* Issue #832: ``Calibration``/``Reduction`` now match dark masters to a science frame's
+  ``EXPTIME`` instead of always scaling whatever dark master ``find_master`` happened to return
+  (see ADR ``0015-dark-master-strict-exptime-matching-reference-scale-down-only.md``). An exact
+  exptime match (within ``dark_exptime_tolerance``, default 1%) is used unscaled; below
+  ``dark_min_exptime`` (default 5s) with no exact match, calibration falls back to bias-only; a
+  reference master (``dark_scale_exptime``, default 600s) is scaled down to shorter science
+  exptimes but never scaled up.
+
+  **Behavior change, upgrade check required:** a site that takes darks at only one exptime and
+  previously relied on always-scale-whatever's-nearest now fails calibration (a caught,
+  catchable ``ValueError``, logged and returned uncalibrated -- not a crash) for any science
+  exptime longer than its one master, or with no reference configured. Set
+  ``allow_unmatched_dark_scale=True`` to keep today's behavior, or take darks at more than one
+  exptime (``DarkBiasScript``'s ``exptimes``/``match_science_exptimes``, issue #831) so exact
+  matches exist. ``Reduction``'s master-calibration-frame filename pattern also gained an
+  exposure-time component (``{EXPTIME|exptime}``, shared by BIAS/SKYFLAT too); existing archives
+  keep their old-pattern masters under their original filenames.
 * Fixes issue #830: ``http_request_with_retries`` no longer logs a WARNING on every failed retry
   attempt. Retries now stay quiet for the first 60s a URL has been failing (covering a typical
   short pyobs-portal restart), then warn at most once per minute until the request succeeds again.

--- a/pyobs/images/processors/calibration/_calibration_cache.py
+++ b/pyobs/images/processors/calibration/_calibration_cache.py
@@ -11,27 +11,33 @@ class _CalibrationCache:
     BINNING_FORMAT = "{0}x{0}"
 
     def __init__(self, max_size: int):
-        self._cache: deque[tuple[tuple[ImageType, str, str, str | None], Image]] = deque([], max_size)
+        self._cache: deque[tuple[tuple[ImageType, str, str, str | None, float | None], Image]] = deque([], max_size)
 
-    def add_to_cache(self, image: Image, image_type: ImageType) -> None:
-        cache_keys = self._get_cache_keys(image, image_type)
+    def add_to_cache(self, image: Image, image_type: ImageType, exptime: float | None = None) -> None:
+        cache_keys = self._get_cache_keys(image, image_type, exptime)
         cache_entry = (cache_keys, image)
         self._cache.append(cache_entry)
 
-    def get_from_cache(self, image: Image, image_type: ImageType) -> Image:
-        cache_keys = self._get_cache_keys(image, image_type)
+    def get_from_cache(self, image: Image, image_type: ImageType, exptime: float | None = None) -> Image:
+        cache_keys = self._get_cache_keys(image, image_type, exptime)
         return self._find_cache_entry(cache_keys)
 
-    def _find_cache_entry(self, keys: tuple[ImageType, str, str, str | None]) -> Image:
+    def _find_cache_entry(self, keys: tuple[ImageType, str, str, str | None, float | None]) -> Image:
         for m, item in self._cache:
             if m == keys:
                 return item
 
         raise ValueError("Calibration not found in cache.")
 
-    def _get_cache_keys(self, image: Image, image_type: ImageType) -> tuple[ImageType, str, str, str | None]:
+    def _get_cache_keys(
+        self, image: Image, image_type: ImageType, exptime: float | None = None
+    ) -> tuple[ImageType, str, str, str | None, float | None]:
         instrument, binning, filter_name = self._get_image_cache_keys(image)
-        cache_keys = (image_type, instrument, binning, filter_name)
+        # exptime is not derived from `image`'s own header: for DARK, callers pass the exptime
+        # they searched for (the science exptime for an exact match, or the configured
+        # reference exptime for a scale-down lookup), which generally differs from either the
+        # science image's or the master's own EXPTIME. None for BIAS/SKYFLAT, unchanged.
+        cache_keys = (image_type, instrument, binning, filter_name, exptime)
 
         return cache_keys
 

--- a/pyobs/images/processors/calibration/_calibration_cache.py
+++ b/pyobs/images/processors/calibration/_calibration_cache.py
@@ -33,6 +33,14 @@ class _CalibrationCache:
         self, image: Image, image_type: ImageType, exptime: float | None = None
     ) -> tuple[ImageType, str, str, str | None, float | None]:
         instrument, binning, filter_name = self._get_image_cache_keys(image)
+        if image_type in (ImageType.BIAS, ImageType.DARK):
+            # BIAS/DARK lookups ignore filter (matching Calibration._find_master_in_archive,
+            # which never passes a science image's FILTER to Pipeline.find_master for these two
+            # types). Deriving filter_name from whichever image was passed -- the science image
+            # on a get, the master on an add -- would otherwise near-guarantee a cache miss:
+            # a master dark/bias frequently has no FILTER header at all (or a stale one from
+            # whatever was mounted at the time) while the science image usually does.
+            filter_name = None
         # exptime is not derived from `image`'s own header: for DARK, callers pass the exptime
         # they searched for (the science exptime for an exact match, or the configured
         # reference exptime for a scale-down lookup), which generally differs from either the

--- a/pyobs/images/processors/calibration/_ccddata_calibrator.py
+++ b/pyobs/images/processors/calibration/_ccddata_calibrator.py
@@ -30,7 +30,10 @@ class _CCDDataCalibrator:
 
         self._ccd_data = self._image.to_ccddata()
 
-        if dark is not None:
+        # only read EXPTIME when it's actually needed -- an unscaled exact-match dark
+        # (dark_scale=False) doesn't require it, and a legacy master combined from raw frames
+        # with no EXPTIME at all (see Reduction._create_master_darks' fallback) doesn't have it
+        if dark is not None and dark_scale:
             self._dark_exp_time = dark.header["EXPTIME"]
 
     @staticmethod

--- a/pyobs/images/processors/calibration/_ccddata_calibrator.py
+++ b/pyobs/images/processors/calibration/_ccddata_calibrator.py
@@ -7,7 +7,14 @@ from pyobs.images import Image
 
 
 class _CCDDataCalibrator:
-    def __init__(self, image: Image, bias: Image | None = None, dark: Image | None = None, flat: Image | None = None):
+    def __init__(
+        self,
+        image: Image,
+        bias: Image | None = None,
+        dark: Image | None = None,
+        flat: Image | None = None,
+        dark_scale: bool = True,
+    ):
         # to_ccddata() below never carries a catalog through anyway, so drop it before trim() to
         # avoid its stale-catalog guard rejecting an image whose catalog wouldn't survive regardless.
         if image.safe_catalog is not None:
@@ -17,6 +24,9 @@ class _CCDDataCalibrator:
         self._bias = self._optional_to_ccddata(bias)
         self._dark = self._optional_to_ccddata(dark)
         self._flat = self._optional_to_ccddata(flat)
+        # whether ccd_process() should rescale the dark to the science exptime -- False for an
+        # exact exptime-match master, which is used as-is (see Calibration._find_dark_master).
+        self._dark_scale = dark_scale
 
         self._ccd_data = self._image.to_ccddata()
 
@@ -47,8 +57,8 @@ class _CCDDataCalibrator:
             bad_pixel_mask=None,
             gain=self._image.header["DET-GAIN"] * u.electron / u.adu,
             readnoise=self._image.header["DET-RON"] * u.electron,
-            dark_exposure=self._dark_exp_time * u.second if self._dark is not None else None,
+            dark_exposure=self._dark_exp_time * u.second if (self._dark is not None and self._dark_scale) else None,
             data_exposure=self._image.header["EXPTIME"] * u.second,
-            dark_scale=True,
+            dark_scale=self._dark_scale,
             gain_corrected=False,
         )

--- a/pyobs/images/processors/calibration/calibration.py
+++ b/pyobs/images/processors/calibration/calibration.py
@@ -284,7 +284,12 @@ class Calibration(ImageProcessor):
         if self._dark_min_exptime is not None and science_exptime < self._dark_min_exptime:
             return None, False
 
-        # (3) reference master, scaled down only (never up)
+        # (3) reference master, scaled down only (never up). The tolerance band means a science
+        # exptime up to ~dark_scale_exptime*(1+tolerance) is accepted here even though it's
+        # technically above the reference -- and _find_dark_at's own exptime_max ceiling for the
+        # reference lookup uses the same band, so the master found is never more than that
+        # ~1% above dark_scale_exptime either. Never scales *up* in practice; the band is a
+        # deliberate width-of-a-hair looseness, not a policy hole.
         if self._dark_scale_exptime is not None and science_exptime <= self._dark_scale_exptime * (
             1 + self._dark_exptime_tolerance
         ):
@@ -300,15 +305,34 @@ class Calibration(ImageProcessor):
             return fallback, True
 
         # (5) strict -- no usable dark master under the configured policy
+        ceiling = (
+            None if self._dark_scale_exptime is None else self._dark_scale_exptime * (1 + self._dark_exptime_tolerance)
+        )
+        available = await self._available_dark_exptimes(image)
         raise ValueError(
             f"No usable dark master for EXPTIME={science_exptime}s (no exact match within "
             f"{self._dark_exptime_tolerance:.0%}"
             + (
-                f", no reference master <= {self._dark_scale_exptime}s to scale down)."
-                if self._dark_scale_exptime is not None
-                else ", no reference exptime configured)."
+                f", no reference master <= {ceiling:.1f}s to scale down"
+                if ceiling is not None
+                else ", no reference exptime configured"
             )
+            + f"); available master exptimes: {available if available else 'none'}."
         )
+
+    async def _available_dark_exptimes(self, image: Image) -> list[float]:
+        """Best-effort list of exptimes among this instrument/binning's archived DARK masters,
+        for the strict-policy error message only (ADR 0015 asks that it name what's available).
+        Never raises -- an archive issue here shouldn't mask the real ValueError being raised."""
+        try:
+            instrument = image.header["INSTRUME"]
+            binning = "{0}x{0}".format(image.header["XBINNING"])  # noqa: UP031
+            infos = await self._archive.list_frames(
+                instrument=instrument, image_type=ImageType.DARK, binning=binning, rlevel=1
+            )
+        except Exception:
+            return []
+        return sorted({i.exptime for i in infos if i.exptime is not None})
 
     async def _find_dark_at(
         self, image: Image, target_exptime: float, max_days: float | None, exptime_max: float | None = None
@@ -356,10 +380,12 @@ class Calibration(ImageProcessor):
         if master is None:
             return None
 
-        if exptime_max is None and not exptimes_close(
-            float(master.header["EXPTIME"]), target_exptime, self._dark_exptime_tolerance
+        if exptime_max is None and (
+            "EXPTIME" not in master.header
+            or not exptimes_close(float(master.header["EXPTIME"]), target_exptime, self._dark_exptime_tolerance)
         ):
-            # nearest available, but not actually an exact match -- not usable for this lookup
+            # nearest available, but not actually an exact match (or a legacy pre-#831 master
+            # with no EXPTIME header at all) -- not usable for this lookup
             return None
 
         self._calib_cache.add_to_cache(master, ImageType.DARK, exptime=target_exptime)

--- a/pyobs/images/processors/calibration/calibration.py
+++ b/pyobs/images/processors/calibration/calibration.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
+import astropy.units as u
+
 from pyobs.images import Image
 from pyobs.images.processor import ImageProcessor
 from pyobs.images.processors.calibration._calibration_cache import _CalibrationCache
@@ -256,9 +258,13 @@ class Calibration(ImageProcessor):
         1. An exact match (within dark_exptime_tolerance) -- used unscaled.
         2. No exact match and EXPTIME < dark_min_exptime -- bias-only, not an error.
         3. No exact match, EXPTIME >= dark_min_exptime, and a reference master with
-           EXPTIME <= dark_scale_exptime exists -- used scaled down to the science exptime.
+           EXPTIME <= dark_scale_exptime *and* EXPTIME >= science_exptime exists -- used
+           scaled down to the science exptime. The second condition is what actually
+           enforces "scaled down only": without it, a site whose longest master happens to be
+           shorter than the science exptime would otherwise get that master scaled *up*.
         4. allow_unmatched_dark_scale=True -- fall back to today's always-scale-whatever-is-
-           nearest behavior.
+           nearest behavior. A candidate with no EXPTIME at all (a legacy master) can't be
+           scaled either way, so it's used unscaled (dark_scale=False) rather than skipped.
         5. Otherwise -- ValueError, caught by __call__ like any other missing-master case.
 
         Returns:
@@ -284,25 +290,27 @@ class Calibration(ImageProcessor):
         if self._dark_min_exptime is not None and science_exptime < self._dark_min_exptime:
             return None, False
 
-        # (3) reference master, scaled down only (never up). The tolerance band means a science
-        # exptime up to ~dark_scale_exptime*(1+tolerance) is accepted here even though it's
-        # technically above the reference -- and _find_dark_at's own exptime_max ceiling for the
-        # reference lookup uses the same band, so the master found is never more than that
-        # ~1% above dark_scale_exptime either. Never scales *up* in practice; the band is a
-        # deliberate width-of-a-hair looseness, not a policy hole.
+        # (3) reference master, scaled down only (never up). exptime_max=dark_scale_exptime only
+        # bounds the reference search from above; a site with no master anywhere near
+        # dark_scale_exptime (e.g. only a 45s one) could otherwise get that shorter master back
+        # as the "reference" and have it scaled UP to a longer science exptime -- exactly the
+        # direction ADR 0015 forbids. Guard against that explicitly: reject a candidate whose
+        # own exptime doesn't cover science_exptime (within tolerance), falling through instead.
         if self._dark_scale_exptime is not None and science_exptime <= self._dark_scale_exptime * (
             1 + self._dark_exptime_tolerance
         ):
             reference = await self._find_dark_at(
                 image, self._dark_scale_exptime, self._max_days_dark, exptime_max=self._dark_scale_exptime
             )
-            if reference is not None:
+            if reference is not None and self._covers_scale_down(reference, science_exptime):
                 return reference, True
 
         # (4) opt back into today's always-scale-whatever-is-nearest behavior
         if self._allow_unmatched_dark_scale:
             fallback = await self._find_master(image, ImageType.DARK, max_days=self._max_days_dark)
-            return fallback, True
+            # a legacy master with no EXPTIME at all can't be scaled -- ccd_process needs the
+            # dark's own exposure time to compute the scale factor (see _CCDDataCalibrator)
+            return fallback, "EXPTIME" in fallback.header
 
         # (5) strict -- no usable dark master under the configured policy
         ceiling = (
@@ -320,15 +328,34 @@ class Calibration(ImageProcessor):
             + f"); available master exptimes: {available if available else 'none'}."
         )
 
+    def _covers_scale_down(self, reference: Image, science_exptime: float) -> bool:
+        """Whether `reference`'s own exptime is long enough to be scaled *down* to
+        science_exptime -- ADR 0015 forbids the reverse. False (not usable as a reference) for
+        a master shorter than science_exptime, or one with no EXPTIME to check at all (a legacy
+        master -- direction can't be verified, so it's rejected rather than assumed safe)."""
+        if "EXPTIME" not in reference.header:
+            return False
+        return float(reference.header["EXPTIME"]) >= science_exptime * (1 - self._dark_exptime_tolerance)
+
     async def _available_dark_exptimes(self, image: Image) -> list[float]:
-        """Best-effort list of exptimes among this instrument/binning's archived DARK masters,
-        for the strict-policy error message only (ADR 0015 asks that it name what's available).
-        Never raises -- an archive issue here shouldn't mask the real ValueError being raised."""
+        """Best-effort list of exptimes among this instrument/binning's archived DARK masters
+        near the science image's DATE-OBS, for the strict-policy error message only (ADR 0015
+        asks that it name what's available). Bounded to max_days_dark (falling back to a wide
+        30-day window if unset) so this doesn't scan an archive's entire DARK history on every
+        strict-failure frame. Never raises -- an archive issue here shouldn't mask the real
+        ValueError being raised."""
         try:
             instrument = image.header["INSTRUME"]
             binning = "{0}x{0}".format(image.header["XBINNING"])  # noqa: UP031
+            time = Time(image.header["DATE-OBS"])
+            max_days = self._max_days_dark if self._max_days_dark is not None else 30.0
             infos = await self._archive.list_frames(
-                instrument=instrument, image_type=ImageType.DARK, binning=binning, rlevel=1
+                start=time - max_days * u.day,
+                end=time + max_days * u.day,
+                instrument=instrument,
+                image_type=ImageType.DARK,
+                binning=binning,
+                rlevel=1,
             )
         except Exception:
             return []

--- a/pyobs/images/processors/calibration/calibration.py
+++ b/pyobs/images/processors/calibration/calibration.py
@@ -9,6 +9,7 @@ from pyobs.images.processors.calibration._calibration_cache import _CalibrationC
 from pyobs.images.processors.calibration._ccddata_calibrator import _CCDDataCalibrator
 from pyobs.robotic.utils.archive import Archive
 from pyobs.utils.enums import ImageType
+from pyobs.utils.exptime_grouping import exptimes_close
 from pyobs.utils.pipeline import Pipeline
 from pyobs.utils.time import Time
 
@@ -51,6 +52,25 @@ class Calibration(ImageProcessor):
                                        Default: ``None``.
     :param float | None max_days_flat: Same as ``max_days_bias`` for flat frames.
                                        Default: ``None``.
+    :param float dark_exptime_tolerance: Relative tolerance for matching a science frame's
+                                         ``EXPTIME`` against a dark master's, and for the
+                                         scale-down-only ceiling around ``dark_scale_exptime``.
+                                         Default: ``0.01`` (1%).
+    :param float | None dark_scale_exptime: Reference dark exposure time (seconds) that may be
+                                            scaled down to a shorter science exptime when no
+                                            exact-exptime master exists. ``None`` disables
+                                            scale-down entirely (branch 3 below never fires).
+                                            Default: ``600.0``.
+    :param bool allow_unmatched_dark_scale: If ``True``, a science exptime with neither an
+                                            exact-match master nor a usable reference master
+                                            falls back to today's always-scale-whatever-is-
+                                            nearest behavior instead of raising. For sites not
+                                            yet taking per-exptime darks. Default: ``False``.
+    :param float | None dark_min_exptime: Science exptimes below this (and with no exact-match
+                                          master) skip dark subtraction entirely and are
+                                          calibrated with bias only -- dark current is assumed
+                                          negligible there. ``None`` or ``0`` disables this
+                                          branch. Default: ``5.0``.
     :param kwargs: Additional keyword arguments forwarded to
                    :class:`pyobs.images.processor.ImageProcessor`.
 
@@ -66,6 +86,20 @@ class Calibration(ImageProcessor):
       - Binning: string formatted as ``"{XBINNING}x{XBINNING}"`` (square binning assumed).
       - Filter: ``FILTER`` only for flats; biases and darks ignore filter.
       - Time constraint: centered on the image ``DATE-OBS`` with optional ``max_days_*``.
+
+    - Dark matching additionally follows ADR
+      ``0015-dark-master-strict-exptime-matching-reference-scale-down-only.md``, checked in
+      order against the science frame's own ``EXPTIME``:
+
+      1. An exact match (within ``dark_exptime_tolerance``) is used unscaled.
+      2. No exact match and ``EXPTIME < dark_min_exptime``: bias-only, no dark subtraction,
+         not an error.
+      3. No exact match, ``EXPTIME >= dark_min_exptime``, and a reference master with
+         ``EXPTIME <= dark_scale_exptime`` exists: used scaled down to the science exptime.
+      4. ``allow_unmatched_dark_scale=True``: fall back to whatever ``find_master`` returns,
+         scaled, regardless of direction (today's behavior).
+      5. Otherwise: a ``ValueError`` naming the requested exptime, caught the same way as any
+         other missing-master case (see below).
 
     - If any required master is missing, logs a warning and returns the original image
       unchanged.
@@ -144,6 +178,10 @@ class Calibration(ImageProcessor):
         max_days_bias: float | None = None,
         max_days_dark: float | None = None,
         max_days_flat: float | None = None,
+        dark_exptime_tolerance: float = 0.01,
+        dark_scale_exptime: float | None = 600.0,
+        allow_unmatched_dark_scale: bool = False,
+        dark_min_exptime: float | None = 5.0,
         **kwargs: Any,
     ):
         """Init a new image calibration pipeline step.
@@ -160,6 +198,10 @@ class Calibration(ImageProcessor):
         self._require_bias = require_bias
         self._require_dark = require_dark
         self._require_flat = require_flat
+        self._dark_exptime_tolerance = dark_exptime_tolerance
+        self._dark_scale_exptime = dark_scale_exptime
+        self._allow_unmatched_dark_scale = allow_unmatched_dark_scale
+        self._dark_min_exptime = dark_min_exptime
 
         self._archive = self.pyobs_model_validate(Archive, archive)
 
@@ -177,12 +219,12 @@ class Calibration(ImageProcessor):
         """
 
         try:
-            bias, dark, flat = await self._get_calibrations_masters(image)
+            bias, dark, flat, dark_scale = await self._get_calibrations_masters(image)
         except ValueError as e:
             log.warning("Could not find calibration frames: %s", e)
             return image
 
-        calibrator = _CCDDataCalibrator(image, bias, dark, flat)
+        calibrator = _CCDDataCalibrator(image, bias, dark, flat, dark_scale=dark_scale)
         calibrated = calibrator()
 
         self._copy_original_filename(calibrated, image)
@@ -192,24 +234,136 @@ class Calibration(ImageProcessor):
 
         return calibrated
 
-    async def _get_calibrations_masters(self, image: Image) -> tuple[Image | None, Image | None, Image | None]:
+    async def _get_calibrations_masters(self, image: Image) -> tuple[Image | None, Image | None, Image | None, bool]:
         bias = (
             None
             if not self._require_bias
             else await self._find_master(image, ImageType.BIAS, max_days=self._max_days_bias)
         )
-        dark = (
-            None
-            if not self._require_dark
-            else await self._find_master(image, ImageType.DARK, max_days=self._max_days_dark)
-        )
+        dark, dark_scale = await self._find_dark_master(image)
         flat = (
             None
             if not self._require_flat
             else await self._find_master(image, ImageType.SKYFLAT, max_days=self._max_days_flat)
         )
 
-        return bias, dark, flat
+        return bias, dark, flat, dark_scale
+
+    async def _find_dark_master(self, image: Image) -> tuple[Image | None, bool]:
+        """Implements ADR 0015's dark-master matching/scaling policy, checked in order against
+        the science image's own EXPTIME:
+
+        1. An exact match (within dark_exptime_tolerance) -- used unscaled.
+        2. No exact match and EXPTIME < dark_min_exptime -- bias-only, not an error.
+        3. No exact match, EXPTIME >= dark_min_exptime, and a reference master with
+           EXPTIME <= dark_scale_exptime exists -- used scaled down to the science exptime.
+        4. allow_unmatched_dark_scale=True -- fall back to today's always-scale-whatever-is-
+           nearest behavior.
+        5. Otherwise -- ValueError, caught by __call__ like any other missing-master case.
+
+        Returns:
+            (master, scale). master is None only for the legitimate bias-only branch (2), or
+            when require_dark is False. scale tells the caller whether _CCDDataCalibrator
+            should rescale the returned master to the science exptime.
+
+        Raises:
+            ValueError: no usable dark master under the configured policy (branch 5).
+        """
+        if not self._require_dark:
+            return None, False
+
+        self._verify_image_header(image)
+        science_exptime = float(image.header["EXPTIME"])
+
+        # (1) exact match, used unscaled
+        exact = await self._find_dark_at(image, science_exptime, self._max_days_dark)
+        if exact is not None:
+            return exact, False
+
+        # (2) below the minimum, no exact match -- bias-only, not an error
+        if self._dark_min_exptime is not None and science_exptime < self._dark_min_exptime:
+            return None, False
+
+        # (3) reference master, scaled down only (never up)
+        if self._dark_scale_exptime is not None and science_exptime <= self._dark_scale_exptime * (
+            1 + self._dark_exptime_tolerance
+        ):
+            reference = await self._find_dark_at(
+                image, self._dark_scale_exptime, self._max_days_dark, exptime_max=self._dark_scale_exptime
+            )
+            if reference is not None:
+                return reference, True
+
+        # (4) opt back into today's always-scale-whatever-is-nearest behavior
+        if self._allow_unmatched_dark_scale:
+            fallback = await self._find_master(image, ImageType.DARK, max_days=self._max_days_dark)
+            return fallback, True
+
+        # (5) strict -- no usable dark master under the configured policy
+        raise ValueError(
+            f"No usable dark master for EXPTIME={science_exptime}s (no exact match within "
+            f"{self._dark_exptime_tolerance:.0%}"
+            + (
+                f", no reference master <= {self._dark_scale_exptime}s to scale down)."
+                if self._dark_scale_exptime is not None
+                else ", no reference exptime configured)."
+            )
+        )
+
+    async def _find_dark_at(
+        self, image: Image, target_exptime: float, max_days: float | None, exptime_max: float | None = None
+    ) -> Image | None:
+        """Looks up a DARK master near target_exptime via the shared calibration cache, keyed
+        by that target rather than either image's own EXPTIME (see _CalibrationCache), falling
+        back to an archive query on a cache miss.
+
+        Args:
+            target_exptime: Exptime to search near -- the science exptime for an exact-match
+                lookup, or dark_scale_exptime for a reference lookup.
+            exptime_max: If given, only accept candidates with EXPTIME <= this (scale-down-only
+                enforcement); the result is otherwise accepted whatever its exptime. If not
+                given, this is an exact-match lookup: the result is discarded (returns None)
+                unless it's actually within dark_exptime_tolerance of target_exptime.
+
+        Returns:
+            The master, or None if nothing usable was found. Never raises.
+        """
+        if self._calib_cache is None:
+            return None
+
+        try:
+            return self._calib_cache.get_from_cache(image, ImageType.DARK, exptime=target_exptime)
+        except ValueError:
+            pass
+
+        self._verify_image_header(image)
+        instrument = image.header["INSTRUME"]
+        binning = "{0}x{0}".format(image.header["XBINNING"])  # noqa: UP031
+        time = Time(image.header["DATE-OBS"])
+
+        master = await Pipeline.find_master(
+            self._archive,
+            ImageType.DARK,
+            time,
+            instrument,
+            binning,
+            None,
+            max_days=max_days,
+            exptime=target_exptime,
+            exptime_tolerance=self._dark_exptime_tolerance,
+            exptime_max=exptime_max,
+        )
+        if master is None:
+            return None
+
+        if exptime_max is None and not exptimes_close(
+            float(master.header["EXPTIME"]), target_exptime, self._dark_exptime_tolerance
+        ):
+            # nearest available, but not actually an exact match -- not usable for this lookup
+            return None
+
+        self._calib_cache.add_to_cache(master, ImageType.DARK, exptime=target_exptime)
+        return master
 
     async def _find_master(self, image: Image, image_type: ImageType, max_days: float | None = None) -> Image:
         """Find master calibration frame for given parameters using a cache.
@@ -241,8 +395,12 @@ class Calibration(ImageProcessor):
         has_instrument = "INSTRUME" in image.header
         has_binning = "XBINNING" in image.header
         has_time = "DATE-OBS" in image.header
+        # EXPTIME is needed by dark-exptime matching (_find_dark_master) and was already an
+        # implicit requirement of _CCDDataCalibrator itself (data_exposure=...EXPTIME...) --
+        # checked upfront here instead of surfacing as a bare KeyError mid-calibration.
+        has_exptime = "EXPTIME" in image.header
 
-        if not (has_instrument and has_binning and has_time):
+        if not (has_instrument and has_binning and has_time and has_exptime):
             raise ValueError("Could not fetch items from image header.")
 
     async def _find_master_in_archive(

--- a/pyobs/robotic/utils/archive/local_archive.py
+++ b/pyobs/robotic/utils/archive/local_archive.py
@@ -185,7 +185,11 @@ class LocalArchive(Archive):
             info.filter_name = row["filter"]
             info.binning = row["binning"]
             info.dateobs = row["date-obs"]
-            info.exptime = row["exptime"]
+            # pandas silently coerces a None in a float64-dtype column (i.e. as soon as any
+            # row in this archive has a real EXPTIME) to NaN, not None -- normalize back so
+            # "no EXPTIME" is always exactly None for callers, never a NaN that compares
+            # unequal to everything including itself
+            info.exptime = None if pd.isna(row["exptime"]) else float(row["exptime"])
             infos.append(info)
         return infos
 

--- a/pyobs/utils/exptime_grouping.py
+++ b/pyobs/utils/exptime_grouping.py
@@ -1,14 +1,17 @@
 """Shared relative-tolerance exposure-time matching/grouping.
 
-Used by the archive's exptime filter (single-value tolerance match) and by
-science_exptimes_for_night's night-exptime grouping (bucketing many raw values);
-#832's per-exptime dark-master grouping reuses this rather than reimplementing it.
+Used by the archive's exptime filter (single-value tolerance match), by
+science_exptimes_for_night's night-exptime grouping (bucketing many raw values), and by
+Reduction's per-exptime dark-master grouping (bucketing raw dark frames, not bare floats).
 """
 
 from __future__ import annotations
 
 import statistics
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
 def exptimes_close(a: float, b: float, tolerance: float = 0.01) -> bool:
@@ -30,16 +33,39 @@ def exptimes_close(a: float, b: float, tolerance: float = 0.01) -> bool:
     return abs(a - b) <= tolerance * max(abs(a), abs(b))
 
 
+def group_by_exptime(items: Iterable[T], key: Callable[[T], float], tolerance: float = 0.01) -> list[list[T]]:
+    """Groups arbitrary items by an exptime-valued key within a relative tolerance.
+
+    A single left-to-right pass over the items sorted by key: each item joins the previous
+    group if its key is within tolerance of that group's current median key, else starts a new
+    group. This is not a transitive-closure/clustering guarantee -- e.g. grouping keys
+    [100.0, 100.9, 101.8] at 1% tolerance can split 100.9 and 101.8 into different groups even
+    though they're pairwise within tolerance, because the group's median drifts as items are
+    added. Fine for the discrete, well-separated exptimes real detectors actually use; a caller
+    that needs a stronger (union-find) grouping guarantee should not rely on this.
+
+    Args:
+        items: Items to group.
+        key: Extracts the exposure time (seconds) to group each item by.
+        tolerance: Relative tolerance for two items to belong to the same group.
+
+    Returns:
+        Groups of items, in ascending order of the group's median key. Each group preserves
+        the relative order its items had in the (key-sorted) input.
+    """
+    groups: list[list[T]] = []
+    for item in sorted(items, key=key):
+        if groups and exptimes_close(key(item), statistics.median(key(i) for i in groups[-1]), tolerance):
+            groups[-1].append(item)
+        else:
+            groups.append([item])
+    return groups
+
+
 def group_exptimes(values: Iterable[float], tolerance: float = 0.01) -> list[float]:
     """Collapses exposure times within a relative tolerance of each other into groups.
 
-    A single left-to-right pass over the sorted values: each value joins the previous group if
-    it's within tolerance of that group's current median, else starts a new group. This is not
-    a transitive-closure/clustering guarantee -- e.g. group_exptimes([100.0, 100.9, 101.8], 0.01)
-    can split 100.9 and 101.8 into different groups even though they're pairwise within
-    tolerance, because the group's median drifts as values are added. Fine for the discrete,
-    well-separated exptimes real detectors actually use; a caller that needs a stronger
-    (union-find) grouping guarantee should not rely on this.
+    See group_by_exptime for the grouping algorithm and its (non-transitive) guarantees.
 
     Args:
         values: Raw exposure times to group.
@@ -48,13 +74,7 @@ def group_exptimes(values: Iterable[float], tolerance: float = 0.01) -> list[flo
     Returns:
         One representative exptime (the group's median) per group, sorted ascending.
     """
-    groups: list[list[float]] = []
-    for value in sorted(values):
-        if groups and exptimes_close(value, statistics.median(groups[-1]), tolerance):
-            groups[-1].append(value)
-        else:
-            groups.append([value])
-    return [statistics.median(group) for group in groups]
+    return [statistics.median(group) for group in group_by_exptime(values, key=lambda v: v, tolerance=tolerance)]
 
 
-__all__ = ["exptimes_close", "group_exptimes"]
+__all__ = ["exptimes_close", "group_by_exptime", "group_exptimes"]

--- a/pyobs/utils/fits.py
+++ b/pyobs/utils/fits.py
@@ -296,6 +296,11 @@ class FilenameFormatter:
         """Formats an exposure time, rendering whole-second values without a trailing ".0"
         (e.g. 600.0 -> "600", 0.333 -> "0.333") so per-exptime master filenames stay readable.
 
+        Unlike the other format functions, a missing key renders as "unknown" rather than
+        raising -- a legacy dark master combined from raw frames that never carried EXPTIME at
+        all has no numeric value to render, and this placeholder lets filename formatting (and
+        therefore storing the master at all) still succeed for that master.
+
         Args:
             hdr: FITS header to take values from.
             key: The name of the FITS header key to use.
@@ -303,6 +308,8 @@ class FilenameFormatter:
         Returns:
             Formatted string.
         """
+        if key not in self.keys and key not in hdr:
+            return "unknown"
         value = float(self._value(hdr, key))
         return str(int(value)) if value == int(value) else str(value)
 

--- a/pyobs/utils/fits.py
+++ b/pyobs/utils/fits.py
@@ -95,6 +95,7 @@ class FilenameFormatter:
             "filter": self._format_filter,
             "string": self._format_string,
             "type": self._format_type,
+            "exptime": self._format_exptime,
         }
 
     def _value(self, hdr: fits.Header, key: str) -> int | float | str:
@@ -290,6 +291,20 @@ class FilenameFormatter:
             return "d"
         else:
             return "e"
+
+    def _format_exptime(self, hdr: fits.Header, key: str) -> str:
+        """Formats an exposure time, rendering whole-second values without a trailing ".0"
+        (e.g. 600.0 -> "600", 0.333 -> "0.333") so per-exptime master filenames stay readable.
+
+        Args:
+            hdr: FITS header to take values from.
+            key: The name of the FITS header key to use.
+
+        Returns:
+            Formatted string.
+        """
+        value = float(self._value(hdr, key))
+        return str(int(value)) if value == int(value) else str(value)
 
 
 def format_filename(hdr: fits.Header, fmt: str | list[str], keys: dict[str, Any] | None = None) -> str:

--- a/pyobs/utils/pipeline/pipeline.py
+++ b/pyobs/utils/pipeline/pipeline.py
@@ -168,6 +168,9 @@ class Pipeline(Object, PipelineMixin):
         binning: str,
         filter_name: str | None = None,
         max_days: float | None = 30.0,
+        exptime: float | None = None,
+        exptime_tolerance: float = 0.01,
+        exptime_max: float | None = None,
     ) -> Image | None:
         """Find and download master calibration frame.
 
@@ -179,6 +182,15 @@ class Pipeline(Object, PipelineMixin):
             binning: Used binning.
             filter_name: Used filter.
             max_days: Maximum number of days from DATE-OBS to find frames.
+            exptime: For DARK, prefer candidates close to this exposure time over ones merely
+                close in DATE-OBS -- an exptime match within exptime_tolerance always sorts
+                ahead of a non-matching one, regardless of how much closer in time the latter
+                is. Ignored for other image types, and if no candidate has exptime set.
+            exptime_tolerance: Relative tolerance used to rank exptime-closeness; see
+                pyobs.utils.exptime_grouping.exptimes_close.
+            exptime_max: For DARK, drop candidates whose exptime exceeds this (within
+                exptime_tolerance) before ranking -- used to enforce "reference master scales
+                down only" when exptime is a scale-down reference rather than an exact target.
 
         Returns:
             FrameInfo for master calibration frame or None.
@@ -207,8 +219,26 @@ class Pipeline(Object, PipelineMixin):
             log.warning("Could not find any matching %s calibration frames.", image_type)
             return None
 
-        # sort by diff to time and take first
-        s = sorted(infos, key=lambda i: abs((i.dateobs - time).sec))
+        # scale-down-only reference lookup: drop candidates longer than exptime_max upfront
+        if exptime_max is not None:
+            ceiling = exptime_max * (1 + exptime_tolerance)
+            infos = [i for i in infos if i.exptime is not None and i.exptime <= ceiling]
+            if not infos:
+                log.warning("Could not find any %s calibration frames with exptime <= %s.", image_type, exptime_max)
+                return None
+
+        # sort by diff to time, or -- for DARK with a target exptime -- by exptime-closeness
+        # first so an exptime match always wins over a merely time-close non-match
+        if exptime is not None and image_type == ImageType.DARK:
+            s = sorted(
+                infos,
+                key=lambda i: (
+                    float("inf") if i.exptime is None else abs(i.exptime - exptime),
+                    abs((i.dateobs - time).sec),
+                ),
+            )
+        else:
+            s = sorted(infos, key=lambda i: abs((i.dateobs - time).sec))
         info = s[0]
         log.info("Found %s frame %s.", image_type.name, info.filename)
 

--- a/pyobs/utils/pipeline/progress.py
+++ b/pyobs/utils/pipeline/progress.py
@@ -16,6 +16,9 @@ class MasterCalibCreated:
     binning: str
     filter_name: str | None
     filename: str
+    exptime: float | None = None
+    """The dark's exposure time in seconds, for a per-exptime DARK master. None for BIAS/SKYFLAT
+    and for a DARK master created before per-exptime grouping existed."""
 
 
 @dataclass

--- a/pyobs/utils/pipeline/reduction.py
+++ b/pyobs/utils/pipeline/reduction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import os.path
 import statistics
@@ -197,26 +198,45 @@ class Reduction(ReductionBase):
         (#831). Frame groups with fewer than 3 members are skipped individually with a
         warning, rather than aborting dark reduction for this instrument/binning entirely.
 
+        If none of the night's raw darks carry EXPTIME at all (a fully legacy instrument, as
+        opposed to a handful of untagged frames mixed in with tagged ones), grouping would
+        silently produce zero masters -- falls back to combining all of them into a single
+        untagged master instead, reproducing this method's pre-#832 behavior.
+
         Returns:
-            The master dark(s) created, longest exptime first.
+            The master dark(s) created, longest exptime first (the untagged legacy fallback,
+            if it fires, is always the only element).
         """
         infos = await self._archive.list_frames(
             night=night, image_type=ImageType.DARK, instrument=instrument, binning=binning, rlevel=0
         )
         log.info("Found %d %s DARK frames from instrument %s.", len(infos), binning, instrument)
-
-        usable = [i for i in infos if i.exptime is not None]
-        if len(usable) < len(infos):
-            log.warning("Dropping %d DARK frame(s) with no EXPTIME.", len(infos) - len(usable))
-        if not usable:
+        if not infos:
             return []
 
-        # longest-first, matching DarkBiasScript's own series order
-        groups = sorted(
-            group_by_exptime(usable, key=lambda i: i.exptime or 0.0, tolerance=self._dark_exptime_tolerance),
-            key=lambda group: statistics.median(i.exptime for i in group if i.exptime is not None),
-            reverse=True,
-        )
+        # not-a-number is defensively treated the same as None -- an Archive backed by a numeric
+        # column (e.g. pandas) can end up coercing a missing EXPTIME to NaN rather than None
+        usable = [i for i in infos if i.exptime is not None and not math.isnan(i.exptime)]
+        groups: list[tuple[list[FrameInfo], float | None]]
+        if not usable:
+            log.warning(
+                "None of the %d DARK frames for instrument %s, binning %s carry EXPTIME -- "
+                "creating one legacy (untagged) master instead of grouping by exptime.",
+                len(infos),
+                instrument,
+                binning,
+            )
+            groups = [(infos, None)]
+        else:
+            if len(usable) < len(infos):
+                log.warning("Dropping %d DARK frame(s) with no EXPTIME.", len(infos) - len(usable))
+            # longest-first, matching DarkBiasScript's own series order
+            by_exptime = sorted(
+                group_by_exptime(usable, key=lambda i: i.exptime or 0.0, tolerance=self._dark_exptime_tolerance),
+                key=lambda group: statistics.median(i.exptime for i in group if i.exptime is not None),
+                reverse=True,
+            )
+            groups = [(g, statistics.median(i.exptime for i in g if i.exptime is not None)) for g in by_exptime]
 
         bias = await self._find_master(night, ImageType.BIAS, instrument, binning, None)
         if bias is None:
@@ -224,26 +244,29 @@ class Reduction(ReductionBase):
             return []
 
         masters: list[Image] = []
-        for group in groups:
-            exptime = statistics.median(i.exptime for i in group if i.exptime is not None)
+        for group, exptime in groups:
+            label = "legacy (no exptime)" if exptime is None else f"~{exptime}s"
 
             if len(group) < 3:
-                log.warning("Too few (%d) dark frames at ~%ss, skipping...", len(group), exptime)
+                log.warning("Too few (%d) dark frames at %s, skipping...", len(group), label)
                 continue
 
             images = await self._archive.download_frames(group)
             if len(images) < 3:
-                log.warning("Too few (%d) dark frames at ~%ss, skipping...", len(images), exptime)
+                log.warning("Too few (%d) dark frames at %s, skipping...", len(images), label)
                 continue
 
             calib = await self._pipeline.create_master_dark(images, bias=bias)
             if calib is None:
-                log.warning("Could not create master dark at ~%ss.", exptime)
+                log.warning("Could not create master dark at %s.", label)
                 continue
 
-            # EXPTIME may or may not survive ccdproc's sigma-clip combine unchanged -- set it
-            # explicitly from the group's own value rather than trusting the combined header.
-            calib.header["EXPTIME"] = (exptime, "Exposure time [s]")
+            if exptime is not None:
+                # EXPTIME may or may not survive ccdproc's sigma-clip combine unchanged -- set
+                # it explicitly from the group's own value rather than trusting the combined
+                # header. The legacy fallback leaves it as whatever (if anything) the raw
+                # frames' own combined header carries -- there is no group value to set it to.
+                calib.header["EXPTIME"] = (exptime, "Exposure time [s]")
 
             self._master_frames[ImageType.DARK, instrument, binning, None, exptime] = calib
             await self._store_master_calib(calib, ImageType.DARK, instrument, binning, None, exptime)

--- a/pyobs/utils/pipeline/reduction.py
+++ b/pyobs/utils/pipeline/reduction.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 import os
 import os.path
+import statistics
 from typing import Any
 
 from pyobs.images import Image
 from pyobs.object import get_object
 from pyobs.robotic.utils.archive import Archive, FrameInfo
 from pyobs.utils.enums import ImageType
+from pyobs.utils.exptime_grouping import group_by_exptime
 from pyobs.utils.fits import FilenameFormatter
 
 from .pipeline import Pipeline
@@ -18,7 +20,15 @@ from .reduction_base import ReductionBase
 log = logging.getLogger(__name__)
 
 
-FILENAME = "{SITEID}{TELID}-{INSTRUME}-{DAY-OBS|date:}-{IMAGETYP}-{XBINNING}x{YBINNING}{FILTER|filter}.fits"
+# Includes an exptime component (rendered without a trailing ".0" -- see
+# FilenameFormatter._format_exptime) so per-exptime DARK masters (see #832) don't collide on
+# filename; harmless for BIAS/SKYFLAT, which each still produce a single master per
+# instrument/binning[/filter] as before. This changed the on-disk filename for every master
+# calibration frame, BIAS/SKYFLAT included -- existing archives keep their old-pattern masters
+# under their original filenames, but reduction runs from here on write the new pattern.
+FILENAME = (
+    "{SITEID}{TELID}-{INSTRUME}-{DAY-OBS|date:}-{IMAGETYP}-{EXPTIME|exptime}-{XBINNING}x{YBINNING}{FILTER|filter}.fits"
+)
 
 
 class Reduction(ReductionBase):
@@ -32,6 +42,7 @@ class Reduction(ReductionBase):
         create_calibs: bool = True,
         calib_science: bool = True,
         progress_callback: ProgressCallback | None = None,
+        dark_exptime_tolerance: float = 0.01,
     ):
         """Creates a Reduction object for reducing a given observation period.
 
@@ -46,6 +57,8 @@ class Reduction(ReductionBase):
             create_calibs: If False, no calibration files are created for night.
             calib_science: If False, no science frames are calibrated.
             progress_callback: See ReductionBase.
+            dark_exptime_tolerance: Relative tolerance for grouping a night's raw DARK frames
+                into per-exptime master series -- see pyobs.utils.exptime_grouping.
         """
         super().__init__(archive=archive, pipeline=pipeline, min_flats=min_flats, progress_callback=progress_callback)
 
@@ -55,6 +68,7 @@ class Reduction(ReductionBase):
         )
         self._create_calibs = create_calibs
         self._calib_science = calib_science
+        self._dark_exptime_tolerance = dark_exptime_tolerance
 
         # make sure the local output directory exists
         if self._store_local:
@@ -69,9 +83,48 @@ class Reduction(ReductionBase):
         self._frames_done = 0
         self._frames_total = 0
 
+    async def _store_master_calib(
+        self,
+        calib: Image,
+        image_type: ImageType,
+        instrument: str,
+        binning: str,
+        filter_name: str | None,
+        exptime: float | None,
+    ) -> None:
+        """Formats the filename, saves/uploads, and reports progress for one freshly-combined
+        master calibration frame. Shared by _create_master_calib (BIAS/SKYFLAT, one master) and
+        _create_master_darks (DARK, one master per exptime group)."""
+        calib.format_filename(self._fmt_calib)
+
+        if self._store_local:
+            path = os.path.join(self._store_local, calib.header["FNAME"])
+            log.info("Storing master calibration frame as %s...", path)
+            calib.writeto(path, overwrite=True)
+        else:
+            log.info("Uploading master calibration frame as %s...", calib.header["FNAME"])
+            await self._output_archive.upload_frames([calib])
+
+        self._report_progress(
+            MasterCalibCreated(
+                image_type=image_type,
+                instrument=instrument,
+                binning=binning,
+                filter_name=filter_name,
+                filename=calib.header["FNAME"],
+                exptime=exptime,
+            )
+        )
+
     async def _create_master_calib(
         self, night: str, instrument: str, image_type: ImageType, binning: str, filter_name: str | None = None
     ) -> Image | None:
+        """Creates a single master BIAS or SKYFLAT frame. DARK masters are created per-exptime
+        by _create_master_darks() instead, since a night's raw darks can span more than one
+        exposure time (see #831)."""
+        if image_type == ImageType.DARK:
+            raise ValueError("DARK masters are created via _create_master_darks(), not this method.")
+
         # get frames
         infos = await self._archive.list_frames(
             night=night,
@@ -108,23 +161,7 @@ class Reduction(ReductionBase):
                 return None
 
             # store in cache
-            self._master_frames[ImageType.BIAS, instrument, binning, None] = calib
-
-        elif image_type == ImageType.DARK:
-            # for DARKs, we first need a BIAS
-            bias = await self._find_master(night, ImageType.BIAS, instrument, binning, None)
-            if bias is None:
-                log.error("Could not find BIAS frame, skipping...")
-                return None
-
-            # combine
-            calib = await self._pipeline.create_master_dark(images, bias=bias)
-            if calib is None:
-                log.warning("Could not create master dark.")
-                return None
-
-            # store in cache
-            self._master_frames[ImageType.DARK, instrument, binning, None] = calib
+            self._master_frames[ImageType.BIAS, instrument, binning, None, None] = calib
 
         elif image_type == ImageType.SKYFLAT:
             # got enough frames?
@@ -145,35 +182,74 @@ class Reduction(ReductionBase):
                 return None
 
             # store in cache
-            self._master_frames[ImageType.SKYFLAT, instrument, binning, filter_name] = calib
+            self._master_frames[ImageType.SKYFLAT, instrument, binning, filter_name, None] = calib
 
         else:
             raise ValueError("Invalid image type")
 
-        # filename
-        calib.format_filename(self._fmt_calib)
+        await self._store_master_calib(calib, image_type, instrument, binning, filter_name, None)
+        return calib
 
-        # save/upload
-        if self._store_local:
-            path = os.path.join(self._store_local, calib.header["FNAME"])
-            log.info("Storing master calibration frame as %s...", path)
-            calib.writeto(path, overwrite=True)
-        else:
-            log.info("Uploading master calibration frame as %s...", calib.header["FNAME"])
-            await self._output_archive.upload_frames([calib])
+    async def _create_master_darks(self, night: str, instrument: str, binning: str) -> list[Image]:
+        """Creates one master dark per exposure time present in the night's raw DARK frames
+        (grouped within self._dark_exptime_tolerance) -- a night can have darks at more than
+        one exptime now that DarkBiasScript can match them to the night's science exptimes
+        (#831). Frame groups with fewer than 3 members are skipped individually with a
+        warning, rather than aborting dark reduction for this instrument/binning entirely.
 
-        self._report_progress(
-            MasterCalibCreated(
-                image_type=image_type,
-                instrument=instrument,
-                binning=binning,
-                filter_name=filter_name,
-                filename=calib.header["FNAME"],
-            )
+        Returns:
+            The master dark(s) created, longest exptime first.
+        """
+        infos = await self._archive.list_frames(
+            night=night, image_type=ImageType.DARK, instrument=instrument, binning=binning, rlevel=0
+        )
+        log.info("Found %d %s DARK frames from instrument %s.", len(infos), binning, instrument)
+
+        usable = [i for i in infos if i.exptime is not None]
+        if len(usable) < len(infos):
+            log.warning("Dropping %d DARK frame(s) with no EXPTIME.", len(infos) - len(usable))
+        if not usable:
+            return []
+
+        # longest-first, matching DarkBiasScript's own series order
+        groups = sorted(
+            group_by_exptime(usable, key=lambda i: i.exptime or 0.0, tolerance=self._dark_exptime_tolerance),
+            key=lambda group: statistics.median(i.exptime for i in group if i.exptime is not None),
+            reverse=True,
         )
 
-        # finished
-        return calib
+        bias = await self._find_master(night, ImageType.BIAS, instrument, binning, None)
+        if bias is None:
+            log.error("Could not find BIAS frame, skipping darks for instrument %s, binning %s.", instrument, binning)
+            return []
+
+        masters: list[Image] = []
+        for group in groups:
+            exptime = statistics.median(i.exptime for i in group if i.exptime is not None)
+
+            if len(group) < 3:
+                log.warning("Too few (%d) dark frames at ~%ss, skipping...", len(group), exptime)
+                continue
+
+            images = await self._archive.download_frames(group)
+            if len(images) < 3:
+                log.warning("Too few (%d) dark frames at ~%ss, skipping...", len(images), exptime)
+                continue
+
+            calib = await self._pipeline.create_master_dark(images, bias=bias)
+            if calib is None:
+                log.warning("Could not create master dark at ~%ss.", exptime)
+                continue
+
+            # EXPTIME may or may not survive ccdproc's sigma-clip combine unchanged -- set it
+            # explicitly from the group's own value rather than trusting the combined header.
+            calib.header["EXPTIME"] = (exptime, "Exposure time [s]")
+
+            self._master_frames[ImageType.DARK, instrument, binning, None, exptime] = calib
+            await self._store_master_calib(calib, ImageType.DARK, instrument, binning, None, exptime)
+            masters.append(calib)
+
+        return masters
 
     async def _count_science_frames(self, night: str, options: dict[str, list[Any]]) -> int:
         """Pre-pass: list (not download) OBJECT frames for every instrument/binning/filter
@@ -267,16 +343,18 @@ class Reduction(ReductionBase):
 
             # loop binnings
             for binning in options["binnings"]:
-                # create bias and dark
+                # create bias and dark(s)
                 if self._create_calibs:
                     try:
                         await self._create_master_calib(night, instrument, ImageType.BIAS, binning)
                     except Exception:
                         log.exception("Error creating master bias for instrument %s, binning %s.", instrument, binning)
                     try:
-                        await self._create_master_calib(night, instrument, ImageType.DARK, binning)
+                        await self._create_master_darks(night, instrument, binning)
                     except Exception:
-                        log.exception("Error creating master dark for instrument %s, binning %s.", instrument, binning)
+                        log.exception(
+                            "Error creating master dark(s) for instrument %s, binning %s.", instrument, binning
+                        )
 
                 # loop filters
                 for filter_name in options["filters"]:

--- a/pyobs/utils/pipeline/reduction_base.py
+++ b/pyobs/utils/pipeline/reduction_base.py
@@ -45,8 +45,9 @@ class ReductionBase(ABC):
         self._min_flats = min_flats
         self._progress_callback = progress_callback
 
-        # cache for master calibration frames
-        self._master_frames: dict[tuple[ImageType, str, str, str | None], Image] = {}
+        # cache for master calibration frames -- exptime is None for every non-DARK type, and
+        # the grouped exptime for DARK (a night can have darks at more than one exposure time)
+        self._master_frames: dict[tuple[ImageType, str, str, str | None, float | None], Image] = {}
 
     def _report_progress(self, event: ProgressEvent) -> None:
         if self._progress_callback is None:
@@ -64,6 +65,8 @@ class ReductionBase(ABC):
         binning: str,
         filter_name: str | None = None,
         max_days: float = 30.0,
+        exptime: float | None = None,
+        exptime_tolerance: float = 0.01,
     ) -> Image | None:
         """Find master calibration frame for given parameters using a cache.
 
@@ -73,23 +76,35 @@ class ReductionBase(ABC):
             binning: Binning.
             filter_name: Name of filter.
             max_days: Maximum number of days from DATE-OBS to find frames.
+            exptime: For DARK, prefer a master close to this exposure time; see
+                Pipeline.find_master. Also used as part of the cache key, so lookups at
+                different exptimes don't collide.
+            exptime_tolerance: See Pipeline.find_master.
 
         Returns:
             Image or None
         """
 
         # is in cache?
-        if (image_type, instrument, binning, filter_name) in self._master_frames:
-            return self._master_frames[image_type, instrument, binning, filter_name]
+        if (image_type, instrument, binning, filter_name, exptime) in self._master_frames:
+            return self._master_frames[image_type, instrument, binning, filter_name, exptime]
 
         # try to download one
         midnight = Time(night + " 23:59:59")
         image = await self._pipeline.find_master(
-            self._archive, image_type, midnight, instrument, binning, filter_name, max_days=max_days
+            self._archive,
+            image_type,
+            midnight,
+            instrument,
+            binning,
+            filter_name,
+            max_days=max_days,
+            exptime=exptime,
+            exptime_tolerance=exptime_tolerance,
         )
         if image is not None:
             # store and return it
-            self._master_frames[image_type, instrument, binning, filter_name] = image
+            self._master_frames[image_type, instrument, binning, filter_name, exptime] = image
             return image
         else:
             # still nothing

--- a/specs/plans/2026-09-01-per-exptime-dark-masters.md
+++ b/specs/plans/2026-09-01-per-exptime-dark-masters.md
@@ -154,10 +154,14 @@ Implements ADR 0015's decision directly.
 - [x] A science frame with `EXPTIME < dark_min_exptime` and no exact-match dark master is
       calibrated with bias only (no dark correction applied, no error); an exact-match master for
       that exptime, if one exists, is still used ahead of the bias-only path.
-- [x] Backward compatibility: existing `Calibration` configs keep working unchanged (all new
-      `__init__` params default to today's ADR-0015-approved policy); the filename-pattern change
-      is a documented migration step (see "Open questions" above and the PR description), not a
-      config break.
+- [x] Backward compatibility: existing `Calibration` *configs* keep validating and running
+      unchanged (all new `__init__` params default to today's ADR-0015-approved policy) -- but
+      per ADR 0015's own "Consequences", *behavior* changes for a site relying on
+      always-scale-whatever's-nearest: it now fails calibration (a caught `ValueError`, not a
+      crash) for science exptimes outside its one master's tolerance, until it sets
+      `allow_unmatched_dark_scale=True` or takes per-exptime darks (#831). Documented in
+      `CHANGELOG.rst` (not just here) per the ADR's explicit requirement. The filename-pattern
+      change is a separate, also-documented migration step.
 - [x] Tests: master grouping by exptime (incl. tolerance, under-populated groups skipped
       individually); filename/cache-key/progress-event exptime plumbing; matching logic
       (exact match / bias-only-below-minimum / reference-scale-down / reference-scale-up rejected

--- a/specs/plans/2026-09-01-per-exptime-dark-masters.md
+++ b/specs/plans/2026-09-01-per-exptime-dark-masters.md
@@ -1,6 +1,6 @@
 # Plan: per-exposure-time dark masters, reference-master scale-down only
 
-Status: **proposed**
+Status: implemented
 
 Tracks issue #832. Reduction/pipeline half of the dark-exptime-matching work; depends on the
 archive `exptime` plumbing from `2026-09-01-morning-darks-match-science-exptimes.md` (#831).
@@ -127,35 +127,38 @@ Implements ADR 0015's decision directly.
   reads `EXPTIME` from the science image's own header (`calibration.py`, per #3) rather than
   needing it passed explicitly from `Reduction`.
 
-## Open questions to resolve during implementation
+## Open questions -- resolved during implementation
 
-- Whether `dark_exptime_tolerance` should be relative (percentage) or absolute (seconds), or
-  configurable as either — ADR 0015 assumes relative 1% as the default; confirm this holds for
-  both very short (bias-adjacent) and very long exptimes before hardcoding relative-only.
-- Filename-pattern migration: hard rename vs. documented opt-in — decide once #1's on-disk
-  layout for existing deployments (MONET, iag50) is checked against what a mid-migration state
-  looks like (old single dark master + new per-exptime ones coexisting during rollout).
+- `dark_exptime_tolerance` is relative-only (matching #831's `exptimes_close`/`group_exptimes`,
+  which this plan already reuses). No absolute-tolerance mode was added -- not needed for the
+  discrete, well-separated exptimes real detectors use, and would have doubled the parameter
+  surface across `Reduction`, `Pipeline.find_master`, and `Calibration` for no concrete use case.
+- Filename-pattern migration: hard rename, called out here and in the PR description rather than
+  adding a second configurable pattern. Existing archives keep their old-pattern masters under
+  their original filenames; only newly-created masters (BIAS/SKYFLAT included, since the pattern
+  is shared) use the new `{EXPTIME|exptime}` component.
 
 ## Acceptance criteria
 
-- [ ] A night with darks at multiple exposure times produces one distinct master dark per
+- [x] A night with darks at multiple exposure times produces one distinct master dark per
       exposure time — distinct filenames, cache entries, and `MasterCalibCreated` events each
       carrying the correct `exptime`.
-- [ ] Science frames are calibrated with the exptime-matching master (within tolerance),
+- [x] Science frames are calibrated with the exptime-matching master (within tolerance),
       unscaled, whenever one exists.
-- [ ] Scaling happens only via the reference master, only downward (science `EXPTIME <=
+- [x] Scaling happens only via the reference master, only downward (science `EXPTIME <=
       dark_scale_exptime`); a science frame with no matching master and `EXPTIME >
       dark_scale_exptime` fails calibration with a clear, catchable error instead of silently
       scaling.
-- [ ] `allow_unmatched_dark_scale=True` reproduces today's always-scale behavior exactly, for
+- [x] `allow_unmatched_dark_scale=True` reproduces today's always-scale behavior exactly, for
       sites not yet taking per-exptime darks.
-- [ ] A science frame with `EXPTIME < dark_min_exptime` and no exact-match dark master is
+- [x] A science frame with `EXPTIME < dark_min_exptime` and no exact-match dark master is
       calibrated with bias only (no dark correction applied, no error); an exact-match master for
       that exptime, if one exists, is still used ahead of the bias-only path.
-- [ ] Backward compatibility: existing `Calibration` configs either keep working unchanged or
-      have a documented, changelog-visible migration step (filename pattern, new default
-      behavior).
-- [ ] Tests: master grouping by exptime (incl. tolerance, under-populated groups skipped
+- [x] Backward compatibility: existing `Calibration` configs keep working unchanged (all new
+      `__init__` params default to today's ADR-0015-approved policy); the filename-pattern change
+      is a documented migration step (see "Open questions" above and the PR description), not a
+      config break.
+- [x] Tests: master grouping by exptime (incl. tolerance, under-populated groups skipped
       individually); filename/cache-key/progress-event exptime plumbing; matching logic
       (exact match / bias-only-below-minimum / reference-scale-down / reference-scale-up rejected
       / unmatched-strict-error / `allow_unmatched_dark_scale` fallback); `_CCDDataCalibrator`'s

--- a/tests/images/processors/misc/test_calibration.py
+++ b/tests/images/processors/misc/test_calibration.py
@@ -32,6 +32,7 @@ def mock_image():
     image.header["XBINNING"] = 1
     image.header["FILTER"] = "filter"
     image.header["DATE-OBS"] = "2023-11-20 07:53:29.653"
+    image.header["EXPTIME"] = 30.0
 
     return image
 
@@ -106,6 +107,7 @@ async def test_call_valid(mocker, mock_image):
     archive = ConcreteArchive()
     calibration = Calibration(archive)
     mocker.patch.object(calibration, "_find_master", return_value=mock_image)
+    mocker.patch.object(calibration, "_find_dark_master", return_value=(mock_image, False))
 
     result_image = await calibration(mock_image)
 
@@ -152,3 +154,190 @@ def test_verify_image_header_invalid():
 
     with pytest.raises(ValueError):
         Calibration._verify_image_header(image)
+
+
+def test_verify_image_header_requires_exptime():
+    image = Image()
+    image.header["INSTRUME"] = "cam"
+    image.header["XBINNING"] = 1
+    image.header["DATE-OBS"] = "2023-11-20 07:53:29.653"
+
+    with pytest.raises(ValueError):
+        Calibration._verify_image_header(image)
+
+
+def _dark_master(exptime: float) -> Image:
+    # real dark masters inherit INSTRUME/XBINNING from the raw frames combined into them, and
+    # the calibration cache derives its key from these on the master, not the science image
+    master = Image()
+    master.header["INSTRUME"] = "cam"
+    master.header["XBINNING"] = 1
+    master.header["EXPTIME"] = exptime
+    return master
+
+
+def _find_master_side_effect(exact: Image | None = None, reference: Image | None = None, fallback: Image | None = None):
+    """Fakes Pipeline.find_master for _find_dark_master tests: _find_dark_at's exact-match call
+    passes exptime= without exptime_max=, its reference call passes both, and the branch-4
+    fallback (via _find_master -> _find_master_in_archive) passes neither."""
+
+    def side_effect(*args, **kwargs):
+        if kwargs.get("exptime_max") is not None:
+            return reference
+        if "exptime" in kwargs:
+            return exact
+        return fallback
+
+    return side_effect
+
+
+# ── _find_dark_master (ADR 0015 policy) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_require_dark_false_skips_lookup(mocker, mock_image):
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master")
+    calibration = Calibration(ConcreteArchive(), require_dark=False)
+
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert (master, scale) == (None, False)
+    pyobs.utils.pipeline.Pipeline.find_master.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_exact_match_used_unscaled(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 600.0
+    exact = _dark_master(600.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(exact=exact))
+
+    calibration = Calibration(ConcreteArchive())
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert master is exact
+    assert scale is False
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_below_minimum_is_bias_only(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 2.0  # below the default dark_min_exptime=5.0
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect())
+
+    calibration = Calibration(ConcreteArchive())
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert (master, scale) == (None, False)
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_exact_match_below_minimum_wins_over_bias_only(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 2.0
+    exact = _dark_master(2.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(exact=exact))
+
+    calibration = Calibration(ConcreteArchive())
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert master is exact
+    assert scale is False
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_reference_scaled_down(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 45.0
+    reference = _dark_master(600.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(reference=reference))
+
+    calibration = Calibration(ConcreteArchive())
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert master is reference
+    assert scale is True
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_science_exptime_above_reference_skips_scale_branch(mocker, mock_image):
+    # EXPTIME > dark_scale_exptime -- branch 3 must not fire even if a reference exists,
+    # otherwise the reference would be scaled UP, which ADR 0015 forbids
+    mock_image.header["EXPTIME"] = 900.0
+    reference = _dark_master(600.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(reference=reference))
+
+    calibration = Calibration(ConcreteArchive())
+    with pytest.raises(ValueError):
+        await calibration._find_dark_master(mock_image)
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_allow_unmatched_dark_scale_falls_back(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 45.0
+    fallback = _dark_master(123.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(fallback=fallback))
+
+    calibration = Calibration(ConcreteArchive(), dark_scale_exptime=None, allow_unmatched_dark_scale=True)
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert master is fallback
+    assert scale is True
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_strict_no_match_raises(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 45.0
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect())
+
+    calibration = Calibration(ConcreteArchive())
+    with pytest.raises(ValueError, match="EXPTIME=45.0"):
+        await calibration._find_dark_master(mock_image)
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_dark_min_exptime_none_disables_bias_only_branch(mocker, mock_image):
+    mock_image.header["EXPTIME"] = 2.0
+    reference = _dark_master(600.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(reference=reference))
+
+    calibration = Calibration(ConcreteArchive(), dark_min_exptime=None)
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    # no exact match, and dark_min_exptime disabled -- falls through to the reference branch
+    # instead of returning the bias-only (None, False)
+    assert master is reference
+    assert scale is True
+
+
+# ── _CCDDataCalibrator dark_scale ──────────────────────────────────────────────
+
+
+def test_ccddata_calibrator_unscaled_dark_passes_no_dark_exposure(mocker):
+    image = Image(data=np.zeros((2, 2), dtype=np.float32))
+    image.header["DET-GAIN"] = 1.0
+    image.header["DET-RON"] = 0.0
+    image.header["EXPTIME"] = 600.0
+
+    dark = Image(data=np.zeros((2, 2), dtype=np.float32))
+    dark.header["EXPTIME"] = 600.0
+
+    mock_ccd_process = mocker.patch("ccdproc.ccd_process")
+    calibrator = _CCDDataCalibrator(image, dark=dark, dark_scale=False)
+    calibrator()
+
+    assert mock_ccd_process.call_args.kwargs["dark_scale"] is False
+    assert mock_ccd_process.call_args.kwargs["dark_exposure"] is None
+
+
+def test_ccddata_calibrator_scaled_dark_passes_dark_exposure(mocker):
+    image = Image(data=np.zeros((2, 2), dtype=np.float32))
+    image.header["DET-GAIN"] = 1.0
+    image.header["DET-RON"] = 0.0
+    image.header["EXPTIME"] = 45.0
+
+    dark = Image(data=np.zeros((2, 2), dtype=np.float32))
+    dark.header["EXPTIME"] = 600.0
+
+    mock_ccd_process = mocker.patch("ccdproc.ccd_process")
+    calibrator = _CCDDataCalibrator(image, dark=dark, dark_scale=True)
+    calibrator()
+
+    assert mock_ccd_process.call_args.kwargs["dark_scale"] is True
+    assert mock_ccd_process.call_args.kwargs["dark_exposure"] is not None

--- a/tests/images/processors/misc/test_calibration.py
+++ b/tests/images/processors/misc/test_calibration.py
@@ -219,6 +219,21 @@ async def test_find_dark_master_exact_match_used_unscaled(mocker, mock_image):
 
 
 @pytest.mark.asyncio
+async def test_find_dark_master_legacy_master_with_no_exptime_is_not_an_exact_match(mocker, mock_image):
+    # a legacy pre-#831 master with no EXPTIME header at all must fall through to the rest of
+    # the policy (here: strict error) rather than raising a bare KeyError
+    mock_image.header["EXPTIME"] = 600.0
+    legacy = Image()
+    legacy.header["INSTRUME"] = "cam"
+    legacy.header["XBINNING"] = 1
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(exact=legacy))
+
+    calibration = Calibration(ConcreteArchive())
+    with pytest.raises(ValueError, match="EXPTIME=600.0"):
+        await calibration._find_dark_master(mock_image)
+
+
+@pytest.mark.asyncio
 async def test_find_dark_master_below_minimum_is_bias_only(mocker, mock_image):
     mock_image.header["EXPTIME"] = 2.0  # below the default dark_min_exptime=5.0
     mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect())

--- a/tests/images/processors/misc/test_calibration.py
+++ b/tests/images/processors/misc/test_calibration.py
@@ -271,6 +271,20 @@ async def test_find_dark_master_reference_scaled_down(mocker, mock_image):
 
 
 @pytest.mark.asyncio
+async def test_find_dark_master_reference_shorter_than_science_rejected(mocker, mock_image):
+    # only a 45s master exists; science at 100s is within the dark_scale_exptime=600 ceiling, so
+    # the reference branch fires, but scaling the 45s master UP to 100s is exactly what ADR 0015
+    # forbids -- must be rejected (falling through to the strict error) rather than used
+    mock_image.header["EXPTIME"] = 100.0
+    too_short = _dark_master(45.0)
+    mocker.patch("pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(reference=too_short))
+
+    calibration = Calibration(ConcreteArchive())
+    with pytest.raises(ValueError, match="EXPTIME=100.0"):
+        await calibration._find_dark_master(mock_image)
+
+
+@pytest.mark.asyncio
 async def test_find_dark_master_science_exptime_above_reference_skips_scale_branch(mocker, mock_image):
     # EXPTIME > dark_scale_exptime -- branch 3 must not fire even if a reference exists,
     # otherwise the reference would be scaled UP, which ADR 0015 forbids
@@ -294,6 +308,26 @@ async def test_find_dark_master_allow_unmatched_dark_scale_falls_back(mocker, mo
 
     assert master is fallback
     assert scale is True
+
+
+@pytest.mark.asyncio
+async def test_find_dark_master_allow_unmatched_dark_scale_legacy_master_used_unscaled(mocker, mock_image):
+    # the fallback master has no EXPTIME at all (Reduction's legacy, all-untagged-darks
+    # fallback) -- ccdproc can't compute a scale factor without it, so it must be used
+    # unscaled instead of the branch normally always scaling
+    mock_image.header["EXPTIME"] = 45.0
+    legacy_fallback = Image()
+    legacy_fallback.header["INSTRUME"] = "cam"
+    legacy_fallback.header["XBINNING"] = 1
+    mocker.patch(
+        "pyobs.utils.pipeline.Pipeline.find_master", side_effect=_find_master_side_effect(fallback=legacy_fallback)
+    )
+
+    calibration = Calibration(ConcreteArchive(), dark_scale_exptime=None, allow_unmatched_dark_scale=True)
+    master, scale = await calibration._find_dark_master(mock_image)
+
+    assert master is legacy_fallback
+    assert scale is False
 
 
 @pytest.mark.asyncio
@@ -332,6 +366,24 @@ def test_ccddata_calibrator_unscaled_dark_passes_no_dark_exposure(mocker):
 
     dark = Image(data=np.zeros((2, 2), dtype=np.float32))
     dark.header["EXPTIME"] = 600.0
+
+    mock_ccd_process = mocker.patch("ccdproc.ccd_process")
+    calibrator = _CCDDataCalibrator(image, dark=dark, dark_scale=False)
+    calibrator()
+
+    assert mock_ccd_process.call_args.kwargs["dark_scale"] is False
+    assert mock_ccd_process.call_args.kwargs["dark_exposure"] is None
+
+
+def test_ccddata_calibrator_unscaled_dark_with_no_exptime_header_does_not_crash(mocker):
+    # a legacy dark master (Reduction's all-untagged-darks fallback) has no EXPTIME at all --
+    # dark_scale=False must not touch dark.header["EXPTIME"], since it doesn't exist
+    image = Image(data=np.zeros((2, 2), dtype=np.float32))
+    image.header["DET-GAIN"] = 1.0
+    image.header["DET-RON"] = 0.0
+    image.header["EXPTIME"] = 45.0
+
+    dark = Image(data=np.zeros((2, 2), dtype=np.float32))  # no EXPTIME
 
     mock_ccd_process = mocker.patch("ccdproc.ccd_process")
     calibrator = _CCDDataCalibrator(image, dark=dark, dark_scale=False)

--- a/tests/images/processors/misc/test_calibration_cache.py
+++ b/tests/images/processors/misc/test_calibration_cache.py
@@ -114,3 +114,32 @@ def test_exptime_defaults_to_none_unaffected_by_dark_entries(dark_lookup_image):
 
     with pytest.raises(ValueError):
         cache.get_from_cache(dark_lookup_image, ImageType.DARK)
+
+
+# ── filter is ignored for BIAS/DARK, still honored for SKYFLAT/OBJECT ───────
+
+
+@pytest.mark.parametrize("image_type", [ImageType.BIAS, ImageType.DARK])
+def test_filter_mismatch_between_science_and_master_still_hits_for_bias_and_dark(mock_image, image_type):
+    # a real master bias/dark commonly has no FILTER header at all (or a stale one), while the
+    # science image looked up against it usually does -- must not cause a cache miss
+    master = _dark_master()  # no FILTER
+
+    cache = _CalibrationCache(5)
+    kwargs = {"exptime": 0.0} if image_type == ImageType.DARK else {}
+    cache.add_to_cache(master, image_type, **kwargs)
+
+    assert cache.get_from_cache(mock_image, image_type, **kwargs) == master
+
+
+def test_filter_mismatch_still_misses_for_skyflat(mock_image):
+    master = Image()
+    master.header["INSTRUME"] = "cam"
+    master.header["XBINNING"] = 1
+    # no FILTER on the master -- unlike BIAS/DARK, SKYFLAT still keys on it
+
+    cache = _CalibrationCache(5)
+    cache.add_to_cache(master, ImageType.SKYFLAT)
+
+    with pytest.raises(ValueError):
+        cache.get_from_cache(mock_image, ImageType.SKYFLAT)

--- a/tests/images/processors/misc/test_calibration_cache.py
+++ b/tests/images/processors/misc/test_calibration_cache.py
@@ -63,4 +63,54 @@ def test_find_cache_entry_emtpy():
     cache = _CalibrationCache(2)
 
     with pytest.raises(ValueError):
-        cache._find_cache_entry((image_type, image_instrument, image_binning, image_filter))
+        cache._find_cache_entry((image_type, image_instrument, image_binning, image_filter, None))
+
+
+# ── exptime keying (DARK masters at different exptimes) ─────────────────────
+
+
+@pytest.fixture()
+def dark_lookup_image():
+    # instrument/binning matching _dark_master()'s, no FILTER -- DARK lookups ignore filter, and
+    # a real dark master's own FITS header often doesn't carry one either (see _get_cache_keys)
+    image = Image()
+    image.header["INSTRUME"] = "cam"
+    image.header["XBINNING"] = 1
+    return image
+
+
+def _dark_master() -> Image:
+    master = Image()
+    master.header["INSTRUME"] = "cam"
+    master.header["XBINNING"] = 1
+    return master
+
+
+def test_get_from_cache_keys_by_exptime(dark_lookup_image):
+    exact = _dark_master()
+    reference = _dark_master()
+
+    cache = _CalibrationCache(5)
+    cache.add_to_cache(exact, ImageType.DARK, exptime=45.0)
+    cache.add_to_cache(reference, ImageType.DARK, exptime=600.0)
+
+    assert cache.get_from_cache(dark_lookup_image, ImageType.DARK, exptime=45.0) == exact
+    assert cache.get_from_cache(dark_lookup_image, ImageType.DARK, exptime=600.0) == reference
+
+
+def test_get_from_cache_miss_for_different_exptime(dark_lookup_image):
+    cache = _CalibrationCache(5)
+    cache.add_to_cache(_dark_master(), ImageType.DARK, exptime=45.0)
+
+    with pytest.raises(ValueError):
+        cache.get_from_cache(dark_lookup_image, ImageType.DARK, exptime=600.0)
+
+
+def test_exptime_defaults_to_none_unaffected_by_dark_entries(dark_lookup_image):
+    # a BIAS/SKYFLAT lookup (exptime=None, the default) must not collide with a DARK entry
+    # cached under an explicit exptime
+    cache = _CalibrationCache(5)
+    cache.add_to_cache(_dark_master(), ImageType.DARK, exptime=600.0)
+
+    with pytest.raises(ValueError):
+        cache.get_from_cache(dark_lookup_image, ImageType.DARK)

--- a/tests/robotic/utils/archive/test_local_archive.py
+++ b/tests/robotic/utils/archive/test_local_archive.py
@@ -242,6 +242,25 @@ async def test_list_frames_filters_by_exptime_within_tolerance(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_list_frames_exptime_is_none_not_nan_when_mixed_with_tagged_frames(tmp_path: Path) -> None:
+    # a pandas float64 column silently coerces None to NaN as soon as any row in it holds a
+    # real float -- this archive's index must normalize that back to None, since NaN is not
+    # None (and compares unequal to everything, including itself)
+    write_fits(tmp_path / "tagged.fits", **make_frame_headers(exptime=30.0, obsnum="1"))
+    write_fits(tmp_path / "untagged.fits", **make_frame_headers(exptime=None, obsnum="2"))
+    archive = LocalArchive(root=str(tmp_path))
+
+    frames = await archive.list_frames()
+
+    by_obsnum = {"tagged.fits": 30.0, "untagged.fits": None}
+    for frame in frames:
+        expected = by_obsnum[Path(frame.filename).name]
+        assert frame.exptime == expected
+        if expected is None:
+            assert frame.exptime is None  # exactly None, not float("nan")
+
+
+@pytest.mark.asyncio
 async def test_list_frames_exptime_excludes_frames_without_exptime(tmp_path: Path) -> None:
     write_fits(tmp_path / "a.fits", **make_frame_headers(exptime=None))
     archive = LocalArchive(root=str(tmp_path))

--- a/tests/utils/pipeline/test_pipeline.py
+++ b/tests/utils/pipeline/test_pipeline.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pyobs.images import Image
+from pyobs.robotic.utils.archive import Archive, FrameInfo
+from pyobs.utils.enums import ImageType
+from pyobs.utils.pipeline import Pipeline
+from pyobs.utils.time import Time
+
+
+def _frame(name: str, dateobs: str, exptime: float | None) -> FrameInfo:
+    info = FrameInfo()
+    info.filename = name
+    info.dateobs = Time(dateobs)
+    info.exptime = exptime
+    return info
+
+
+class _FakeArchive(Archive):
+    """Stub archive returning a fixed list of DARK master candidates."""
+
+    frames: list[FrameInfo] = []
+
+    async def list_options(self, **kwargs: Any) -> dict[str, list[Any]]:
+        return {}
+
+    async def list_frames(self, **kwargs: Any) -> list[FrameInfo]:
+        return self.frames
+
+    async def download_frames(self, frames: list[FrameInfo]) -> list[Image]:
+        images = []
+        for frame in frames:
+            image = Image()
+            image.header["FNAME"] = frame.filename
+            images.append(image)
+        return images
+
+
+@pytest.mark.asyncio
+async def test_find_master_no_exptime_sorts_by_date_only() -> None:
+    archive = _FakeArchive(
+        frames=[
+            _frame("near.fits", "2024-01-01T12:00:00", exptime=600.0),
+            _frame("far.fits", "2024-01-01T00:00:00", exptime=45.0),
+        ]
+    )
+
+    result = await Pipeline.find_master(
+        archive, ImageType.DARK, Time("2024-01-01T12:00:01"), "cam1", "1x1", max_days=None
+    )
+
+    assert result is not None
+    assert result.header["FNAME"] == "near.fits"
+
+
+@pytest.mark.asyncio
+async def test_find_master_exptime_match_wins_over_closer_in_time() -> None:
+    archive = _FakeArchive(
+        frames=[
+            _frame("time-close.fits", "2024-01-01T12:00:00", exptime=999.0),
+            _frame("exptime-close.fits", "2024-01-01T00:00:00", exptime=45.0),
+        ]
+    )
+
+    result = await Pipeline.find_master(
+        archive,
+        ImageType.DARK,
+        Time("2024-01-01T12:00:01"),
+        "cam1",
+        "1x1",
+        max_days=None,
+        exptime=45.0,
+    )
+
+    assert result is not None
+    assert result.header["FNAME"] == "exptime-close.fits"
+
+
+@pytest.mark.asyncio
+async def test_find_master_exptime_ignored_for_non_dark() -> None:
+    archive = _FakeArchive(
+        frames=[
+            _frame("time-close.fits", "2024-01-01T12:00:00", exptime=999.0),
+            _frame("exptime-close.fits", "2024-01-01T00:00:00", exptime=45.0),
+        ]
+    )
+
+    # exptime is only honored for DARK -- SKYFLAT still sorts by date only
+    result = await Pipeline.find_master(
+        archive,
+        ImageType.SKYFLAT,
+        Time("2024-01-01T12:00:01"),
+        "cam1",
+        "1x1",
+        max_days=None,
+        exptime=45.0,
+    )
+
+    assert result is not None
+    assert result.header["FNAME"] == "time-close.fits"
+
+
+@pytest.mark.asyncio
+async def test_find_master_exptime_max_drops_longer_candidates() -> None:
+    archive = _FakeArchive(
+        frames=[
+            _frame("too-long.fits", "2024-01-01T12:00:00", exptime=900.0),
+            _frame("usable.fits", "2024-01-01T00:00:00", exptime=580.0),
+        ]
+    )
+
+    result = await Pipeline.find_master(
+        archive,
+        ImageType.DARK,
+        Time("2024-01-01T12:00:01"),
+        "cam1",
+        "1x1",
+        max_days=None,
+        exptime=600.0,
+        exptime_max=600.0,
+    )
+
+    assert result is not None
+    assert result.header["FNAME"] == "usable.fits"
+
+
+@pytest.mark.asyncio
+async def test_find_master_exptime_max_none_left_returns_none() -> None:
+    archive = _FakeArchive(frames=[_frame("too-long.fits", "2024-01-01T12:00:00", exptime=900.0)])
+
+    result = await Pipeline.find_master(
+        archive,
+        ImageType.DARK,
+        Time("2024-01-01T12:00:01"),
+        "cam1",
+        "1x1",
+        max_days=None,
+        exptime=600.0,
+        exptime_max=600.0,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_master_no_candidates_returns_none() -> None:
+    archive = _FakeArchive(frames=[])
+
+    result = await Pipeline.find_master(archive, ImageType.DARK, Time("2024-01-01T12:00:01"), "cam1", "1x1")
+
+    assert result is None

--- a/tests/utils/pipeline/test_reduction.py
+++ b/tests/utils/pipeline/test_reduction.py
@@ -32,6 +32,7 @@ def make_frame_headers(
     telescope: str = "tel1",
     rlevel: int = 0,
     fname: str = "raw.fits",
+    exptime: float = 30.0,
 ) -> dict[str, object]:
     return {
         "DATE-OBS": date_obs,
@@ -45,6 +46,7 @@ def make_frame_headers(
         "TELID": telescope,
         "RLEVEL": rlevel,
         "FNAME": fname,
+        "EXPTIME": exptime,
     }
 
 
@@ -218,6 +220,116 @@ async def test_progress_callback_reports_calibs_and_cumulative_science_frames(tm
     assert [e.index for e in frame_events] == [1, 2]
     assert all(e.total == 2 for e in frame_events)
     assert all(e.status == "ok" for e in frame_events)
+
+
+# ── per-exptime dark masters ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_master_darks_groups_by_exptime(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    for i in range(3):
+        write_fits(in_dir / f"bias{i}.fits", **make_frame_headers(image_type="bias", fname=f"bias{i}.fits"))
+    for i in range(3):
+        write_fits(
+            in_dir / f"dark30_{i}.fits",
+            **make_frame_headers(image_type="dark", fname=f"dark30_{i}.fits", exptime=30.0),
+        )
+    for i in range(3):
+        write_fits(
+            in_dir / f"dark600_{i}.fits",
+            **make_frame_headers(image_type="dark", fname=f"dark600_{i}.fits", exptime=600.0),
+        )
+
+    archive = LocalArchive(root=str(in_dir))
+    output = LocalArchive(root=str(tmp_path / "out"))
+    pipeline = Pipeline(steps=[])
+
+    events: list[ProgressEvent] = []
+    reduction = Reduction(
+        archive=archive, pipeline=pipeline, output=output, calib_science=False, progress_callback=events.append
+    )
+    await reduction._create_master_calib("2024-01-01", "cam1", ImageType.BIAS, "1x1")
+    masters = await reduction._create_master_darks("2024-01-01", "cam1", "1x1")
+
+    assert sorted(m.header["EXPTIME"] for m in masters) == [30.0, 600.0]
+    # longest exptime first, matching DarkBiasScript's own series order
+    assert [m.header["EXPTIME"] for m in masters] == [600.0, 30.0]
+
+    dark_events = [e for e in events if isinstance(e, MasterCalibCreated) and e.image_type == ImageType.DARK]
+    assert sorted(e.exptime for e in dark_events) == [30.0, 600.0]
+
+    # two distinct master files landed in the output archive, one per exptime
+    dark_files = sorted(p.name for p in (tmp_path / "out").glob("*-dark-*"))
+    assert len(dark_files) == 2
+    assert dark_files[0] != dark_files[1]
+
+
+@pytest.mark.asyncio
+async def test_create_master_darks_skips_under_populated_group_individually(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    for i in range(3):
+        write_fits(in_dir / f"bias{i}.fits", **make_frame_headers(image_type="bias", fname=f"bias{i}.fits"))
+    # enough at 30s, too few at 600s
+    for i in range(3):
+        write_fits(
+            in_dir / f"dark30_{i}.fits",
+            **make_frame_headers(image_type="dark", fname=f"dark30_{i}.fits", exptime=30.0),
+        )
+    for i in range(2):
+        write_fits(
+            in_dir / f"dark600_{i}.fits",
+            **make_frame_headers(image_type="dark", fname=f"dark600_{i}.fits", exptime=600.0),
+        )
+
+    archive = LocalArchive(root=str(in_dir))
+    output = LocalArchive(root=str(tmp_path / "out"))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(archive=archive, pipeline=pipeline, output=output, calib_science=False)
+    await reduction._create_master_calib("2024-01-01", "cam1", ImageType.BIAS, "1x1")
+    masters = await reduction._create_master_darks("2024-01-01", "cam1", "1x1")
+
+    assert [m.header["EXPTIME"] for m in masters] == [30.0]
+
+
+@pytest.mark.asyncio
+async def test_create_master_darks_no_bias_skips_all_groups(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    for i in range(3):
+        write_fits(
+            in_dir / f"dark30_{i}.fits",
+            **make_frame_headers(image_type="dark", fname=f"dark30_{i}.fits", exptime=30.0),
+        )
+
+    archive = LocalArchive(root=str(in_dir))
+    output = LocalArchive(root=str(tmp_path / "out"))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(archive=archive, pipeline=pipeline, output=output, calib_science=False)
+    masters = await reduction._create_master_darks("2024-01-01", "cam1", "1x1")
+
+    assert masters == []
+
+
+@pytest.mark.asyncio
+async def test_create_master_darks_no_dark_frames_returns_empty(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    for i in range(3):
+        write_fits(in_dir / f"bias{i}.fits", **make_frame_headers(image_type="bias", fname=f"bias{i}.fits"))
+
+    archive = LocalArchive(root=str(in_dir))
+    output = LocalArchive(root=str(tmp_path / "out"))
+    pipeline = Pipeline(steps=[])
+
+    reduction = Reduction(archive=archive, pipeline=pipeline, output=output, calib_science=False)
+    masters = await reduction._create_master_darks("2024-01-01", "cam1", "1x1")
+
+    assert masters == []
 
 
 @pytest.mark.asyncio

--- a/tests/utils/pipeline/test_reduction.py
+++ b/tests/utils/pipeline/test_reduction.py
@@ -316,6 +316,42 @@ async def test_create_master_darks_no_bias_skips_all_groups(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_create_master_darks_legacy_fallback_when_all_darks_lack_exptime(tmp_path: Path) -> None:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    for i in range(3):
+        write_fits(in_dir / f"bias{i}.fits", **make_frame_headers(image_type="bias", fname=f"bias{i}.fits"))
+    for i in range(3):
+        headers = make_frame_headers(image_type="dark", fname=f"dark{i}.fits")
+        del headers["EXPTIME"]
+        write_fits(in_dir / f"dark{i}.fits", **headers)
+
+    archive = LocalArchive(root=str(in_dir))
+    output = LocalArchive(root=str(tmp_path / "out"))
+    pipeline = Pipeline(steps=[])
+
+    events: list[ProgressEvent] = []
+    reduction = Reduction(
+        archive=archive, pipeline=pipeline, output=output, calib_science=False, progress_callback=events.append
+    )
+    await reduction._create_master_calib("2024-01-01", "cam1", ImageType.BIAS, "1x1")
+    masters = await reduction._create_master_darks("2024-01-01", "cam1", "1x1")
+
+    # one combined master, not zero -- and it's not tagged with a made-up exptime
+    assert len(masters) == 1
+    assert "EXPTIME" not in masters[0].header
+
+    dark_events = [e for e in events if isinstance(e, MasterCalibCreated) and e.image_type == ImageType.DARK]
+    assert len(dark_events) == 1
+    assert dark_events[0].exptime is None
+
+    # filename formatting didn't blow up despite the missing EXPTIME
+    dark_files = list((tmp_path / "out").glob("*-dark-*"))
+    assert len(dark_files) == 1
+    assert "unknown" in dark_files[0].name
+
+
+@pytest.mark.asyncio
 async def test_create_master_darks_no_dark_frames_returns_empty(tmp_path: Path) -> None:
     in_dir = tmp_path / "in"
     in_dir.mkdir()

--- a/tests/utils/test_exptime_grouping.py
+++ b/tests/utils/test_exptime_grouping.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pyobs.utils.exptime_grouping import exptimes_close, group_exptimes
+import statistics
+from dataclasses import dataclass
+
+from pyobs.utils.exptime_grouping import exptimes_close, group_by_exptime, group_exptimes
 
 # ── exptimes_close ───────────────────────────────────────────────────────────
 
@@ -46,3 +49,40 @@ def test_group_exptimes_empty_input() -> None:
 
 def test_group_exptimes_single_value() -> None:
     assert group_exptimes([45.0]) == [45.0]
+
+
+# ── group_by_exptime ────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Frame:
+    name: str
+    exptime: float
+
+
+def test_group_by_exptime_groups_items_not_just_values() -> None:
+    frames = [_Frame("a", 30.0), _Frame("b", 30.1), _Frame("c", 600.0)]
+
+    groups = group_by_exptime(frames, key=lambda f: f.exptime)
+
+    assert [f.name for f in groups[0]] == ["a", "b"]
+    assert [f.name for f in groups[1]] == ["c"]
+
+
+def test_group_by_exptime_preserves_key_sorted_order_within_group() -> None:
+    frames = [_Frame("second", 30.1), _Frame("first", 29.9)]
+
+    groups = group_by_exptime(frames, key=lambda f: f.exptime)
+
+    assert [f.name for f in groups[0]] == ["first", "second"]
+
+
+def test_group_by_exptime_empty_input() -> None:
+    assert group_by_exptime([], key=lambda f: f.exptime) == []
+
+
+def test_group_exptimes_is_group_by_exptime_collapsed_to_medians() -> None:
+    values = [30.0, 30.1, 29.9, 600.0, 601.0]
+    groups = group_by_exptime(values, key=lambda v: v)
+
+    assert group_exptimes(values) == [statistics.median(g) for g in groups]

--- a/tests/utils/test_fits.py
+++ b/tests/utils/test_fits.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from astropy.io import fits
+
+from pyobs.utils.fits import FilenameFormatter
+
+
+def test_format_exptime_renders_whole_seconds_without_trailing_zero() -> None:
+    hdr = fits.Header({"EXPTIME": 600.0})
+    formatter = FilenameFormatter("{EXPTIME|exptime}")
+
+    assert formatter(hdr) == "600"
+
+
+def test_format_exptime_keeps_fractional_seconds() -> None:
+    hdr = fits.Header({"EXPTIME": 0.333})
+    formatter = FilenameFormatter("{EXPTIME|exptime}")
+
+    assert formatter(hdr) == "0.333"
+
+
+def test_format_exptime_missing_key_renders_placeholder_instead_of_raising() -> None:
+    # a legacy dark master combined from raw frames with no EXPTIME at all -- format_filename()
+    # must still succeed so the master can be stored, not raise KeyError
+    hdr = fits.Header({})
+    formatter = FilenameFormatter("{EXPTIME|exptime}")
+
+    assert formatter(hdr) == "unknown"


### PR DESCRIPTION
## Summary
- `Reduction._create_master_darks()` groups a night's raw `DARK` frames by exptime (tolerance-grouped, reusing #831's `pyobs.utils.exptime_grouping`) and creates one master per group instead of a single night-wide dark, longest-first. Frame groups with fewer than 3 members are skipped individually with a warning rather than aborting dark reduction for the whole instrument/binning.
- `FILENAME` gains an exptime component (`{EXPTIME|exptime}`), shared by `BIAS`/`SKYFLAT` too since it's one pattern — via a new `FilenameFormatter` `"exptime"` function that renders `600.0` as `600`. `MasterCalibCreated` carries the dark's `exptime`. `ReductionBase`'s master-frame cache key gains `exptime` (`None` for non-DARK).
- `Pipeline.find_master()` gains `exptime`/`exptime_tolerance`/`exptime_max` params: for `DARK`, an exptime match ranks ahead of a merely time-close non-match, and `exptime_max` enforces scale-down-only when searching for a reference master.
- `Calibration` implements ADR `0015-dark-master-strict-exptime-matching-reference-scale-down-only.md`'s policy via a new `_find_dark_master()`, checked in order against the science frame's `EXPTIME`: (1) exact match within `dark_exptime_tolerance` → unscaled; (2) no exact match and `EXPTIME < dark_min_exptime` → bias-only, not an error; (3) no exact match, above the minimum, and a reference master (`dark_scale_exptime`, default 600s) exists → scaled down to the science exptime; (4) `allow_unmatched_dark_scale=True` → today's always-scale-whatever's-nearest behavior; (5) otherwise → `ValueError`, caught the same way as any other missing-master case in `__call__`.
- `_CalibrationCache` now keys `DARK` entries by the *target* exptime searched for (science exptime for an exact-match lookup, or the reference exptime), not the science image's own `EXPTIME` header — a science frame's own exptime no longer identifies which master it needs once scaling is in play.
- `_CCDDataCalibrator` gains a `dark_scale: bool` param threaded from `Calibration.__call__`, so an exact-match dark isn't rescaled by `ccdproc.ccd_process()`.
- ADR `0015` was already `accepted` (flipped in #840); this plan (`2026-09-01-per-exptime-dark-masters.md`) is flipped `proposed` → `implemented`, both open questions resolved (relative-only tolerance; hard filename-pattern rename, documented rather than dual-pattern).

Scoped to issue #832 only (reduction/pipeline side). #831 (archive/robotic side) already landed on `develop` via PR #840.

## Design notes / judgment calls
- **`_verify_image_header` now also requires `EXPTIME`.** It was already an implicit requirement of `_CCDDataCalibrator` (`data_exposure=...EXPTIME...`); checking it upfront turns a bare `KeyError` mid-calibration into the same `ValueError` path every other missing-header case already takes.
- **The bias-only branch (2) needed no new `_CCDDataCalibrator` path.** `dark: Image | None = None` was already handled end-to-end (`ccd_process(dark_frame=None, ...)`); the plan's open question here is resolved by reuse, not a new branch.
- **Cache key considered and rejected: full archive/image config dump.** First pass keyed `_CalibrationCache` by deriving `exptime` from the master image's own header — works, but doesn't generalize past this PR. Landed on keying explicitly by the *target* exptime the caller searched for, passed in by `_find_dark_at`, which is what actually identifies "which master do I need" once scaling means the returned master's own exptime can legitimately differ from what was asked for.

## Test plan
- [x] `pytest tests/` (excluding `integration`/`xmpp`): 1758 passed, same 7 pre-existing/unrelated `tests/cli/test_pyobsd.py` failures as `develop` (local-environment `pyobs` executable lookup).
- [x] `ruff check .` clean.
- [x] `black --check` clean.
- [x] `pyrefly check pyobs/` (CI's actual invocation): 0 errors, same baseline suppressed/warning counts as `develop`.
- New/updated tests: `tests/utils/pipeline/test_pipeline.py` (new — `Pipeline.find_master`'s exptime ranking/`exptime_max`), `tests/utils/pipeline/test_reduction.py` (per-exptime dark grouping, under-populated-group skip, no-bias skip), `tests/images/processors/misc/test_calibration.py` (all 5 `_find_dark_master` policy branches + `_CCDDataCalibrator.dark_scale`), `tests/images/processors/misc/test_calibration_cache.py` (exptime keying), `tests/utils/test_exptime_grouping.py` (new `group_by_exptime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)