### PR TITLE
feat: add InstrumentCapabilities models (§A.1 of duration-estimates plan)

### DIFF
--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -1,0 +1,167 @@
+"""Planning-time instrument capability data sourced from pyobs-portal's `instruments` app.
+
+Plain data models mirroring the shape `InstrumentSerializer` emits
+(`pyobs_portal/instruments/serializers.py`) -- no Django import, this module only ever
+deserializes the JSON the portal API already returns. Hand-entered planning data only, never a
+live query against `ICamera`/`IBinning`/etc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from pyobs.utils.serialization import BaseModel
+
+
+class Filter(BaseModel):
+    """A single filter position in a filter wheel."""
+
+    name: str
+    position: int | None = None
+    updated_at: str | None = None
+
+
+class BinningOption(BaseModel):
+    """Readout time for one binning mode of a camera."""
+
+    x: int
+    y: int
+    readout_time_s: float | None = None
+    updated_at: str | None = None
+
+
+class FilterWheelCapability(BaseModel):
+    """Planning-time capability data for one filter wheel.
+
+    `module_name` is nullable -- not every filter wheel is its own addressable module (some
+    cameras expose filter selection through the camera module itself), per pyobs-portal#142.
+    """
+
+    name: str = ""
+    module_name: str | None = None
+    filter_change_time_s: float | None = None
+    updated_at: str | None = None
+    filters: list[Filter] = Field(default_factory=list)
+
+
+class CameraCapability(BaseModel):
+    """Planning-time capability data for one camera, keyed by `module_name`."""
+
+    module_name: str
+    code: str
+    pixel_size_um: float | None = None
+    sensor_width_px: int | None = None
+    sensor_height_px: int | None = None
+    roi_min_width_px: int | None = None
+    roi_min_height_px: int | None = None
+    roi_step_px: int | None = None
+    exposure_time_min_s: float | None = None
+    exposure_time_max_s: float | None = None
+    image_types: list[str] = Field(default_factory=list)
+    updated_at: str | None = None
+    binnings: list[BinningOption] = Field(default_factory=list)
+    filter_wheels: list[FilterWheelCapability] = Field(default_factory=list)
+
+
+class TelescopeCapability(BaseModel):
+    """Planning-time capability data for one telescope, keyed by `module_name`."""
+
+    module_name: str
+    aperture_mm: float | None = None
+    focal_length_mm: float | None = None
+    mount_type: str = ""
+    slew_rate_deg_per_s: float | None = None
+    updated_at: str | None = None
+
+
+class DomeCapability(BaseModel):
+    """Planning-time capability data for one dome, keyed by `module_name`."""
+
+    module_name: str
+    rotate_rate_deg_per_s: float | None = None
+    updated_at: str | None = None
+
+
+class Instrument(BaseModel):
+    """One telescope + dome + camera(s) grouping, as returned by `GET /api/instruments/`.
+
+    Purely an organizational grouping on the portal side -- it carries no module identity of its
+    own; each device below carries its own `module_name`. `InstrumentCapabilities` is what
+    flattens these into the module-name-keyed lookups scripts actually use.
+    """
+
+    display_name: str = ""
+    notes: str = ""
+    updated_at: str | None = None
+    cameras: list[CameraCapability] = Field(default_factory=list)
+    telescope: TelescopeCapability | None = None
+    dome: DomeCapability | None = None
+
+
+class InstrumentCapabilities:
+    """Module-name-keyed view over a `GET /api/instruments/` response.
+
+    Scripts only ever need one device's capability row (by the module name they already
+    reference, e.g. `ImagingScript.camera`), never "the instrument" as a concept -- this flattens
+    the nested portal response into direct lookups once at parse time instead of every script
+    walking `instruments` and searching nested lists.
+    """
+
+    def __init__(self, instruments: list[Instrument]):
+        self.instruments = instruments
+        self._cameras: dict[str, CameraCapability] = {}
+        self._cameras_by_code: dict[str, CameraCapability] = {}
+        self._telescopes: dict[str, TelescopeCapability] = {}
+        self._domes: dict[str, DomeCapability] = {}
+        self._filter_wheels: dict[str, FilterWheelCapability] = {}
+
+        for instrument in instruments:
+            for camera in instrument.cameras:
+                self._cameras[camera.module_name] = camera
+                self._cameras_by_code[camera.code] = camera
+                for wheel in camera.filter_wheels:
+                    if wheel.module_name is not None:
+                        self._filter_wheels[wheel.module_name] = wheel
+            if instrument.telescope is not None:
+                self._telescopes[instrument.telescope.module_name] = instrument.telescope
+            if instrument.dome is not None:
+                self._domes[instrument.dome.module_name] = instrument.dome
+
+    @classmethod
+    def from_api_response(cls, data: list[dict[str, Any]]) -> InstrumentCapabilities:
+        """Parse `GET /api/instruments/`'s `results` list (already unwrapped by the caller)."""
+        return cls([Instrument.model_validate(item) for item in data])
+
+    def camera(self, module_name: str) -> CameraCapability | None:
+        """The `CameraCapability` whose own `module_name` matches, or None."""
+        return self._cameras.get(module_name)
+
+    def by_camera_code(self, code: str) -> CameraCapability | None:
+        """The `CameraCapability` with this fleet-wide physical camera code, or None."""
+        return self._cameras_by_code.get(code)
+
+    def telescope(self, module_name: str) -> TelescopeCapability | None:
+        """The `TelescopeCapability` whose own `module_name` matches, or None."""
+        return self._telescopes.get(module_name)
+
+    def dome(self, module_name: str) -> DomeCapability | None:
+        """The `DomeCapability` whose own `module_name` matches, or None."""
+        return self._domes.get(module_name)
+
+    def filter_wheel(self, module_name: str) -> FilterWheelCapability | None:
+        """The `FilterWheelCapability` whose own `module_name` matches, or None."""
+        return self._filter_wheels.get(module_name)
+
+
+__all__ = [
+    "Filter",
+    "BinningOption",
+    "FilterWheelCapability",
+    "CameraCapability",
+    "TelescopeCapability",
+    "DomeCapability",
+    "Instrument",
+    "InstrumentCapabilities",
+]

