### PR TITLE
Reschedule on project and same-ID task content changes

### DIFF
--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -180,23 +180,33 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
         )
         log.info("Downloaded %d schedulable tasks(s).", len(tasks))
 
-        # download projects
-        self._projects = await self._task_archive.get_projects()
+        # download projects -- keep the old list around long enough to diff against below,
+        # mirroring self._tasks (only overwritten once _need_update has been decided)
+        old_projects = self._projects
+        projects = await self._task_archive.get_projects()
+        projects_changed = {p.code: p.model_dump() for p in projects} != {p.code: p.model_dump() for p in old_projects}
 
-        # compare new and old lists
+        # compare new and old lists, both by ID (removed/added) and by content (changed, same ID)
         removed, added = self._compare_task_lists(self._tasks, tasks)
+        changed = self._changed_task_ids(self._tasks, tasks)
 
         # schedule update
         self._need_update = True
 
-        # no changes?
-        if not self._trigger_on_every_update and len(removed) == 0 and len(added) == 0:
+        # no changes at all?
+        if (
+            not self._trigger_on_every_update
+            and len(removed) == 0
+            and len(added) == 0
+            and len(changed) == 0
+            and not projects_changed
+        ):
             # no need to re-schedule
             log.info("No change in list of blocks detected.")
             self._need_update = False
 
-        # has only the current block been removed?
-        log.info("Removed: %d, added: %d", len(removed), len(added))
+        # has only the current block been removed, with nothing else changed?
+        log.info("Removed: %d, added: %d, changed: %d", len(removed), len(added), len(changed))
         if len(removed) == 1:
             log.info(
                 "Found 1 removed block with ID %d. Last task ID was %s, current is %s.",
@@ -204,21 +214,38 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
                 str(self._last_task_id),
                 str(self._current_task_id),
             )
-        if len(removed) == 1 and len(added) == 0 and removed[0] == self._last_task_id:
+        if (
+            len(removed) == 1
+            and len(added) == 0
+            and len(changed) == 0
+            and not projects_changed
+            and removed[0] == self._last_task_id
+        ):
             # no need to re-schedule
             log.info("Only one removed block detected, which is the one currently running.")
             self._need_update = False
 
-        # check, if one of the removed blocks was actually in schedule
-        if len(removed) > 0 and self._need_update:
+        # a content change on the currently-running block always forces a reschedule -- its new
+        # content (e.g. priority) can reorder everything scheduled after it. Unlike a *removed*
+        # current block (handled above), it isn't simply ending on its own, so it must not be
+        # waved through by the schedule-membership check below.
+        current_task_changed = self._current_task_id in changed
+
+        # check, if one of the removed/changed blocks was actually in schedule -- an off-schedule
+        # removal or content change can't affect the active plan
+        if (removed or changed) and self._need_update and not current_task_changed:
             schedule = await self._schedule.get_schedule()
-            removed_from_schedule = [s for s in schedule if s.task.id in removed]
-            if len(removed_from_schedule) == 0:
-                log.info("Found %s tasks, but none of them was scheduled.", len(removed))
+            scheduled_ids = {s.task.id for s in schedule}
+            if not (set(removed) & scheduled_ids) and not (changed & scheduled_ids):
+                log.info(
+                    "Found %d removed/changed task(s), but none of them was scheduled.",
+                    len(removed) + len(changed),
+                )
                 self._need_update = False
 
         # store blocks
         self._tasks = tasks
+        self._projects = projects
 
         # schedule update
         if self._need_update:
@@ -251,6 +278,22 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
         additional2 = list(set(ids2.keys()).difference(ids1.keys()))
 
         return sorted(additional1), sorted(additional2)  # type: ignore[type-var]
