### PR TITLE
ImageWatcher: relative-path preservation and recursive watching

### DIFF
--- a/pyobs/modules/image/imagewatcher.py
+++ b/pyobs/modules/image/imagewatcher.py
@@ -60,13 +60,26 @@ class ImageWatcher(Module):
             wait_time: Time in seconds between adding a file to the list and processing it. Gives a file that is
                 still being written time to finish (relevant for poll mode and the initial scan) and spaces out
                 re-queued files after failed destination copies.
-            pattern: Only watch/process files matching this fnmatch pattern; also applied recursively, i.e. it
-                is matched against the full path, so a pattern like "*.fits" matches files in subdirectories too.
+            pattern: Only watch/process files matching this fnmatch pattern, checked against the full path (so
+                e.g. "*.fits" also matches files found in subdirectories). This is the single point of filtering,
+                applied uniformly in ``add_file`` regardless of watch mode -- inotify events, polling, and the
+                initial scan in ``open()`` all discover candidates first and let ``add_file`` decide, none of
+                them pre-filter by pattern before that.
             flatten: For a non-templated destination (one without ``{placeholder}``s), whether to collapse the
                 file's path to just its basename under that destination (the historical behavior, default) or to
                 preserve its path relative to ``watchpath`` under the destination instead. Files found via
                 recursive watching or polling only keep their subdirectory structure at the destination when this
-                is False.
+                is False. Note this relies on the destination VFS root creating missing parent directories on
+                write (the default for e.g. ``LocalFile``) -- a destination configured to not do that would
+                repeatedly fail and re-queue any file whose relative path needs a parent directory that doesn't
+                exist yet.
+
+        Note:
+            If a directory holding a file that's already queued (added but not yet processed by ``_worker``) is
+            renamed before that happens, the worker's read of the file at its captured (pre-rename) path fails
+            and the file is dropped rather than picked up at its new location -- this is unrelated to, and not
+            covered by, the recursive-watching support for directories renamed after they no longer hold queued
+            files. Avoid renaming directories that may still hold queued/retrying files.
         """
         Module.__init__(self, **kwargs)
 
@@ -101,28 +114,35 @@ class ImageWatcher(Module):
 
         # recursively watch the local directory: watches are added for subdirectories as they're
         # created or moved in, and removed as they're moved out (deletion needs no explicit
-        # removal -- the kernel invalidates the watch on its own, see the plan doc for details)
-        watcher = RecursiveWatcher(Path(local), Mask.CLOSE_WRITE)
-        async for event in watcher.watch_recursive():
-            if event.path is None:
-                continue
+        # removal -- the kernel invalidates the watch on its own, see the plan doc for details).
+        # A directory can also vanish between an event being received and asyncinotify acting on
+        # it (its own add_watch/rm_watch racing a concurrent delete), which raises OSError from
+        # inside the library rather than being handled there. Restart with a fresh watcher (a
+        # full re-walk) on that instead of letting it kill this task outright -- self-heals faster
+        # than falling back to the module's outer background-task restart-with-backoff.
+        while True:
+            try:
+                watcher = RecursiveWatcher(Path(local), Mask.CLOSE_WRITE)
+                async for event in watcher.watch_recursive():
+                    # get filename by replacing local with watchpath
+                    filename = str(event.path).replace(local, self._watchpath)
 
-            # get filename by replacing local with watchpath
-            filename = str(event.path).replace(local, self._watchpath)
-
-            # add file
-            await self.add_file(filename)
+                    # add file
+                    await self.add_file(filename)
+            except OSError as e:
+                log.warning("Inotify watch error (directory likely vanished mid-scan), restarting watch: %s", e)
 
     async def _watch_poll(self) -> None:
-        # init list (recursive, so subdirectories are picked up too)
-        files = set(await self.vfs.find(self._watchpath, self._pattern))
+        # init list (recursive, so subdirectories are picked up too; unfiltered by pattern here --
+        # add_file is the single point of pattern filtering, same as inotify mode)
+        files = set(await self.vfs.find(self._watchpath, "*"))
 
         # run forever
         while True:
             await asyncio.sleep(self._poll_interval)
 
             # get new list
-            new_files = set(await self.vfs.find(self._watchpath, self._pattern))
+            new_files = set(await self.vfs.find(self._watchpath, "*"))
 
             # find all new files and add them
             for f in new_files - files:
@@ -135,8 +155,10 @@ class ImageWatcher(Module):
         """Open image watcher."""
         await Module.open(self)
 
-        # add all files from directory to queue (recursive, so subdirectories are picked up too)
-        for filename in await self.vfs.find(self._watchpath, self._pattern):
+        # add all files from directory to queue (recursive, so subdirectories are picked up too;
+        # unfiltered by pattern here -- add_file is the single point of pattern filtering, same as
+        # inotify mode)
+        for filename in await self.vfs.find(self._watchpath, "*"):
             await self.add_file(os.path.join(self._watchpath, filename))
 
     async def close(self) -> None:

--- a/pyobs/modules/image/imagewatcher.py
+++ b/pyobs/modules/image/imagewatcher.py
@@ -5,7 +5,7 @@ import os
 import time
 import warnings
 from dataclasses import dataclass
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from astropy.io import fits
@@ -47,6 +47,7 @@ class ImageWatcher(Module):
         poll_interval: int = 5,
         wait_time: int = 10,
         pattern: str = "*",
+        flatten: bool = True,
         **kwargs: Any,
     ):
         """Create a new image watcher.
@@ -59,6 +60,13 @@ class ImageWatcher(Module):
             wait_time: Time in seconds between adding a file to the list and processing it. Gives a file that is
                 still being written time to finish (relevant for poll mode and the initial scan) and spaces out
                 re-queued files after failed destination copies.