--- a/specs/steering/fleet-open-items.md
+++ b/specs/steering/fleet-open-items.md
@@ -61,9 +61,13 @@ One row per issue — same layout for every repo.
   capability data (readout/filter-change/slew/dome-rotate times) into `Script.estimate_duration()`
   for `ImagingScript` and 4 other leaf scripts via a new `TaskData.instrument_capabilities` field;
   wires the portal's script builder and `OnDemandScheduler` (not `AstroplanScheduler`). Was
-  blocked on pyobs-portal#139, landed 2026-09-02 in pyobs-portal#140. Slew/rotate start-position
-  left as a fixed placeholder except `OnDemandScheduler`'s first placed task, split out as
-  pyobs-core#858 (first task) and pyobs-core#859 (every task after).
+  blocked on pyobs-portal#139, landed 2026-09-02 in pyobs-portal#140. A review follow-up on #140
+  (`FilterWheelCapability` had no `module_name` key for the filter-change lookup) also landed
+  2026-09-02, in pyobs-portal#142 — no more blockers on the design itself. Slew/rotate
+  start-position left as a fixed placeholder except `OnDemandScheduler`'s first placed task, split
+  out as pyobs-core#858 (first task) and pyobs-core#859 (every task after). §B's pyobs-portal-side
+  implementation detail now has its own plan, see the pyobs-portal entry below.
+
 ### Design docs still *proposed*
 
 - [gui-standalone-binary.md](../design/gui-standalone-binary.md) — umbrella for the compiled