+
+    @staticmethod
+    def _changed_task_ids(tasks1: list[Task], tasks2: list[Task]) -> set[Any]:
+        """IDs present in both lists whose task content differs between them.
+
+        Comparison is via ``model_dump()``, not pydantic ``==``: ``Task.__eq__`` also compares
+        runtime-only ``PrivateAttr``s (e.g. ``_cant_run_reason`` set by ``can_run()``, or
+        ``_resolved_target`` set while scheduling), which would make a task that has merely been
+        scheduled/run look "changed" on the next poll. ``model_dump()`` excludes private
+        attributes by construction, so only real content differences (priority, duration,
+        script, ...) are reported.
+        """
+        by_id1 = {t.id: t for t in tasks1}
+        by_id2 = {t.id: t for t in tasks2}
+        common = set(by_id1).intersection(by_id2)
+        return {i for i in common if by_id1[i].model_dump() != by_id2[i].model_dump()}
 
     async def _schedule_worker(self) -> None:
         await asyncio.sleep(5)

--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -184,7 +184,12 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
         # mirroring self._tasks (only overwritten once _need_update has been decided)
         old_projects = self._projects
         projects = await self._task_archive.get_projects()
-        projects_changed = {p.code: p.model_dump() for p in projects} != {p.code: p.model_dump() for p in old_projects}
+        # `updated_at` is excluded: it's a portal-side save timestamp (round-trip-only field, not
+        # scheduling-relevant), and a no-op re-save still bumps it -- comparing it in would force
+        # a reschedule on every no-op edit, not just real content changes.
+        projects_changed = {p.code: p.model_dump(exclude={"updated_at"}) for p in projects} != {
+            p.code: p.model_dump(exclude={"updated_at"}) for p in old_projects
+        }
 
         # compare new and old lists, both by ID (removed/added) and by content (changed, same ID)
         removed, added = self._compare_task_lists(self._tasks, tasks)
@@ -280,20 +285,36 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
         return sorted(additional1), sorted(additional2)  # type: ignore[type-var]
 
     @staticmethod
-    def _changed_task_ids(tasks1: list[Task], tasks2: list[Task]) -> set[Any]:
+    def _content_dump(task: Task) -> dict[str, Any]:
+        """``task.model_dump()`` with ``updated_at`` stripped.
+
+        ``Task`` is a ``PolymorphicBaseModel``, whose ``@model_serializer`` builds its own dict
+        from ``model_fields`` and injects a ``class`` key (``pyobs/utils/serialization.py:44-49``)
+        -- it does not honor ``model_dump(exclude=...)`` at all, so the key has to be dropped from
+        the result afterwards instead. ``updated_at`` is a portal-side save timestamp, not
+        scheduling-relevant content, and a no-op re-save (e.g. an unchanged DRF PATCH) still bumps
+        it -- leaving it in would report every no-op edit as a "changed" task.
+        """
+        dump = task.model_dump()
+        dump.pop("updated_at", None)
+        return dump
+
+    @classmethod
+    def _changed_task_ids(cls, tasks1: list[Task], tasks2: list[Task]) -> set[Any]:
         """IDs present in both lists whose task content differs between them.
 
-        Comparison is via ``model_dump()``, not pydantic ``==``: ``Task.__eq__`` also compares
-        runtime-only ``PrivateAttr``s (e.g. ``_cant_run_reason`` set by ``can_run()``, or
-        ``_resolved_target`` set while scheduling), which would make a task that has merely been
-        scheduled/run look "changed" on the next poll. ``model_dump()`` excludes private
-        attributes by construction, so only real content differences (priority, duration,
-        script, ...) are reported.
+        Comparison is via ``model_dump()`` (see :meth:`_content_dump`), not pydantic ``==``:
+        ``Task.__eq__`` also compares runtime-only ``PrivateAttr``s (e.g. ``_cant_run_reason`` set
+        by ``can_run()``, or ``_resolved_target`` set while scheduling), which would make a task
+        that has merely been scheduled/run look "changed" on the next poll. ``model_dump()``
+        excludes private attributes by construction. What's left after also dropping
+        ``updated_at`` (priority, duration, script, ...) are the fields that actually matter for
+        scheduling.
         """
         by_id1 = {t.id: t for t in tasks1}
         by_id2 = {t.id: t for t in tasks2}
         common = set(by_id1).intersection(by_id2)