+            pattern: Only watch/process files matching this fnmatch pattern; also applied recursively, i.e. it
+                is matched against the full path, so a pattern like "*.fits" matches files in subdirectories too.
+            flatten: For a non-templated destination (one without ``{placeholder}``s), whether to collapse the
+                file's path to just its basename under that destination (the historical behavior, default) or to
+                preserve its path relative to ``watchpath`` under the destination instead. Files found via
+                recursive watching or polling only keep their subdirectory structure at the destination when this
+                is False.
         """
         Module.__init__(self, **kwargs)
 
@@ -77,6 +85,7 @@ class ImageWatcher(Module):
         self._poll_interval = poll_interval
         self._wait_time = wait_time
         self._pattern = pattern
+        self._flatten = flatten
         self.current_file: CurrentFile | None = None
 
         # filename patterns
@@ -85,49 +94,49 @@ class ImageWatcher(Module):
         self._destinations = destinations
 
     async def _watch_inotify(self) -> None:
-        from asyncinotify import Inotify, Mask
+        from asyncinotify import Mask, RecursiveWatcher
 
         # get local directory
         local = await self.vfs.local_path(self._watchpath)
 
-        # Context manager to close the inotify handle after use
-        with Inotify() as inotify:
-            # add watch on local directory
-            inotify.add_watch(local, Mask.CLOSE_WRITE)
+        # recursively watch the local directory: watches are added for subdirectories as they're
+        # created or moved in, and removed as they're moved out (deletion needs no explicit
+        # removal -- the kernel invalidates the watch on its own, see the plan doc for details)
+        watcher = RecursiveWatcher(Path(local), Mask.CLOSE_WRITE)
+        async for event in watcher.watch_recursive():
+            if event.path is None:
+                continue
 
-            # iterate events forever
-            async for event in inotify:
-                # get filename by replacing local with watchpath
-                filename = str(event.path).replace(local, self._watchpath)
+            # get filename by replacing local with watchpath
+            filename = str(event.path).replace(local, self._watchpath)
 
-                # add file
-                await self.add_file(filename)
+            # add file
+            await self.add_file(filename)
 
     async def _watch_poll(self) -> None:
-        # init list
-        files = set(await self.vfs.listdir(self._watchpath))
+        # init list (recursive, so subdirectories are picked up too)
+        files = set(await self.vfs.find(self._watchpath, self._pattern))
 
         # run forever
-        path = PurePosixPath(self._watchpath)
         while True:
+            await asyncio.sleep(self._poll_interval)
+
             # get new list
-            new_files = await self.vfs.listdir(self._watchpath)
+            new_files = set(await self.vfs.find(self._watchpath, self._pattern))
 
             # find all new files and add them
-            for f in new_files:
-                if f not in files:
-                    print(str(path / f))
-                    await self.add_file(str(path / f))
+            for f in new_files - files:
+                await self.add_file(os.path.join(self._watchpath, f))
 
             # store new list
-            files = set(new_files)
+            files = new_files
 
     async def open(self) -> None:
         """Open image watcher."""
         await Module.open(self)
 
-        # add all files from directory to queue
-        for filename in await self.vfs.listdir(self._watchpath):
+        # add all files from directory to queue (recursive, so subdirectories are picked up too)
+        for filename in await self.vfs.find(self._watchpath, self._pattern):
             await self.add_file(os.path.join(self._watchpath, filename))
 
     async def close(self) -> None:
@@ -193,9 +202,14 @@ class ImageWatcher(Module):
                         if out_filename is None:
                             raise ValueError("Could not create name for file.")
 
-                    else:
+                    elif self._flatten:
                         # no formatting, so just add filename to destination
                         out_filename = os.path.join(pattern, os.path.basename(filename))
+
+                    else:
+                        # preserve the file's path relative to watchpath under the destination
+                        rel = PurePosixPath(filename).relative_to(self._watchpath)
+                        out_filename = str(PurePosixPath(pattern) / rel)
 
                     # store it
                     log.info("Storing file as %s...", out_filename)

--- a/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
+++ b/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
@@ -49,17 +49,39 @@ instead of a hand-rolled watch table avoids re-deriving both cases from scratch.
       `watch_recursive()` already filters its yielded events to ones matching the passed-in mask
       (`if event.mask & self._mask: yield event`), so no manual filtering of the internal
       `CREATE`/`MOVED_FROM`/`MOVED_TO`/`IGNORED` bookkeeping events is needed on our side.
+- [x] Robustness (caught in review): `watch_recursive()`'s internal `add_watch`/`rm_watch` calls
+      can raise `OSError` if a directory vanishes between an event being received and the library
+      acting on it — a real possibility under directory churn, not hypothetical. Left unhandled,
+      that exits `_watch_inotify` entirely; the module's outer `BackgroundTask` machinery restarts
+      it, but repeated churn risks tripping its failure-quit guard. Wrapped the watch loop in
+      `while True: try: ... except OSError: log.warning(...)`, so a single vanished directory just
+      triggers a fresh `RecursiveWatcher` (full re-walk) locally instead of propagating up.
 - [x] `_watch_poll` needs the equivalent for polling mode: recursive listing instead of a flat
       `vfs.listdir` (`imagewatcher.py:108-123`) — no library helper for this path, since polling
-      doesn't go through `asyncinotify` at all. Implemented via `vfs.find(watchpath, pattern)`
-      (only `LocalFile` implements `find()` today — other VFS root types raise, so recursive poll
-      mode is implicitly local-filesystem-only, same constraint inotify mode already has via
-      `vfs.local_path()`). While rewriting this method, also fixed two pre-existing bugs directly
-      in the code being touched: `poll_interval` was stored but never actually awaited between
-      iterations (a busy-loop), and a stray debug `print()` was left in the new-file branch.
+      doesn't go through `asyncinotify` at all. Implemented via `vfs.find(watchpath, "*")`, always
+      unfiltered (see the pattern-filtering note below) — **correction**: an earlier version of
+      this doc claimed "only `LocalFile` implements `find()`, other VFS root types raise"; that's
+      wrong. `VFSFile.find` is a concrete base-class method (flat `listdir` + `fnmatch`, not
+      recursive), inherited by SSH/SMB/SFTP/TempFile — so a non-local watchpath in poll mode or
+      `open()` doesn't raise, it silently stays non-recursive instead. Only `LocalFile.find`
+      actually walks (`os.walk`) subdirectories. Recursive poll/`open()` behavior is therefore
+      still implicitly local-filesystem-only in effect, just via silent flat fallback rather than
+      an error — worth a log warning on a non-recursive `find()` result if this becomes a real
+      footgun in practice, not done in this PR. While rewriting `_watch_poll`, also fixed two
+      pre-existing bugs directly in the code being touched: `poll_interval` was stored but never
+      actually awaited between iterations (a busy-loop), and a stray debug `print()` was left in
+      the new-file branch.
 - [x] `open()`'s initial scan (`imagewatcher.py:130-131`, flat `listdir`) needs the same recursive
       treatment, or files present before the module starts get missed. Also switched to
       `vfs.find()`.
+- [x] Pattern filtering, unified: `_watch_poll`/`open()` originally pre-filtered their `find()` call
+      by `pattern` (matched only against each entry's basename, per-directory, by `find`'s own
+      `fnmatch.filter`), while inotify mode never pre-filters and relies solely on `add_file`'s
+      check against the *full* path. That's a real behavioral divergence (caught in review): a
+      pattern like `*2026*` would match a file under a `2026/` subdirectory in inotify mode but not
+      in poll/`open()` mode, since the full-path/basename distinction changes what matches. Fixed
+      by always calling `find(watchpath, "*")` (no pre-filtering) and letting `add_file`'s existing
+      full-path `fnmatch` check be the single point of pattern filtering across all three paths.
 
 ### Known limitation (not fixed, not fixable at this layer)
 
@@ -83,6 +105,26 @@ recursive `find()` the initial scan/poll mode already does, on some interval, to
 inotify missed). Flagging for whichever downstream plan integrates this so that mitigation gets
 scoped explicitly rather than assumed away.
 
+### Second known limitation: a directory renamed while it still holds a queued file
+
+Caught in review, and distinct from the race above (which is about *destination* directories not
+yet watched). `add_file` captures a file's path at event/scan time and queues it; `_worker`
+doesn't read that file until `wait_time` later. If the directory holding that file is renamed in
+between (recursive watching keeps tracking the directory itself fine — this isn't about missing
+the rename), the worker's read at the now-stale captured path fails, and the generic exception
+handler in `_worker` just logs and moves on — the file is not re-queued at its new location. Note
+also that a *file* itself being renamed into an already-watched directory is never observed
+either way, queued or not: `MOVED_TO` on a file isn't `CLOSE_WRITE`, so it was never delivered
+here even before this PR — unchanged, pre-existing semantics, not a new gap.
+
+Practical exposure is low if a consumer's workflow only renames a directory once it's done writing
+into it and *before* anything has had a chance to be queued from it (e.g. the whole directory is
+renamed as one atomic step, then files get *added to* the queue only after settling under their
+final name) — the two real-filesystem tests here follow exactly that ordering. Not fixed in this
+PR; flagged for whichever downstream plan/deployment integrates this so directory-move timing gets
+designed around it rather than assumed safe. The same periodic reconciliation re-scan mitigation
+above would also catch anything dropped this way.
+
 ## 3. Cleanup, tests, docs, release
 
 - [ ] Clean up now-empty local subdirectories once their files have all moved (extend
@@ -101,3 +143,20 @@ scoped explicitly rather than assumed away.
       Sphinx pulls this in automatically via `autoclass ... :members:`, no separate `.rst` edit
       needed.
 - [ ] Release per pyobs-core conventions — not done yet, pending PR review/merge.
+
+### Review follow-up (thusser, PR #860)
+
+All non-blocking findings addressed:
+
+1. Pattern-filtering divergence between watch modes — fixed, see the "Pattern filtering, unified"
+   item above.
+2. `find()`-on-non-local-roots claim was wrong — corrected above.
+3. Directory-renamed-while-holding-a-queued-file gap — documented as a second known limitation
+   above and in the class docstring; not fixed (same reasoning as the first known limitation).
+4. `asyncinotify` `OSError` under directory churn — fixed, see the new checklist item above.
+5. Nits: removed the dead `event.path is None` guard in `_watch_inotify` (confirmed unreachable —
+   `CLOSE_WRITE` events always carry a path) per this repo's own "don't guard against what can't
+   happen" convention; rewrote the poll test that relied on implicit `AsyncMock` `side_effect`
+   list exhaustion to terminate via the same explicit sleep-then-cancel pattern every other test
+   here uses; documented the `flatten=False` + non-mkdir-destination edge case in the `flatten`
+   docstring; §3's empty-dir cleanup deferral needs no change, already tracked as open above.

--- a/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
+++ b/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
@@ -1,0 +1,69 @@
+# Plan: ImageWatcher — relative-path preservation and recursive watching
+
+Status: planned
+
+## Context
+
+A downstream consumer needs `ImageWatcher` to relocate a whole nested directory tree (e.g.
+`{a}/{b}/{c}/{files...}`) from local staging disk to a network share, preserving structure, so
+that data survives an outage of that network share instead of being written to it live. This doc
+covers only what changes in `pyobs-core`'s `ImageWatcher` itself, written generically since it's a
+shared fleet module and other configs may already depend on its current flat/flatten-to-basename
+behavior.
+
+`pyobs/modules/image/imagewatcher.py` already does most of what's needed: watch a directory, copy
+each new file to one or more destinations, delete the source only once every destination
+succeeded, and re-queue (retry) on a destination write failure — so an outage stalls and retries
+rather than dropping anything, with no changes required for that part. Two gaps remain:
+
+## 1. Relative-path preservation
+
+- [ ] Add a `flatten: bool = True` constructor option. Default `True` preserves current behavior
+      for every existing user of `ImageWatcher` fleet-wide (no silent semantics change).
+- [ ] When `False`, the non-templated destination branch in `_worker` computes `out_filename` via
+      `filename.replace(self._watchpath, pattern)` instead of
+      `os.path.join(pattern, os.path.basename(filename))` (`imagewatcher.py:198`), preserving
+      subdirectory structure between source and destination. The FITS-header-templated branch
+      (`imagewatcher.py:190-194`) is unaffected either way — it already builds its own path from
+      header placeholders.
+
+## 2. Recursive watching
+
+`_watch_inotify` currently does one non-recursive `inotify.add_watch(local, Mask.CLOSE_WRITE)`
+(`imagewatcher.py:96`), built on `asyncinotify.Inotify`. `asyncinotify` (already a dependency, ≥
+4.2.1 in-fleet) ships `RecursiveInotify`, a drop-in subclass with `add_recursive_watch()`: it walks
+and watches all subdirectories up front, then keeps itself in sync — adds watches on
+`CREATE`/`MOVED_TO`, drops them on `MOVED_FROM`, and relies on the kernel's automatic `IGNORED`
+event (which its base `Inotify.get()` already handles, `__init__.py:596-598`) to clean up watches
+on plain deletion, with no explicit `rm_watch()` call needed for that case. This matters
+concretely: a consumer like the one motivating this doc deletes-and-recreates one directory before
+every run (auto-handled for free) and *renames* a directory into its final location once a run
+completes (needs the `MOVED_FROM`/`MOVED_TO` pairing `RecursiveInotify` already implements) — so
+building on it instead of a hand-rolled watch table avoids re-deriving both cases from scratch.
+
+- [ ] Switch `_watch_inotify` to `RecursiveInotify` + `add_recursive_watch(local)` instead of plain
+      `Inotify` + `add_watch`. Confirm the `CLOSE_WRITE` mask composes correctly with
+      `RecursiveInotify`'s own `_DIR_MASK` (`MOVED_FROM | MOVED_TO | CREATE | IGNORED`) — the
+      constructor ORs a passed-in mask with `_DIR_MASK` (`add_recursive_watch`,
+      `asyncinotify/__init__.py:703-723`), so this should be additive rather than requiring
+      separate bookkeeping.
+- [ ] `_watch_poll` needs the equivalent for polling mode: recursive listing instead of a flat
+      `vfs.listdir` (`imagewatcher.py:108-123`) — no library helper for this path, since polling
+      doesn't go through `asyncinotify` at all.
+- [ ] `open()`'s initial scan (`imagewatcher.py:130-131`, flat `listdir`) needs the same recursive
+      treatment, or files present before the module starts get missed.
+
+## 3. Cleanup, tests, docs, release
+
+- [ ] Clean up now-empty local subdirectories once their files have all moved (extend
+      `cleanup_extra`, or a small periodic sweep) — otherwise a deeply nested watch tree
+      accumulates empty directories forever. This is a local-disk/filesystem cleanup concern, not
+      an inotify-watch-leak concern — §2 already established that watches for deleted directories
+      clean themselves up automatically. Open question: automatic, or is a periodic manual sweep
+      acceptable for the first version?
+- [ ] Tests: existing flat-mode behavior stays a pure regression; add coverage for recursive
+      watching (including delete-and-recreate and rename-into-place, the two patterns identified
+      in §2), `flatten=False` path preservation, and confirm retry-on-destination-failure still
+      works with both new modes.
+- [ ] Docs: update the `ImageWatcher` docstring/Sphinx reference for the new option.
+- [ ] Release per pyobs-core conventions.

--- a/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
+++ b/specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md
@@ -1,6 +1,6 @@
 # Plan: ImageWatcher — relative-path preservation and recursive watching
 
-Status: planned
+Status: **implemented, PR open** — cleanup-of-empty-dirs (§3) deliberately deferred, see below
 
 ## Context
 
@@ -18,40 +18,70 @@ rather than dropping anything, with no changes required for that part. Two gaps 
 
 ## 1. Relative-path preservation
 
-- [ ] Add a `flatten: bool = True` constructor option. Default `True` preserves current behavior
+- [x] Add a `flatten: bool = True` constructor option. Default `True` preserves current behavior
       for every existing user of `ImageWatcher` fleet-wide (no silent semantics change).
-- [ ] When `False`, the non-templated destination branch in `_worker` computes `out_filename` via
-      `filename.replace(self._watchpath, pattern)` instead of
-      `os.path.join(pattern, os.path.basename(filename))` (`imagewatcher.py:198`), preserving
-      subdirectory structure between source and destination. The FITS-header-templated branch
-      (`imagewatcher.py:190-194`) is unaffected either way — it already builds its own path from
-      header placeholders.
+- [x] When `False`, the non-templated destination branch in `_worker` preserves subdirectory
+      structure between source and destination (implemented via `PurePosixPath.relative_to` +
+      join, not the naive `str.replace` originally sketched here — safer against a path
+      coincidentally recurring elsewhere in the string). The FITS-header-templated branch is
+      unaffected either way — it already builds its own path from header placeholders.
 
 ## 2. Recursive watching
 
 `_watch_inotify` currently does one non-recursive `inotify.add_watch(local, Mask.CLOSE_WRITE)`
-(`imagewatcher.py:96`), built on `asyncinotify.Inotify`. `asyncinotify` (already a dependency, ≥
-4.2.1 in-fleet) ships `RecursiveInotify`, a drop-in subclass with `add_recursive_watch()`: it walks
-and watches all subdirectories up front, then keeps itself in sync — adds watches on
-`CREATE`/`MOVED_TO`, drops them on `MOVED_FROM`, and relies on the kernel's automatic `IGNORED`
-event (which its base `Inotify.get()` already handles, `__init__.py:596-598`) to clean up watches
-on plain deletion, with no explicit `rm_watch()` call needed for that case. This matters
-concretely: a consumer like the one motivating this doc deletes-and-recreates one directory before
-every run (auto-handled for free) and *renames* a directory into its final location once a run
-completes (needs the `MOVED_FROM`/`MOVED_TO` pairing `RecursiveInotify` already implements) — so
-building on it instead of a hand-rolled watch table avoids re-deriving both cases from scratch.
+(`imagewatcher.py:96`), built on `asyncinotify.Inotify`. `asyncinotify` ships two recursive
+helpers; which one is available depends on version. `RecursiveInotify` (an `Inotify` subclass with
+`add_recursive_watch()`) is newer and not present at the fleet's pinned floor (`>=4.2.1,<5` in
+`pyproject.toml` — checked directly against the `4.2.1` sdist, which has it. `RecursiveWatcher`
+(an async-generator wrapper around a plain `Inotify`, same file) *is* present at `4.2.1`, so that's
+the one to build on without bumping the dependency floor. Both implement the same policy: add
+watches on `CREATE`/`MOVED_TO`, drop them on `MOVED_FROM`, and rely on the kernel's automatic
+`IGNORED` event to clean up watches on plain deletion (no explicit `rm_watch()` call needed for
+that case — `RecursiveWatcher.watch_recursive()`'s own comment: "DELETE event is not
+watched/handled here because IGNORED event follows deletion"). This matters concretely: a consumer
+like the one motivating this doc deletes-and-recreates one directory before every run (auto-handled
+for free) and *renames* a directory into its final location once a run completes (needs the
+`MOVED_FROM`/`MOVED_TO` pairing these helpers already implement) — so building on one of them
+instead of a hand-rolled watch table avoids re-deriving both cases from scratch.
 
-- [ ] Switch `_watch_inotify` to `RecursiveInotify` + `add_recursive_watch(local)` instead of plain
-      `Inotify` + `add_watch`. Confirm the `CLOSE_WRITE` mask composes correctly with
-      `RecursiveInotify`'s own `_DIR_MASK` (`MOVED_FROM | MOVED_TO | CREATE | IGNORED`) — the
-      constructor ORs a passed-in mask with `_DIR_MASK` (`add_recursive_watch`,
-      `asyncinotify/__init__.py:703-723`), so this should be additive rather than requiring
-      separate bookkeeping.
-- [ ] `_watch_poll` needs the equivalent for polling mode: recursive listing instead of a flat
+- [x] Switch `_watch_inotify` to `RecursiveWatcher(Path(local), Mask.CLOSE_WRITE)` +
+      `async for event in watcher.watch_recursive():` instead of plain `Inotify` + `add_watch`.
+      `watch_recursive()` already filters its yielded events to ones matching the passed-in mask
+      (`if event.mask & self._mask: yield event`), so no manual filtering of the internal
+      `CREATE`/`MOVED_FROM`/`MOVED_TO`/`IGNORED` bookkeeping events is needed on our side.
+- [x] `_watch_poll` needs the equivalent for polling mode: recursive listing instead of a flat
       `vfs.listdir` (`imagewatcher.py:108-123`) — no library helper for this path, since polling
-      doesn't go through `asyncinotify` at all.
-- [ ] `open()`'s initial scan (`imagewatcher.py:130-131`, flat `listdir`) needs the same recursive
-      treatment, or files present before the module starts get missed.
+      doesn't go through `asyncinotify` at all. Implemented via `vfs.find(watchpath, pattern)`
+      (only `LocalFile` implements `find()` today — other VFS root types raise, so recursive poll
+      mode is implicitly local-filesystem-only, same constraint inotify mode already has via
+      `vfs.local_path()`). While rewriting this method, also fixed two pre-existing bugs directly
+      in the code being touched: `poll_interval` was stored but never actually awaited between
+      iterations (a busy-loop), and a stray debug `print()` was left in the new-file branch.
+- [x] `open()`'s initial scan (`imagewatcher.py:130-131`, flat `listdir`) needs the same recursive
+      treatment, or files present before the module starts get missed. Also switched to
+      `vfs.find()`.
+
+### Known limitation (not fixed, not fixable at this layer)
+
+Confirmed by direct reproduction (both a standalone script against `asyncinotify` and a pytest
+case, kept as `test_watch_inotify_loses_race_on_rename_into_freshly_created_deep_dir`,
+`xfail(strict=True)`): when a *destination* directory tree that doesn't exist yet is created and
+something is renamed into it before this process's asyncio loop gets scheduled to consume the
+resulting `CREATE` event(s) and add a watch, the move is never observed — inotify only reports
+events for already-watched parents, and nothing later re-discovers the miss. This is a genuine
+kernel/library-level race, not a bug introduced here; `asyncinotify`'s own example script
+documents the same caveat ("doing two changes on a directory before the program has a time to
+handle it"). A directory whose parent tree already exists (or existed at watcher startup) is
+unaffected — proven by `test_watch_inotify_survives_rename_into_watched_tree`, which passes.
+
+For a consumer whose directories are per-day (e.g. `{year}/{month}/{date}/...`), this means only
+the *first* write of a new day/month is at risk (every subsequent `mkdir(exist_ok=True)` into an
+already-existing tree is a no-op — no `CREATE` event, no race). If lost, nothing recovers it on
+its own. Mitigation belongs at the consumer/deployment level, not in `ImageWatcher` itself — the
+standard fix for inotify-based systems is a periodic reconciliation re-scan (re-running the same
+recursive `find()` the initial scan/poll mode already does, on some interval, to catch anything
+inotify missed). Flagging for whichever downstream plan integrates this so that mitigation gets
+scoped explicitly rather than assumed away.
 
 ## 3. Cleanup, tests, docs, release
 
@@ -60,10 +90,14 @@ building on it instead of a hand-rolled watch table avoids re-deriving both case
       accumulates empty directories forever. This is a local-disk/filesystem cleanup concern, not
       an inotify-watch-leak concern — §2 already established that watches for deleted directories
       clean themselves up automatically. Open question: automatic, or is a periodic manual sweep
-      acceptable for the first version?
-- [ ] Tests: existing flat-mode behavior stays a pure regression; add coverage for recursive
-      watching (including delete-and-recreate and rename-into-place, the two patterns identified
-      in §2), `flatten=False` path preservation, and confirm retry-on-destination-failure still
-      works with both new modes.
-- [ ] Docs: update the `ImageWatcher` docstring/Sphinx reference for the new option.
-- [ ] Release per pyobs-core conventions.
+      acceptable for the first version? **Not implemented in this PR** — deferred, still open.
+- [x] Tests: existing flat-mode behavior stays a pure regression (all pre-existing tests still
+      pass unmodified); added coverage for recursive watching (new-subdirectory pickup,
+      delete-and-recreate, rename-into-an-already-watched-tree, and the known
+      rename-into-freshly-created-tree race as an `xfail`), `flatten=False`/`flatten=True` path
+      handling (including that the FITS-header-templated branch is unaffected by `flatten`), and
+      the `poll_interval` busy-loop fix.
+- [x] Docs: `ImageWatcher`'s docstring covers `flatten` and the recursive `pattern` matching;
+      Sphinx pulls this in automatically via `autoclass ... :members:`, no separate `.rst` edit
+      needed.
+- [ ] Release per pyobs-core conventions — not done yet, pending PR review/merge.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -202,3 +202,7 @@ Implementation plans, checklist-style. Newest at the bottom.
   of that same guard for `removed` (both silently discarded real changes against
   `PortalObservationArchive`'s permanently-empty schedule cache). **implemented** (issue #848; PR
   #854; Repos: pyobs-core; portal-side signal fix pyobs-portal#134)
+- [2026-09-02-imagewatcher-relative-path-recursive.md](2026-09-02-imagewatcher-relative-path-recursive.md) —
+  `ImageWatcher`: optional relative-path preservation (`flatten=False`) and recursive directory
+  watching, needed so it can relocate a nested directory tree wholesale instead of flattening it.
+  **planned**

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -205,4 +205,4 @@ Implementation plans, checklist-style. Newest at the bottom.
 - [2026-09-02-imagewatcher-relative-path-recursive.md](2026-09-02-imagewatcher-relative-path-recursive.md) —
   `ImageWatcher`: optional relative-path preservation (`flatten=False`) and recursive directory
   watching, needed so it can relocate a nested directory tree wholesale instead of flattening it.
-  **planned**
+  **implemented, PR open** (PR #860)

--- a/tests/modules/image/test_imagewatcher.py
+++ b/tests/modules/image/test_imagewatcher.py
@@ -367,7 +367,12 @@ async def test_worker_flatten_false_still_uses_fits_header_template() -> None:
 @pytest.mark.asyncio
 async def test_watch_poll_picks_up_nested_files() -> None:
     watcher = make_watcher(poll=True, poll_interval=0)
-    watcher._vfs.find = AsyncMock(side_effect=[[], ["2026/09/02/test.fits"]])
+    # side_effect list: first call is the initial scan (empty), every call after returns the
+    # nested file -- avoids relying on list exhaustion to end the test (that would raise
+    # StopAsyncIteration inside the task instead of the explicit cancel below doing it).
+    watcher._vfs.find = AsyncMock(
+        side_effect=lambda *a, **kw: [] if watcher._vfs.find.call_count == 1 else ["2026/09/02/test.fits"]
+    )
 
     added: list[str] = []
 
@@ -385,6 +390,38 @@ async def test_watch_poll_picks_up_nested_files() -> None:
         pass
 
     assert added == ["/watch/2026/09/02/test.fits"]
+    # pattern filtering happens in add_file, not here: find() is always called unfiltered
+    watcher._vfs.find.assert_called_with("/watch", "*")
+
+
+@pytest.mark.asyncio
+async def test_watch_poll_and_inotify_apply_pattern_consistently() -> None:
+    """Regression for a review finding: poll mode used to pre-filter find() by pattern (matched
+    per-directory against each entry's basename), while inotify mode only ever filtered in
+    add_file (matched against the full path) -- a real behavioral divergence for a pattern like
+    "*2026*" against a file under a "2026/" subdirectory. Both now defer entirely to add_file, so
+    this exercises the real (unmocked) add_file to prove the filtering actually happens there."""
+    watcher = make_watcher(poll=True, poll_interval=0, pattern="*.fits")
+    found = ["2026/keep.fits", "2026/skip.txt"]
+    # first call (the initial baseline scan) sees nothing yet, so the files "found" afterward
+    # register as new and get queued
+    watcher._vfs.find = AsyncMock(side_effect=lambda *a, **kw: [] if watcher._vfs.find.call_count == 1 else found)
+
+    task = asyncio.create_task(watcher._watch_poll())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    # find() itself is unfiltered ("*"); only the .fits file survives add_file's own check
+    watcher._vfs.find.assert_called_with("/watch", "*")
+    queued = []
+    while not watcher._queue.empty():
+        filename, _ = watcher._queue.get_nowait()
+        queued.append(filename)
+    assert queued == ["/watch/2026/keep.fits"]
 
 
 @pytest.mark.asyncio
@@ -550,6 +587,56 @@ async def test_watch_inotify_survives_rename_into_watched_tree(tmp_path: Path) -
         pass
 
     assert added == ["/watch/2026/09/02/result.fits"]
+
+
+@pytest.mark.asyncio
+async def test_watch_inotify_restarts_on_oserror(monkeypatch) -> None:
+    """Regression for a review finding: asyncinotify's own add_watch/rm_watch (inside
+    watch_recursive()) can raise OSError if a directory vanishes between an event being received
+    and the library acting on it -- real under directory churn, not hypothetical. Confirm
+    _watch_inotify catches it and restarts with a fresh RecursiveWatcher instead of letting the
+    whole background task die."""
+    watcher = make_watcher()
+    watcher._vfs.local_path = AsyncMock(return_value="/some/local/path")
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    class FakeEvent:
+        def __init__(self, path: Path) -> None:
+            self.path = path
+
+    attempts = 0
+
+    class FakeRecursiveWatcher:
+        def __init__(self, path: Path, mask: object) -> None:
+            nonlocal attempts
+            attempts += 1
+            self._attempt = attempts
+
+        async def watch_recursive(self):
+            if self._attempt == 1:
+                # simulate a directory vanishing mid-scan, as asyncinotify's own bookkeeping would
+                raise OSError("directory vanished mid-scan")
+            yield FakeEvent(Path("/some/local/path/test.fits"))
+            await asyncio.sleep(3600)  # stay "alive" until the test cancels it
+
+    monkeypatch.setattr("asyncinotify.RecursiveWatcher", FakeRecursiveWatcher)
+
+    task = asyncio.create_task(watcher._watch_inotify())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert attempts == 2, "expected a fresh RecursiveWatcher after the first one's OSError"
+    assert added == ["/watch/test.fits"]
 
 
 @pytest.mark.xfail(strict=True, reason="known asyncinotify/kernel-level race, see docstring")

--- a/tests/modules/image/test_imagewatcher.py
+++ b/tests/modules/image/test_imagewatcher.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import logging
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -16,12 +17,17 @@ from pyobs.modules.image.imagewatcher import ImageWatcher
 from pyobs.vfs import VirtualFileSystem
 
 
-def make_watcher(destinations=None, pattern="*", wait_time=0) -> ImageWatcher:
+def make_watcher(
+    destinations=None, pattern="*", wait_time=0, flatten=True, poll=False, poll_interval=5
+) -> ImageWatcher:
     return ImageWatcher(
         watchpath="/watch",
         destinations=destinations or ["/dest"],
         pattern=pattern,
         wait_time=wait_time,
+        flatten=flatten,
+        poll=poll,
+        poll_interval=poll_interval,
         comm=DummyComm(),
         vfs=MagicMock(spec=VirtualFileSystem),
     )
@@ -269,3 +275,332 @@ async def test_cleanup_extra_is_noop() -> None:
 def test_constructor_raises_without_destinations() -> None:
     with pytest.raises(ValueError, match="No filename patterns"):
         ImageWatcher(watchpath="/watch", destinations=[])
+
+
+# ── flatten ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_worker_flattens_nested_path_by_default() -> None:
+    """flatten=True (default): a file found in a subdirectory still lands at the destination
+    root, keyed only by its basename -- the pre-existing, non-recursive behavior."""
+    watcher = make_watcher(destinations=["/dest"], wait_time=0, flatten=True)
+    data = b"raw data"
+    read_ctx, write_ctx = make_read_write_ctx(data)
+
+    def open_side_effect(filename, mode):
+        return read_ctx if mode == "rb" else write_ctx
+
+    watcher._vfs.open_file = MagicMock(side_effect=open_side_effect)
+    watcher._vfs.remove = AsyncMock(return_value=True)
+
+    watcher._queue.put_nowait(("/watch/2026/09/02/test.fits", 0.0))
+    task = asyncio.create_task(watcher._worker())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert watcher.current_file is not None
+    assert watcher.current_file.out_filename == "/dest/test.fits"
+
+
+@pytest.mark.asyncio
+async def test_worker_preserves_relative_path_when_not_flattened() -> None:
+    """flatten=False: a file found in a subdirectory keeps that subdirectory structure under
+    the destination."""
+    watcher = make_watcher(destinations=["/dest"], wait_time=0, flatten=False)
+    data = b"raw data"
+    read_ctx, write_ctx = make_read_write_ctx(data)
+
+    def open_side_effect(filename, mode):
+        return read_ctx if mode == "rb" else write_ctx
+
+    watcher._vfs.open_file = MagicMock(side_effect=open_side_effect)
+    watcher._vfs.remove = AsyncMock(return_value=True)
+
+    watcher._queue.put_nowait(("/watch/2026/09/02/test.fits", 0.0))
+    task = asyncio.create_task(watcher._worker())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert watcher.current_file is not None
+    assert watcher.current_file.out_filename == "/dest/2026/09/02/test.fits"
+
+
+@pytest.mark.asyncio
+async def test_worker_flatten_false_still_uses_fits_header_template() -> None:
+    """flatten only governs the non-templated branch -- a {placeholder} destination pattern
+    is unaffected either way."""
+    watcher = make_watcher(destinations=["/dest/{FNAME}"], wait_time=0, flatten=False)
+    data = make_fits_bytes()
+    read_ctx, write_ctx = make_read_write_ctx(data)
+
+    def open_side_effect(filename, mode):
+        return read_ctx if mode == "rb" else write_ctx
+
+    watcher._vfs.open_file = MagicMock(side_effect=open_side_effect)
+    watcher._vfs.remove = AsyncMock(return_value=True)
+
+    watcher._queue.put_nowait(("/watch/2026/09/02/img.fits", 0.0))
+    task = asyncio.create_task(watcher._worker())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert watcher.current_file is not None
+    assert watcher.current_file.out_filename == "/dest/test.fits"
+
+
+# ── recursive polling / initial scan ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_watch_poll_picks_up_nested_files() -> None:
+    watcher = make_watcher(poll=True, poll_interval=0)
+    watcher._vfs.find = AsyncMock(side_effect=[[], ["2026/09/02/test.fits"]])
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    task = asyncio.create_task(watcher._watch_poll())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert added == ["/watch/2026/09/02/test.fits"]
+
+
+@pytest.mark.asyncio
+async def test_watch_poll_respects_poll_interval() -> None:
+    """Regression: the pre-existing implementation never awaited poll_interval at all, so it
+    busy-looped. Confirm the sleep is actually observed between iterations."""
+    watcher = make_watcher(poll=True, poll_interval=123)
+    watcher._vfs.find = AsyncMock(return_value=[])
+
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(imagewatcher_module.asyncio, "sleep", fake_sleep)
+        task = asyncio.create_task(watcher._watch_poll())
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    assert sleep_calls[:2] == [123, 123]
+
+
+@pytest.mark.asyncio
+async def test_open_scans_nested_files() -> None:
+    watcher = make_watcher()
+    watcher._vfs.find = AsyncMock(return_value=["2026/09/02/test.fits"])
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    await watcher.open()
+
+    assert added == ["/watch/2026/09/02/test.fits"]
+    watcher._vfs.find.assert_called_once_with("/watch", "*")
+
+
+# ── recursive inotify watching (real filesystem) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_watch_inotify_picks_up_file_in_new_nested_subdirectory(tmp_path: Path) -> None:
+    """A directory created after the watcher starts, containing a file, is still picked up --
+    covering the CREATE-then-write-into-it pattern (e.g. an observation's per-run directory)."""
+    watcher = make_watcher()
+    watcher._vfs.local_path = AsyncMock(return_value=str(tmp_path))
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    task = asyncio.create_task(watcher._watch_inotify())
+    await asyncio.sleep(0.1)
+
+    sub = tmp_path / "2026" / "09" / "02"
+    sub.mkdir(parents=True)
+    await asyncio.sleep(0.1)
+    (sub / "test.fits").write_bytes(b"data")
+
+    await asyncio.sleep(0.3)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert added == ["/watch/2026/09/02/test.fits"]
+
+
+@pytest.mark.asyncio
+async def test_watch_inotify_survives_delete_and_recreate_of_watched_directory(tmp_path: Path) -> None:
+    """The watched root's subdirectory being deleted and recreated (e.g. pyftscontrol's
+    create_observation_directory, which rmtree()s and re-mkdir()s the same "tmp" scratch dir
+    before every run) must not silently stop future files in it from being detected."""
+    watcher = make_watcher()
+    watcher._vfs.local_path = AsyncMock(return_value=str(tmp_path))
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    task = asyncio.create_task(watcher._watch_inotify())
+    await asyncio.sleep(0.1)
+
+    scratch = tmp_path / "tmp"
+    scratch.mkdir()
+    await asyncio.sleep(0.1)
+    (scratch / "first.fits").write_bytes(b"data")
+    await asyncio.sleep(0.1)
+
+    # delete and recreate the same directory, as pyftscontrol does before every observation
+    (scratch / "first.fits").unlink()
+    scratch.rmdir()
+    await asyncio.sleep(0.1)
+    scratch.mkdir()
+    await asyncio.sleep(0.1)
+    (scratch / "second.fits").write_bytes(b"data")
+
+    await asyncio.sleep(0.3)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert "/watch/tmp/first.fits" in added
+    assert "/watch/tmp/second.fits" in added
+
+
+@pytest.mark.asyncio
+async def test_watch_inotify_survives_rename_into_watched_tree(tmp_path: Path) -> None:
+    """A directory renamed (moved) into its final location within the watched tree -- as
+    pyftscontrol's move_observation_directory does -- must still be watched afterward, including
+    files written into it after the rename."""
+    # both the scratch dir and the destination's parent tree exist before the watcher starts,
+    # so they're covered by the initial recursive watch -- isolates the rename/MOVED_FROM+
+    # MOVED_TO handling from the (separately covered) CREATE-triggered sub-watch timing.
+    scratch = tmp_path / "tmp"
+    scratch.mkdir()
+    final_dir = tmp_path / "2026" / "09" / "02"
+    final_dir.parent.mkdir(parents=True)
+
+    watcher = make_watcher()
+    watcher._vfs.local_path = AsyncMock(return_value=str(tmp_path))
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    task = asyncio.create_task(watcher._watch_inotify())
+    await asyncio.sleep(0.1)
+
+    scratch.rename(final_dir)
+    await asyncio.sleep(0.1)
+
+    # written after the rename, at the new (final) location
+    (final_dir / "result.fits").write_bytes(b"data")
+
+    await asyncio.sleep(0.3)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert added == ["/watch/2026/09/02/result.fits"]
+
+
+@pytest.mark.xfail(strict=True, reason="known asyncinotify/kernel-level race, see docstring")
+@pytest.mark.asyncio
+async def test_watch_inotify_loses_race_on_rename_into_freshly_created_deep_dir(tmp_path: Path) -> None:
+    """Known gap, not a bug we can fix here: when a *destination* directory tree that doesn't
+    exist yet is created and something is renamed into it before this process's asyncio loop
+    gets scheduled to consume the resulting CREATE event(s) and add a watch, the move is never
+    seen -- inotify only reports events for already-watched parents, and nothing later
+    re-discovers the miss. Reproduced directly against asyncinotify.RecursiveWatcher outside
+    pytest too, so this is a genuine kernel/library-level race, not a mock or test artifact; the
+    upstream example script (asyncinotify's examples/recursivewatch.py) documents the same
+    caveat ("doing two changes on a directory before the program has a time to handle it").
+
+    Practical exposure for a consumer building on this: only the *first* write into a brand-new
+    multi-level destination directory (e.g. a new {year}/{month} not yet on disk) is at risk --
+    every subsequent one that day is a no-op mkdir, no CREATE event, no race. Mitigation belongs
+    at the consumer/deployment level (e.g. a periodic reconciliation re-scan, the standard fix for
+    inotify-based systems), not in ImageWatcher itself.
+    """
+    watcher = make_watcher()
+    watcher._vfs.local_path = AsyncMock(return_value=str(tmp_path))
+
+    added: list[str] = []
+
+    async def fake_add_file(filename: str) -> None:
+        added.append(filename)
+
+    watcher.add_file = fake_add_file
+
+    task = asyncio.create_task(watcher._watch_inotify())
+    await asyncio.sleep(0.1)
+
+    scratch = tmp_path / "tmp"
+    scratch.mkdir()
+    await asyncio.sleep(0.1)
+
+    # created and renamed-into with no yield in between: the watcher process has no chance to
+    # consume the CREATE event(s) for the new tree before the rename fires.
+    final_dir = tmp_path / "2026" / "09" / "02"
+    final_dir.parent.mkdir(parents=True)
+    scratch.rename(final_dir)
+    await asyncio.sleep(0.1)
+
+    (final_dir / "result.fits").write_bytes(b"data")
+
+    await asyncio.sleep(0.3)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert added == ["/watch/2026/09/02/result.fits"]


### PR DESCRIPTION
## Summary

- Adds `flatten: bool = True` to `ImageWatcher`: when `False`, a non-templated destination keeps a
  file's path relative to `watchpath` instead of collapsing it to just the basename, so a nested
  directory tree can be relocated while preserving structure. Default preserves existing behavior
  for every current user.
- Recursive watching: `_watch_inotify` (via `asyncinotify.RecursiveWatcher`, already available at
  the pinned dependency floor), `_watch_poll`, and `open()`'s initial scan (both via `vfs.find()`)
  now pick up subdirectories, not just the watched root.
- While rewriting `_watch_poll`, fixed two pre-existing bugs in the code being touched:
  `poll_interval` was stored but never actually awaited between iterations (a busy-loop), and a
  stray debug `print()` was left in the new-file branch.

## Known limitation (documented, not fixed here)

Confirmed by direct reproduction: when a *destination* directory tree that doesn't exist yet is
created and something is renamed into it before this process's asyncio loop is scheduled to
consume the resulting `CREATE` event and add a watch, the move is never observed — inotify only
reports events for already-watched parents. This is a genuine kernel/library-level race (the
`asyncinotify` example script documents the same caveat), not something fixable at this layer.
Kept as an `xfail(strict=True)` regression test so it stays visible rather than silently assumed
away. A directory whose parent tree already existed at watcher startup is unaffected (covered by a
passing test). See the plan doc for the full writeup and the suggested consumer-side mitigation
(periodic reconciliation re-scan).

## Test plan

- [x] `uv run pytest tests/modules/image/test_imagewatcher.py -v` — 21 passed, 1 xfailed (the known
      limitation above)
- [x] `uv run pytest tests/ -m "not integration and not xmpp"` — full suite, 1832 passed, 1
      pre-existing unrelated failure (confirmed via `git stash` to fail identically without this
      branch's changes — a sandbox permission error writing to `/opt/pyobs/storage`, unrelated to
      `ImageWatcher`)
- [x] `black --check` / `ruff check` clean
- [x] `pyrefly check pyobs/modules/image/imagewatcher.py` — 0 errors

See `specs/plans/2026-09-02-imagewatcher-relative-path-recursive.md` for the full plan, reasoning,
and status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRXBxNFz1KrzhyKaKtdy8Y