### PR TITLE
fix: honor exclude/include/by_alias/exclude_* on PolymorphicBaseModel

### DIFF
--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -268,18 +268,13 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
 
     @staticmethod
     def _content_dump(task: Task) -> dict[str, Any]:
-        """``task.model_dump()`` with ``updated_at`` stripped.
+        """``task.model_dump(exclude={"updated_at"})``.
 
-        ``Task`` is a ``PolymorphicBaseModel``, whose ``@model_serializer`` builds its own dict
-        from ``model_fields`` and injects a ``class`` key (``pyobs/utils/serialization.py:44-49``)
-        -- it does not honor ``model_dump(exclude=...)`` at all, so the key has to be dropped from
-        the result afterwards instead. ``updated_at`` is a portal-side save timestamp, not
-        scheduling-relevant content, and a no-op re-save (e.g. an unchanged DRF PATCH) still bumps
-        it -- leaving it in would report every no-op edit as a "changed" task.
+        ``updated_at`` is a portal-side save timestamp, not scheduling-relevant content, and a
+        no-op re-save (e.g. an unchanged DRF PATCH) still bumps it -- leaving it in would report
+        every no-op edit as a "changed" task.
         """
-        dump = task.model_dump()
-        dump.pop("updated_at", None)
-        return dump
+        return task.model_dump(exclude={"updated_at"})
 
     @classmethod
     def _changed_task_ids(cls, tasks1: list[Task], tasks2: list[Task]) -> set[Any]:

--- a/pyobs/robotic/storage/filesystem/observationarchive.py
+++ b/pyobs/robotic/storage/filesystem/observationarchive.py
@@ -248,6 +248,12 @@ class YamlObservationArchive(FileSystemObservationArchive):
             return ObservationList([self.pyobs_model_validate(Observation, obs) for obs in observations])
 
     async def _save_observations_to_file(self, path: str, observations: ObservationList) -> None:
+        # exclude_defaults now also applies to the nested (PolymorphicBaseModel) Task/Constraint/
+        # etc. fields, not just Observation's own -- pyobs-core#855 fixed inject_class_on_
+        # serialization() silently ignoring it. Saved YAML files drop more default-valued task
+        # fields (active, empty constraints/merits/script, priority: 1.0, ...) than before; this
+        # is intentional and round-trips fine (model_validate refills the defaults), but anyone
+        # reading these files raw will notice the shape change.
         data = [obs.model_dump(mode="json", exclude_defaults=True) for obs in observations]
         with open(path, "w") as f:
             yaml.safe_dump(data, f)

--- a/pyobs/robotic/storage/portal/taskarchive.py
+++ b/pyobs/robotic/storage/portal/taskarchive.py
@@ -84,21 +84,6 @@ class PortalTaskArchive(TaskArchive):
             await self._update()
             self._last_marker = last_update
 
-    @staticmethod
-    def _task_content_dump(task: Task) -> dict[str, Any]:
-        """``task.model_dump()`` with ``updated_at`` stripped.
-
-        ``Task`` is a ``PolymorphicBaseModel``, whose ``@model_serializer`` builds its own dict
-        from ``model_fields`` (``pyobs/utils/serialization.py``) and does not honor
-        ``model_dump(exclude=...)`` at all, so the key has to be dropped from the result
-        afterwards instead (same workaround as ``Scheduler._content_dump()``). ``updated_at`` is a
-        portal-side save timestamp -- an unchanged DRF PATCH still bumps it via ``auto_now`` -- so
-        leaving it in would flag every no-op re-save as a content change.
-        """
-        dump = task.model_dump()
-        dump.pop("updated_at", None)
-        return dump
-
     async def _update(self) -> None:
         """Fetch tasks/projects from the portal and apply them if anything changed.
 
@@ -108,16 +93,15 @@ class PortalTaskArchive(TaskArchive):
         ``Task._cant_run_reason`` set by ``can_run()``) and would flag unchanged tasks as changed
         on every poll; it is keyed by ID so that a stable reordering of the same items (e.g. an
         unordered portal queryset) is not mistaken for a change. ``updated_at`` is excluded from