-        return {i for i in common if by_id1[i].model_dump() != by_id2[i].model_dump()}
+        return {i for i in common if cls._content_dump(by_id1[i]) != cls._content_dump(by_id2[i])}
 
     async def _schedule_worker(self) -> None:
         await asyncio.sleep(5)

--- a/pyobs/robotic/task.py
+++ b/pyobs/robotic/task.py
@@ -155,6 +155,10 @@ class Project(BaseModel):
     priority: float | None = Field(ge=0.0, le=9999.0, default=1.0)
     users: list[str] = Field(default_factory=list)
     public: bool = False  # ingest backend `public` flag; default keeps old backends valid
+    updated_at: str | None = None
+    """Last-modification timestamp as emitted by pyobs-portal (DB-derived ``updated_at``,
+    added in pyobs-portal#134). Carried for round-trip fidelity so the strict ``Project`` model
+    (``extra="forbid"``) accepts the field the portal now sends; not used by pyobs itself."""
 
 
 __all__ = ["Task", "TaskData", "Project"]

--- a/specs/plans/2026-09-01-scheduler-reschedule-on-project-and-task-changes.md
+++ b/specs/plans/2026-09-01-scheduler-reschedule-on-project-and-task-changes.md
@@ -4,7 +4,9 @@ Status: implemented
 
 Tracks issue #848. Repos: pyobs-core (this plan); the signal-delivery half lives in
 `pyobs-portal/specs/plans/2026-09-01-last-task-update-marker-includes-projects.md` (separate
-repo, separate plan) — the two are independently landable, see Out of scope.
+repo, separate plan). **Not independently landable** — see Out of scope: pyobs-portal's
+`Project` payload gained `updated_at`, which core's `Project` model must accept a round-trip
+field for (added in this PR) or every poll fails with a `ValidationError`.
 
 ## Problem
 