@@ -79,6 +83,11 @@ One line per plan — same layout for every repo.
 - **pyobs-gui** — [2026-09-01-gui-video-widget-split.md](../../pyobs-gui/specs/2026-09-01-gui-video-widget-split.md) —
   split `VideoWidget` into a main widget + paired sidebar widget, D6 follow-up to the (now landed,
   see pyobs-gui's own `specs/index.md`) main-vs-sidebar-widgets plan (#150) (*draft, unblocked*)
+- **pyobs-portal** — [2026-09-02-instrument-capability-estimate-duration-endpoint.md](../../pyobs-portal/specs/plans/2026-09-02-instrument-capability-estimate-duration-endpoint.md) —
+  this repo's half of the pyobs-core instrument-capability-duration-estimates plan above: a
+  TTL-cached `get_instrument_capabilities()` helper feeding `schema.py`'s `estimate_duration/`,
+  plus a `last_instrument_update/` marker for pyobs-core's `PortalTaskArchive` to poll
+  (*proposed, no issue yet*)
 - **pyobs-web-client** — [acl-aware-shell-forms](../../pyobs-web-client/specs/plans/acl-aware-shell-forms.md) —
   ACL-aware Shell forms (*proposed*)
 - **pyobs-web-client** — [auxiliary-interface-widgets](../../pyobs-web-client/specs/plans/auxiliary-interface-widgets.md) —

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pyobs.robotic.instruments import Instrument, InstrumentCapabilities
+
+# One Instrument's InstrumentSerializer output, dumped from a live pyobs-portal instance
+# (pyobs-portal#142's schema: module_name lives on CameraCapability/TelescopeCapability/
+# DomeCapability/FilterWheelCapability, not on Instrument itself) -- confirmed against the actual
+# serializer output, not just hand-guessed field names.
+INSTRUMENT_RESPONSE: dict[str, Any] = {
+    "display_name": "GOE 50cm",
+    "notes": "Main telescope",
+    "updated_at": "2026-09-02T18:34:16.451210Z",
+    "cameras": [
+        {
+            "module_name": "iag50cam",
+            "code": "ef01",
+            "pixel_size_um": 5.4,
+            "sensor_width_px": 4096,
+            "sensor_height_px": 4096,
+            "roi_min_width_px": None,
+            "roi_min_height_px": None,
+            "roi_step_px": None,
+            "exposure_time_min_s": 0.001,
+            "exposure_time_max_s": 3600.0,
+            "image_types": ["object", "bias", "dark", "flat"],
+            "updated_at": "2026-09-02T18:34:16.452157Z",
+            "binnings": [
+                {"x": 1, "y": 1, "readout_time_s": 3.2, "updated_at": "2026-09-02T18:34:16.452608Z"},
+                {"x": 2, "y": 2, "readout_time_s": 1.8, "updated_at": "2026-09-02T18:34:16.452879Z"},
+            ],
+            "filter_wheels": [
+                {
+                    "name": "",
+                    "module_name": "iag50filt",
+                    "filter_change_time_s": 4.5,
+                    "updated_at": "2026-09-02T18:34:16.453140Z",
+                    "filters": [
+                        {"name": "R", "position": 1, "updated_at": "2026-09-02T18:34:16.453420Z"},
+                        {"name": "V", "position": 2, "updated_at": "2026-09-02T18:34:16.453663Z"},
+                    ],
+                }
+            ],
+        }
+    ],
+    "telescope": {
+        "module_name": "iag50telescope",
+        "aperture_mm": 500.0,
+        "focal_length_mm": 4000.0,
+        "mount_type": "fork",
+        "slew_rate_deg_per_s": 3.0,
+        "updated_at": "2026-09-02T18:34:16.453947Z",
+    },
+    "dome": {
+        "module_name": "iag50dome",
+        "rotate_rate_deg_per_s": 2.5,
+        "updated_at": "2026-09-02T18:34:16.454272Z",
+    },
+}
+
+
+def test_instrument_round_trips_portal_response() -> None:
+    instrument = Instrument.model_validate(INSTRUMENT_RESPONSE)
+    assert instrument.display_name == "GOE 50cm"
+    camera = instrument.cameras[0]
+    assert camera.module_name == "iag50cam"
+    assert camera.code == "ef01"
+    assert [(b.x, b.y, b.readout_time_s) for b in camera.binnings] == [(1, 1, 3.2), (2, 2, 1.8)]
+    wheel = camera.filter_wheels[0]
+    assert wheel.module_name == "iag50filt"
+    assert wheel.filter_change_time_s == 4.5
+    assert [f.name for f in wheel.filters] == ["R", "V"]
+    assert instrument.telescope is not None
+    assert instrument.telescope.module_name == "iag50telescope"
+    assert instrument.telescope.slew_rate_deg_per_s == 3.0
+    assert instrument.dome is not None
+    assert instrument.dome.module_name == "iag50dome"
+    assert instrument.dome.rotate_rate_deg_per_s == 2.5
+
+
+def test_instrument_with_no_telescope_or_dome() -> None:
+    response = {**INSTRUMENT_RESPONSE, "telescope": None, "dome": None}
+    instrument = Instrument.model_validate(response)
+    assert instrument.telescope is None
+    assert instrument.dome is None
+
+
+class TestInstrumentCapabilities:
+    def setup_method(self) -> None:
+        self.capabilities = InstrumentCapabilities.from_api_response([INSTRUMENT_RESPONSE])
+
+    def test_camera_lookup_by_module_name(self) -> None:
+        camera = self.capabilities.camera("iag50cam")
+        assert camera is not None
+        assert camera.code == "ef01"
+        assert self.capabilities.camera("no-such-module") is None
+
+    def test_by_camera_code(self) -> None:
+        camera = self.capabilities.by_camera_code("ef01")
+        assert camera is not None
+        assert camera.module_name == "iag50cam"
+        assert self.capabilities.by_camera_code("zz99") is None
+
+    def test_telescope_lookup_by_module_name(self) -> None:
+        telescope = self.capabilities.telescope("iag50telescope")
+        assert telescope is not None
+        assert telescope.slew_rate_deg_per_s == 3.0
+        assert self.capabilities.telescope("iag50cam") is None
+
+    def test_dome_lookup_by_module_name(self) -> None:
+        dome = self.capabilities.dome("iag50dome")
+        assert dome is not None
+        assert dome.rotate_rate_deg_per_s == 2.5
+
+    def test_filter_wheel_lookup_by_module_name(self) -> None:
+        wheel = self.capabilities.filter_wheel("iag50filt")
+        assert wheel is not None
+        assert wheel.filter_change_time_s == 4.5
+
+    def test_filter_wheel_with_no_module_name_is_not_indexed(self) -> None:
+        # pyobs-portal#142: module_name is nullable on FilterWheelCapability -- a wheel with none
+        # set has no key to look it up by, and must not silently collide with another None-named
+        # entry.
+        response = {
+            **INSTRUMENT_RESPONSE,
+            "cameras": [
+                {
+                    **INSTRUMENT_RESPONSE["cameras"][0],
+                    "filter_wheels": [
+                        {
+                            "name": "unnamed",
+                            "module_name": None,
+                            "filter_change_time_s": 1.0,
+                            "updated_at": None,
+                            "filters": [],
+                        }
+                    ],
+                }
+            ],
+        }
+        capabilities = InstrumentCapabilities.from_api_response([response])
+        assert capabilities.filter_wheel("iag50filt") is None
+
+    def test_multiple_instruments_aggregate_into_one_lookup(self) -> None:
+        other = {
+            **INSTRUMENT_RESPONSE,
+            "display_name": "Guide scope",
+            "cameras": [{**INSTRUMENT_RESPONSE["cameras"][0], "module_name": "guidecam", "code": "ef02"}],
+            "telescope": {**INSTRUMENT_RESPONSE["telescope"], "module_name": "guidetelescope"},
+            "dome": None,
+        }
+        capabilities = InstrumentCapabilities.from_api_response([INSTRUMENT_RESPONSE, other])
+        assert capabilities.camera("iag50cam") is not None
+        assert capabilities.camera("guidecam") is not None
+        assert capabilities.telescope("guidetelescope") is not None
+        assert len(capabilities.instruments) == 2


### PR DESCRIPTION
## Summary
- First slice of `specs/plans/2026-09-01-instrument-capability-duration-estimates.md` (§A.1): new `pyobs/robotic/instruments.py` with plain pydantic models mirroring pyobs-portal's `InstrumentSerializer` JSON shape (post-#139/#140/[pyobs-portal#142](https://github.com/pyobs/pyobs-portal/pull/142) — `module_name` lives on `CameraCapability`/`TelescopeCapability`/`DomeCapability`/`FilterWheelCapability`, not on `Instrument` itself).
- `InstrumentCapabilities` flattens the nested portal response into direct `camera()`/`telescope()`/`dome()`/`filter_wheel()` lookups by `module_name`, plus `by_camera_code()` for the fleet-wide-ID case — no two-step "resolve `Instrument`, then search its nested list" indirection, since each script only ever needs one device's row.
- No Django import — this only ever deserializes JSON the portal API already returns.
- Follows the existing `pyobs.utils.serialization.BaseModel` convention already used for external-API models (`pyobs/robotic/storage/lco/_portal.py`'s `Lco*` classes).

## Not in this PR
§A.2–A.8 (`TaskData` field, `TaskArchive`/`PortalTaskArchive` wiring, `Task.estimate_duration()`/`TaskScheduler.schedule()` threading, and the 5 leaf scripts) are follow-up work, tracked in the plan doc.

## Test plan
- [x] `pytest tests/robotic/test_instruments.py` — 9/9 passing, including a round-trip test against a real `InstrumentSerializer` dump from a live pyobs-portal instance (not hand-guessed field names)
- [x] `pytest tests/robotic/` — 451/451 passing, no regressions
- [x] `ruff check` / `black --check` / `pyrefly check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XoNCe7YyJELc8xup1zVdE