-        both comparisons so a no-op re-save doesn't trigger a re-download/reschedule cascade (see
-        pyobs-core#856); ``Project`` isn't polymorphic so ``exclude=`` works directly, while
-        ``Task`` needs :meth:`_task_content_dump`'s pop-after-dump workaround.
+        both comparisons via ``exclude=`` so a no-op re-save doesn't trigger a re-download/
+        reschedule cascade (see pyobs-core#856).
         """
         projects = await self._get_projects()
         tasks = await self._get_tasks()
         if {p.code: p.model_dump(exclude={"updated_at"}) for p in projects} != {
             p.code: p.model_dump(exclude={"updated_at"}) for p in self._projects
-        } or {t.id: self._task_content_dump(t) for t in tasks} != {
-            t.id: self._task_content_dump(t) for t in self._tasks
+        } or {t.id: t.model_dump(exclude={"updated_at"}) for t in tasks} != {
+            t.id: t.model_dump(exclude={"updated_at"}) for t in self._tasks
         }:
             self._projects = projects
             self._tasks = tasks

--- a/pyobs/utils/serialization.py
+++ b/pyobs/utils/serialization.py
@@ -7,7 +7,7 @@ from typing import Any, Self, TypeVar
 from astroplan import Observer
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, PrivateAttr, model_serializer, model_validator
-from pydantic_core.core_schema import ValidationInfo, ValidatorFunctionWrapHandler
+from pydantic_core.core_schema import SerializationInfo, ValidationInfo, ValidatorFunctionWrapHandler
 
 from pyobs.comm import Comm
 from pyobs.object import PrivateAttrMixin
@@ -40,11 +40,57 @@ class BaseModel(PydanticBaseModel, PrivateAttrMixin):
 class PolymorphicBaseModel(BaseModel, metaclass=ABCMeta):  # type: ignore[misc]
     """Pydantic base model for pyobs sub classes that need to be serialized."""
 
+    def _flat_field_spec(self, spec: Any, info_kwarg: str) -> set[str] | None:
+        """Reduce a pydantic `exclude=`/`include=` spec to a flat set of field names.
+
+        `inject_class_on_serialization` hand-builds its output dict instead of delegating to
+        `handler`, so it also has to hand-apply `exclude`/`include` itself -- pydantic's spec
+        grammar supports nested dicts (partial excludes on sub-fields) and integer/`__all__` keys
+        (per-element excludes on sequences), forwarded into each field's own serialization. Doing
+        that generically would mean reimplementing a chunk of pydantic-core's own traversal; since
+        every current caller only ever passes a flat set of top-level field names (see
+        pyobs-core#855), only that flat form is supported. Anything else raises rather than
+        silently ignoring or partially applying the spec.
+        """
+        if spec is None:
+            return None
+        if isinstance(spec, set | frozenset):
+            return set(spec)
+        if isinstance(spec, dict) and all(v is True for v in spec.values()):
+            return set(spec.keys())
+        raise NotImplementedError(
+            f"PolymorphicBaseModel.model_dump() only supports a flat field-name {info_kwarg}= "
+            f"(no nested specs) -- got {spec!r} for {type(self).__name__}; see pyobs-core#855"
+        )
+
     @model_serializer(mode="wrap")
-    def inject_class_on_serialization(self, handler: ValidatorFunctionWrapHandler) -> dict[str, Any]:
+    def inject_class_on_serialization(
+        self, handler: ValidatorFunctionWrapHandler, info: SerializationInfo
+    ) -> dict[str, Any]:
         # Collect fields from the concrete runtime type to avoid Pydantic v2
         # resolving field schemas against the abstract base type when nested in a parent model
-        result = {field_name: getattr(self, field_name) for field_name in type(self).model_fields}
+        if info.exclude_computed_fields and type(self).__pydantic_decorators__.computed_fields:
+            raise NotImplementedError(
+                f"PolymorphicBaseModel.model_dump() doesn't support exclude_computed_fields= for "
+                f"{type(self).__name__}; see pyobs-core#855"
+            )
+        exclude = self._flat_field_spec(info.exclude, "exclude")
+        include = self._flat_field_spec(info.include, "include")
+        fields = type(self).model_fields
+        names = [n for n in fields if (include is None or n in include) and (exclude is None or n not in exclude)]
+
+        result: dict[str, Any] = {}
+        for name in names:
+            value = getattr(self, name)
+            if info.exclude_none and value is None:
+                continue
+            if info.exclude_unset and name not in self.model_fields_set:
+                continue
+            if info.exclude_defaults and value == fields[name].get_default(call_default_factory=True):
+                continue
+            alias = fields[name].alias
+            key = alias if (info.by_alias and alias) else name
+            result[key] = value
         result["class"] = f"{self.__module__}.{self.__class__.__name__}"
         return result
 

--- a/specs/plans/2026-09-02-polymorphic-model-dump-exclude-include.md
+++ b/specs/plans/2026-09-02-polymorphic-model-dump-exclude-include.md
@@ -1,6 +1,6 @@
 # Plan: honor exclude/include/by_alias/exclude_* on PolymorphicBaseModel
 
-Status: proposed
+Status: implemented
 
 Tracks issue #855. Repos: pyobs-core only.
 
@@ -156,14 +156,23 @@ purely cosmetic, and touches code that's already correct — leave alone unless 
 
 ## Acceptance criteria
 
-- [ ] `inject_class_on_serialization` accepts `info: SerializationInfo` and honors flat
+- [x] `inject_class_on_serialization` accepts `info: SerializationInfo` and honors flat
       `exclude`/`include`/`by_alias`/`exclude_none`/`exclude_defaults`/`exclude_unset`.
-- [ ] Any nested (non-flat) `exclude`/`include` spec raises `NotImplementedError` instead of being
-      silently ignored or partially applied.
-- [ ] Plain `model_dump()` (no kwargs) output is unchanged for every existing caller — no
-      regression in current scheduler/task-archive/portal-import tests.
-- [ ] New tests listed above pass.
-- [ ] `ruff`/`pyrefly` clean; full non-integration suite green.
+- [x] Any nested (non-flat) `exclude`/`include` spec raises `NotImplementedError` instead of being
+      silently ignored or partially applied. **Caveat found during implementation**: pydantic-core
+      wraps any exception a `@model_serializer` function raises into its own
+      `pydantic_core.PydanticSerializationError` — the `NotImplementedError` never reaches the
+      caller as its own type, only as embedded text in the wrapped error's message
+      (`"...: NotImplementedError: ..."`). This is pydantic-core's own behavior for every
+      `model_serializer`, not something this fix can avoid; tests assert on
+      `PydanticSerializationError` with `match="NotImplementedError"` rather than
+      `pytest.raises(NotImplementedError)`.
+- [x] Plain `model_dump()` (no kwargs) output is unchanged for every existing caller — no
+      regression in current scheduler/task-archive/portal-import tests (111/111 pass unchanged).
+- [x] New tests listed above pass (15/15, `tests/utils/test_serialization.py`).
+- [x] `ruff`/`black`/`pyrefly` clean; full non-integration suite green (1817 passed; 7 pre-existing,
+      unrelated `tests/cli/test_pyobsd.py` failures confirmed present on `develop` before this
+      change too — local-environment "pyobs executable not found", untouched by this fix).
 
 ## Out of scope
 

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -175,7 +175,7 @@ Implementation plans, checklist-style. Newest at the bottom.
   `PolymorphicBaseModel`'s hand-rolled `model_serializer` silently ignores `exclude`/`include`/
   `by_alias`/`exclude_none`/`exclude_defaults`/`exclude_unset`; make it honor flat (non-nested)
   specs and raise `NotImplementedError` on anything nested rather than silently doing the wrong
-  thing. **proposed** (issue #855; Repos: pyobs-core)
+  thing. **implemented** (issue #855; Repos: pyobs-core)
 - [2026-09-01-instrument-capability-duration-estimates.md](2026-09-01-instrument-capability-duration-estimates.md) —
   feed pyobs-portal#133's instrument capability data (readout/filter-change/slew/dome-rotate
   times) into `Script.estimate_duration()` for `ImagingScript` and 4 other leaf scripts, via a new

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -1,0 +1,143 @@
+import pytest
+from pydantic_core import PydanticSerializationError
+
+from pyobs.robotic.scheduler.constraints.airmassconstraint import AirmassConstraint
+from pyobs.robotic.task import Task
+
+
+def make_task(**kwargs: object) -> Task:
+    return Task(id=1, name="t1", duration=100.0, **kwargs)  # type: ignore[arg-type]
+
+
+# ── exclude/include: flat forms ─────────────────────────────────────────────────────────────
+
+
+def test_exclude_flat_set_drops_field() -> None:
+    d = make_task().model_dump(exclude={"updated_at"})
+    assert "updated_at" not in d
+    assert "id" in d
+
+
+def test_exclude_flat_dict_true_matches_set_form() -> None:
+    t = make_task()
+    assert t.model_dump(exclude={"updated_at": True}) == t.model_dump(exclude={"updated_at"})
+
+
+def test_include_keeps_only_named_fields_plus_class() -> None:
+    d = make_task().model_dump(include={"id", "name"})
+    assert set(d.keys()) == {"id", "name", "class"}
+
+
+def test_exclude_flat_on_nested_subclass_field() -> None:
+    c = AirmassConstraint(max_airmass=2.0)
+    d = c.model_dump(exclude={"target_dependent"})
+    assert "target_dependent" not in d
+    assert d["max_airmass"] == 2.0
+    assert d["class"].endswith("AirmassConstraint")
+
+
+# ── by_alias ─────────────────────────────────────────────────────────────────────────────────
+
+
+def test_by_alias_uses_task_target_alias() -> None:
+    d = make_task().model_dump(by_alias=True)
+    assert "target" in d
+    assert "static_target" not in d
+
+
+def test_by_alias_no_op_when_no_aliased_fields() -> None:
+    c = AirmassConstraint(max_airmass=2.0)
+    assert c.model_dump(by_alias=True) == c.model_dump()
+
+
+# ── exclude_none / exclude_defaults / exclude_unset ─────────────────────────────────────────
+
+
+def test_exclude_none_drops_unset_optional_field() -> None:
+    d = make_task().model_dump(exclude_none=True)
+    assert "static_target" not in d  # defaults to None, never set
+
+
+def test_exclude_defaults_drops_factory_default_and_keeps_explicit_value() -> None:
+    d = make_task().model_dump(exclude_defaults=True)
+    assert "constraints" not in d  # untouched default_factory=list
+
+    d2 = make_task(constraints=[AirmassConstraint(max_airmass=2.0)]).model_dump(exclude_defaults=True)
+    assert "constraints" in d2
+
+
+def test_exclude_unset_drops_field_never_passed_to_constructor() -> None:
+    d = make_task().model_dump(exclude_unset=True)
+    assert "priority" not in d  # never passed, even though it has a non-None default
+    assert "id" in d  # explicitly passed in make_task()
+
+
+# ── nested (unsupported) specs raise ────────────────────────────────────────────────────────
+#
+# The NotImplementedError raised inside inject_class_on_serialization never reaches the caller
+# as-is: pydantic-core wraps any exception a model_serializer function raises into its own
+# PydanticSerializationError, embedding the original type/message in the wrapped text. That's
+# pydantic-core's behavior for every @model_serializer, not something this fix controls.
+
+
+def test_nested_exclude_spec_raises_on_direct_call() -> None:
+    with pytest.raises(PydanticSerializationError, match="NotImplementedError"):
+        make_task().model_dump(exclude={"static_target": {"name"}})
+
+
+def test_nested_exclude_spec_on_child_field_raises_from_parent_call() -> None:
+    t = make_task(constraints=[AirmassConstraint(max_airmass=2.0)])
+    with pytest.raises(PydanticSerializationError, match="NotImplementedError"):
+        t.model_dump(exclude={"constraints": {0: {"cost"}}})
+
+
+def test_nested_include_spec_raises() -> None:
+    with pytest.raises(PydanticSerializationError, match="NotImplementedError"):
+        make_task().model_dump(include={"static_target": {"name"}})
+
+
+# ── regressions ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_plain_dump_unchanged_for_task() -> None:
+    t = make_task()
+    assert t.model_dump() == {
+        "id": 1,
+        "name": "t1",
+        "project": "",
+        "duration": 100.0,
+        "priority": 1.0,
+        "constraints": [],
+        "merits": [],
+        "static_target": None,
+        "script": {},
+        "active": True,
+        "updated_at": None,
+        "class": "pyobs.robotic.task.Task",
+    }
+
+
+def test_plain_dump_unchanged_for_subclass() -> None:
+    c = AirmassConstraint(max_airmass=2.0)
+    assert c.model_dump() == {
+        "cost": 2.0,
+        "target_dependent": True,
+        "max_airmass": 2.0,
+        "class": "pyobs.robotic.scheduler.constraints.airmassconstraint.AirmassConstraint",
+    }
+
+
+def test_nested_subclass_fields_still_resolved_under_abstract_parent_field() -> None:
+    """Guards the reason inject_class_on_serialization bypasses `handler` in the first place:
+    a Constraint subclass nested in Task.constraints (typed list[Constraint]) must still dump
+    its own subclass-specific fields (max_airmass), not just Constraint's base fields."""
+    t = make_task(constraints=[AirmassConstraint(max_airmass=2.0)])
+    d = t.model_dump()
+    assert d["constraints"] == [
+        {
+            "cost": 2.0,
+            "target_dependent": True,
+            "max_airmass": 2.0,
+            "class": "pyobs.robotic.scheduler.constraints.airmassconstraint.AirmassConstraint",
+        }
+    ]


### PR DESCRIPTION
## Summary

- `PolymorphicBaseModel.inject_class_on_serialization()` (`Task`/`Script`/`Constraint`/`Merit`/
  `Target`'s `@model_serializer`) hand-built its output dict via raw `getattr()` and never touched
  `handler`, so `model_dump()`/`model_dump_json()` silently ignored `exclude`, `include`,
  `by_alias`, `exclude_none`, `exclude_unset`, and `exclude_defaults` on every subclass.
- Adds `info: SerializationInfo` and applies all of the above for flat (top-level, non-nested)
  field specs — the only pattern any current caller uses.
- A nested spec (e.g. `{"constraints": {0: {"cost"}}}`) now raises `NotImplementedError` instead
  of being silently ignored or partially applied. Note: pydantic-core wraps any exception a
  `@model_serializer` raises into its own `PydanticSerializationError` before it reaches the
  caller, embedding the original type/message in the wrapped text — that's pydantic-core's own
  behavior, not something this fix controls.
- Full nested-spec support (matching pydantic's own include/exclude grammar for sequences,
  `__all__`, partial nested excludes) is intentionally out of scope — see
  `specs/plans/2026-09-02-polymorphic-model-dump-exclude-include.md`.

Fixes #855.

## Test plan

- [x] New `tests/utils/test_serialization.py` (15 tests): flat exclude/include (set and
      dict-with-`True` forms), `by_alias`, `exclude_none`/`exclude_defaults`/`exclude_unset`,
      nested-spec rejection (direct and via a nested `Constraint` field), plain-dump regression,
      and abstract-type-resolution regression (subclass-specific fields still present under a
      `list[Constraint]`-typed field).
- [x] Full non-integration suite: 1817 passed (7 pre-existing `tests/cli/test_pyobsd.py` failures
      confirmed present on `develop` before this change too — local "pyobs executable not found",
      unrelated).
- [x] `ruff`, `black`, `pyrefly` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJgXh6sdZeSJQ9epwra7H1