@@ -113,6 +115,35 @@ end (`:221`), the same place `self._tasks = tasks` already happens.
 - pyobs-portal's `/api/last_task_update/` marker not moving on project edits — a separate,
   required gap for the fix to matter in production (without it, `PortalTaskArchive` never
   re-polls, so this plan's comparison never even runs on a real project edit). Tracked in
-  `pyobs-portal/specs/plans/2026-09-01-last-task-update-marker-includes-projects.md`. The two
-  plans are independently correct and independently landable — this one is already exercised by
-  `trigger_on_every_update=True` deployments and by the new tests regardless of portal state.
+  `pyobs-portal/specs/plans/2026-09-01-last-task-update-marker-includes-projects.md`.
+
+## Post-review addendum
+
+Independent review of the initial implementation (verified against PR head `a374458d`) found
+and this PR's follow-up commit fixed:
+
+- **Coupling, not independence**: pyobs-portal's `ProjectSerializer` is `fields="__all__"`, so
+  once pyobs-portal#134 lands, `/api/projects/` starts emitting `updated_at`. Core's `Project`
+  (`pyobs/robotic/task.py:152`) is `extra="forbid"` with no such field, so
+  `PortalTaskArchive._get_projects()` (`taskarchive.py:117`) would raise `ValidationError` on
+  every poll — the two PRs are **not** independently landable as originally claimed. Fixed by
+  adding `updated_at: str | None = None` to `Project`, mirroring the identical precedent already
+  shipped for `Task.updated_at` (commit `e550423e`, pyobs-portal#84), plus a regression test
+  (`test_task_get_projects_from_portal_accepts_updated_at`) mirroring that precedent's own test.
+- **`updated_at` leaking into content comparisons**: once `Project` carries `updated_at`, both
+  `projects_changed` and `_changed_task_ids()`'s `model_dump()` comparisons would count a no-op
+  re-save (timestamp-only change) as a real content change, forcing spurious reschedules. Fixed
+  by excluding `updated_at` from both comparisons. For `Task` this could **not** be done via
+  `model_dump(exclude={"updated_at"})`: `Task` is a `PolymorphicBaseModel`, whose
+  `@model_serializer` (`pyobs/utils/serialization.py:44-49`) builds its own dict from
+  `model_fields` via `getattr` and never calls `handler(self)`, so it silently ignores
+  `exclude`/`include` entirely — filed as a separate, wider-scoped follow-up,
+  pyobs-core#855. Worked around locally with `Scheduler._content_dump()`, which dumps
+  normally and pops the key from the resulting dict.
+- **Regression test breadth**: `test_changed_task_ids_ignores_private_attr_mutation` now also
+  sets `_resolved_target`/`_running_script`, not just `_cant_run_reason`, guarding all three
+  `PrivateAttr`s a real scheduling round-trip can touch.
+- **Missing coverage** (nits): added `test_update_schedule_project_removed_triggers_update` and
+  `test_update_schedule_mixed_removed_running_and_changed_scheduled_triggers_update` (the
+  currently-running task removed at the same time as an unrelated, actually-scheduled task's
+  content changes — the latter must still force a reschedule).

--- a/specs/plans/2026-09-01-scheduler-reschedule-on-project-and-task-changes.md
+++ b/specs/plans/2026-09-01-scheduler-reschedule-on-project-and-task-changes.md
@@ -1,6 +1,6 @@
 # Plan: reschedule on project and same-ID task content changes
 
-Status: proposed
+Status: implemented
 
 Tracks issue #848. Repos: pyobs-core (this plan); the signal-delivery half lives in
 `pyobs-portal/specs/plans/2026-09-01-last-task-update-marker-includes-projects.md` (separate
@@ -97,15 +97,16 @@ end (`:221`), the same place `self._tasks = tasks` already happens.
 
 ## Acceptance criteria
 
-- [ ] Project-only content change triggers a reschedule.
-- [ ] Assignment-order bug fixed — old projects are diffed against new before `self._projects`
+- [x] Project-only content change triggers a reschedule.
+- [x] Assignment-order bug fixed — old projects are diffed against new before `self._projects`
       is overwritten.
-- [ ] Same-ID task content change triggers a reschedule when the task is on the current schedule
+- [x] Same-ID task content change triggers a reschedule when the task is on the current schedule
       or is the running task; is skipped when the task isn't on the schedule at all.
-- [ ] Existing `_compare_task_lists` contract and its two removed/added downgrade checks are
+- [x] Existing `_compare_task_lists` contract and its two removed/added downgrade checks are
       unchanged for pure add/remove cases — no regression in current scheduler tests.
-- [ ] New tests listed above pass.
-- [ ] `ruff`/`pyrefly` clean.
+- [x] New tests listed above pass (implemented as `_changed_task_ids()` rather than the
+      originally-sketched `_diff_task_content()` name; behavior matches).
+- [x] `ruff`/`pyrefly` clean. Full non-integration suite (1786 tests) also green.
 
 ## Out of scope
 

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -9,7 +9,7 @@ from pyobs.events import GoodWeatherEvent, TaskFailedEvent, TaskFinishedEvent, T
 from pyobs.interfaces import IRoboticScheduler, IRunning
 from pyobs.modules.robotic import Scheduler
 from pyobs.modules.robotic.scheduler import _class_accepts_param
-from pyobs.robotic import ObservationArchive, Task, TaskArchive
+from pyobs.robotic import ObservationArchive, Project, Task, TaskArchive
 from pyobs.robotic.observation import Observation, ObservationList, ObservationState
 from pyobs.robotic.scheduler import TaskScheduler
 from pyobs.robotic.scheduler.astroplanscheduler import AstroplanScheduler
@@ -77,6 +77,30 @@ def test_compare_block_lists() -> None:
     # both lists should be empty
     assert len(unique1) == 0
     assert len(unique2) == 0
+
+
+def test_changed_task_ids_detects_content_change() -> None:
+    task1a = DummyTask(id=1, name="t1", duration=100, priority=1.0)
+    task1b = DummyTask(id=1, name="t1", duration=100, priority=5.0)
+    task2 = DummyTask(id=2, name="t2", duration=100)
+
+    changed = Scheduler._changed_task_ids([task1a, task2], [task1b, task2])
+
+    assert changed == {1}
+
+
+def test_changed_task_ids_ignores_private_attr_mutation() -> None:
+    # a task that has merely been scheduled/run (can_run()/resolve_target() touch only
+    # PrivateAttrs) must not look "changed" against a freshly downloaded, otherwise-identical
+    # copy -- that's what keeps this comparison from livelocking the scheduler on its own
+    # runtime state.
+    task_before = DummyTask(id=1, name="t1", duration=100)
+    task_after = DummyTask(id=1, name="t1", duration=100)
+    task_after._cant_run_reason = "some reason set at runtime"
+
+    changed = Scheduler._changed_task_ids([task_before], [task_after])
+
+    assert changed == set()
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -324,6 +348,105 @@ async def test_update_schedule_removed_task_in_schedule_triggers_update() -> Non
     await scheduler._update_schedule()
 
     assert scheduler._need_update is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "old_project,new_project",
+    [
+        (
+            Project(code="P1", name="Project 1", priority=1.0),
+            Project(code="P1", name="Project 1", priority=5.0),
+        ),
+        (
+            Project(code="P1", name="Project 1", users=["alice"]),
+            Project(code="P1", name="Project 1", users=["alice", "bob"]),
+        ),
+        (
+            Project(code="P1", name="Project 1", public=False),
+            Project(code="P1", name="Project 1", public=True),
+        ),
+    ],
+    ids=["priority", "users", "public"],
+)
+async def test_update_schedule_project_content_change_triggers_update(old_project, new_project) -> None:
+    scheduler = make_scheduler()
+    task1 = DummyTask(id=1, name="t1", duration=100)
+    scheduler._tasks = [task1]
+    scheduler._projects = [old_project]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task1])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[new_project])
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is True
+    assert scheduler._projects == [new_project]
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_project_and_tasks_unchanged_skips_update() -> None:
+    scheduler = make_scheduler()
+    task1 = DummyTask(id=1, name="t1", duration=100)
+    scheduler._tasks = [task1]
+    scheduler._projects = [Project(code="P1", name="Project 1", priority=1.0)]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task1])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[Project(code="P1", name="Project 1", priority=1.0)])
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is False
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_task_content_change_not_in_schedule_skips_update() -> None:
+    scheduler = make_scheduler()
+    task_old = DummyTask(id=1, name="t1", duration=100, priority=1.0)
+    task_new = DummyTask(id=1, name="t1", duration=100, priority=5.0)
+    scheduler._tasks = [task_old]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task_new])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[])
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList())
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is False
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_task_content_change_in_schedule_triggers_update() -> None:
+    scheduler = make_scheduler()
+    task_old = DummyTask(id=1, name="t1", duration=100, priority=1.0)
+    task_new = DummyTask(id=1, name="t1", duration=100, priority=5.0)
+    scheduler._tasks = [task_old]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task_new])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[])
+    scheduled_obs = make_obs(task_old, "2024-01-01T00:00:00", "2024-01-01T00:05:00")
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([scheduled_obs]))
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is True
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_task_content_change_on_running_task_triggers_update() -> None:
+    # asymmetry vs. a *removed* running task (see test_update_schedule_only_current_task_removed_
+    # skips_update above): a content change on the currently-running task must force a
+    # reschedule regardless of get_schedule() contents, since its new priority can reorder
+    # everything scheduled after it.
+    scheduler = make_scheduler()
+    task_old = DummyTask(id=1, name="t1", duration=100, priority=1.0)
+    task_new = DummyTask(id=1, name="t1", duration=100, priority=5.0)
+    scheduler._tasks = [task_old]
+    scheduler._current_task_id = 1
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task_new])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[])
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList())
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is True
+    scheduler._schedule.get_schedule.assert_not_awaited()
 
 
 # ── _schedule_worker ─────────────────────────────────────────────────────────

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -90,13 +90,28 @@ def test_changed_task_ids_detects_content_change() -> None:
 
 
 def test_changed_task_ids_ignores_private_attr_mutation() -> None:
-    # a task that has merely been scheduled/run (can_run()/resolve_target() touch only
+    # a task that has merely been scheduled/run (can_run()/resolve_target()/run() touch only
     # PrivateAttrs) must not look "changed" against a freshly downloaded, otherwise-identical
     # copy -- that's what keeps this comparison from livelocking the scheduler on its own
-    # runtime state.
+    # runtime state. Exercises every PrivateAttr a real scheduling round-trip can set
+    # (`pyobs/robotic/task.py:53-55`), not just the one _cant_run_reason.
     task_before = DummyTask(id=1, name="t1", duration=100)
     task_after = DummyTask(id=1, name="t1", duration=100)
     task_after._cant_run_reason = "some reason set at runtime"
+    task_after._resolved_target = "stand-in for a resolved Target, set via resolve_target()"
+    task_after._running_script = "stand-in for a Script instance, set via run()"
+
+    changed = Scheduler._changed_task_ids([task_before], [task_after])
+
+    assert changed == set()
+
+
+def test_changed_task_ids_ignores_updated_at() -> None:
+    # updated_at is a portal-side save timestamp, not scheduling content -- a no-op re-save
+    # (e.g. an unchanged DRF PATCH) bumps it without changing anything that matters for
+    # scheduling, and must not be reported as a content change.
+    task_before = DummyTask(id=1, name="t1", duration=100, updated_at="2026-01-01T00:00:00Z")
+    task_after = DummyTask(id=1, name="t1", duration=100, updated_at="2026-01-02T00:00:00Z")
 
     changed = Scheduler._changed_task_ids([task_before], [task_after])
 
@@ -398,6 +413,39 @@ async def test_update_schedule_project_and_tasks_unchanged_skips_update() -> Non
 
 
 @pytest.mark.asyncio
+async def test_update_schedule_project_updated_at_only_change_skips_update() -> None:
+    # updated_at is a portal-side save timestamp, not scheduling content -- a no-op re-save of a
+    # project must not force a reschedule on its own.
+    scheduler = make_scheduler()
+    task1 = DummyTask(id=1, name="t1", duration=100)
+    scheduler._tasks = [task1]
+    scheduler._projects = [Project(code="P1", name="Project 1", updated_at="2026-01-01T00:00:00Z")]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task1])
+    scheduler._task_archive.get_projects = AsyncMock(
+        return_value=[Project(code="P1", name="Project 1", updated_at="2026-01-02T00:00:00Z")]
+    )
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is False
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_project_removed_triggers_update() -> None:
+    scheduler = make_scheduler()
+    task1 = DummyTask(id=1, name="t1", duration=100)
+    scheduler._tasks = [task1]
+    scheduler._projects = [Project(code="P1", name="Project 1"), Project(code="P2", name="Project 2")]
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task1])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[Project(code="P1", name="Project 1")])
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is True
+    assert scheduler._projects == [Project(code="P1", name="Project 1")]
+
+
+@pytest.mark.asyncio
 async def test_update_schedule_task_content_change_not_in_schedule_skips_update() -> None:
     scheduler = make_scheduler()
     task_old = DummyTask(id=1, name="t1", duration=100, priority=1.0)
@@ -447,6 +495,28 @@ async def test_update_schedule_task_content_change_on_running_task_triggers_upda
 
     assert scheduler._need_update is True
     scheduler._schedule.get_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_mixed_removed_running_and_changed_scheduled_triggers_update() -> None:
+    # a mixed poll: the currently-running task ends (removed, alone a no-op) at the same time an
+    # unrelated, actually-scheduled task's content changes -- the latter must still force a
+    # reschedule, not get canceled out by the former.
+    scheduler = make_scheduler()
+    task_running = DummyTask(id=1, name="running", duration=100)
+    task_old = DummyTask(id=3, name="t3", duration=100, priority=1.0)
+    task_new = DummyTask(id=3, name="t3", duration=100, priority=5.0)
+    scheduler._tasks = [task_running, task_old]
+    scheduler._last_task_id = 1
+    scheduler._current_task_id = 1
+    scheduler._task_archive.get_schedulable_tasks = AsyncMock(return_value=[task_new])
+    scheduler._task_archive.get_projects = AsyncMock(return_value=[])
+    scheduled_obs = make_obs(task_old, "2024-01-01T00:00:00", "2024-01-01T00:05:00")
+    scheduler._schedule.get_schedule = AsyncMock(return_value=ObservationList([scheduled_obs]))
+
+    await scheduler._update_schedule()
+
+    assert scheduler._need_update is True
 
 
 # ── _schedule_worker ─────────────────────────────────────────────────────────

--- a/tests/robotic/storage/portal/test_portal_archives.py
+++ b/tests/robotic/storage/portal/test_portal_archives.py
@@ -138,6 +138,29 @@ async def test_task_get_projects_from_portal_accepts_public(mocker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_task_get_projects_from_portal_accepts_updated_at(mocker) -> None:
+    """Projects with the portal `updated_at` field (pyobs-portal#134, pyobs-core#848) ingest
+    without a strict-model ValidationError, and the value round-trips."""
+    archive = make_task_archive()
+    mocker.patch(
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
+        AsyncMock(
+            return_value=[
+                {
+                    "code": "test",
+                    "name": "Test",
+                    "priority": 1.0,
+                    "updated_at": "2026-08-20T17:59:29.526066Z",
+                }
+            ]
+        ),
+    )
+    result = await archive._get_projects()
+    assert len(result) == 1
+    assert result[0].updated_at == "2026-08-20T17:59:29.526066Z"
+
+
+@pytest.mark.asyncio
 async def test_task_get_tasks_from_portal(mocker) -> None:
     archive = make_task_archive()
     mock = mocker.patch(


### PR DESCRIPTION
## Summary
- `Scheduler._update_schedule()` diffed task IDs only, so a project priority change or a same-ID task content change never triggered a reschedule even once the archive re-polled.
- Fixes an assignment-order bug where `self._projects` was overwritten before it could ever be diffed against the previous download.
- Adds project content-diff (`model_dump()`, keyed by `code`, mirroring `PortalTaskArchive._update()`) and a new `Scheduler._changed_task_ids()` helper for same-ID task content diffs.
- New asymmetry vs. removed/added: a content change on the *currently-running* task always forces a reschedule (its new priority can reorder everything after it), unlike a *removed* running task, which is ending anyway. A content change on a task that isn't in the current schedule is skipped, reusing the existing schedule-membership guard.
- **Follow-up commit** (post-review): adds `Project.updated_at` for round-trip compatibility with pyobs-portal#134 (without it, `Project`'s `extra="forbid"` model rejects the portal's payload on every poll — see review below); excludes `updated_at` from the content-diff comparisons so a no-op re-save doesn't force a spurious reschedule; broadens the private-attr regression test; adds coverage for project removal and a mixed removed+changed poll.

Closes #848 (pyobs-core half — the portal-side \`/api/last_task_update/\` marker fix is pyobs-portal#134). **Not independently landable as originally scoped** — see the PR comment below; that's now fixed in this PR.

Also filed #855: \`PolymorphicBaseModel\`'s custom serializer silently ignores \`model_dump(exclude=/include=)\` for every subclass (\`Task\`, \`Script\`, \`Constraint\`, \`Merit\`, \`Target\`), found while fixing this — worked around locally here, real fix is a separate, wider-scoped change.

Plan: \`specs/plans/2026-09-01-scheduler-reschedule-on-project-and-task-changes.md\`

## Test plan
- [x] Unit tests in \`tests/modules/robotic/test_scheduler.py\`: project content-diff (priority/users/public, parametrized, plus removal and an \`updated_at\`-only no-op), same-ID task content-diff (in schedule / not in schedule / on the running task / \`updated_at\`-only no-op / mixed with a removed running task), \`_changed_task_ids()\` unit tests including a private-attr-mutation regression guard.
- [x] Regression test in \`tests/robotic/storage/portal/test_portal_archives.py\` for \`Project.updated_at\` round-tripping through \`_get_projects()\`.
- [x] Existing scheduler test suite unaffected.
- [x] Full non-integration suite: 1786 passed, 0 failed.
- [x] \`ruff\` / \`pyrefly\` clean; \`black\` pre-commit hook passed.