### PR TITLE
feat: thread instrument_capabilities through TaskData/TaskArchive/scheduler (§A.2-A.7)

### DIFF
--- a/pyobs/modules/robotic/scheduler.py
+++ b/pyobs/modules/robotic/scheduler.py
@@ -334,7 +334,10 @@ class Scheduler(Module, IRunnable, IRoboticScheduler):
                     # schedule
                     scheduled_tasks = ObservationList()
                     first = True
-                    async for scheduled_task in self._scheduler.schedule(self._tasks, self._projects, start, end):
+                    instrument_capabilities = self._task_archive.get_instrument_capabilities()
+                    async for scheduled_task in self._scheduler.schedule(
+                        self._tasks, self._projects, start, end, instrument_capabilities=instrument_capabilities
+                    ):
                         # remember for later
                         scheduled_tasks.append(scheduled_task)
 

--- a/pyobs/robotic/scheduler/astroplanscheduler.py
+++ b/pyobs/robotic/scheduler/astroplanscheduler.py
@@ -11,6 +11,7 @@ import astropy.units as u
 from astroplan import FixedTarget, ObservingBlock
 
 from pyobs.object import Object
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.utils.time import Time
 
 from .targets import SiderealTarget
@@ -44,8 +45,17 @@ class AstroplanScheduler(TaskScheduler):
         self._is_running: bool = False
 
     async def schedule(
-        self, tasks: list[Task], projects: list[Project], start: Time, end: Time
+        self,
+        tasks: list[Task],
+        projects: list[Project],
+        start: Time,
+        end: Time,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> AsyncIterator[Observation]:
+        # instrument_capabilities: accepted for TaskScheduler interface consistency, unused --
+        # this scheduler reads the stored Task.duration field rather than calling
+        # estimate_duration() live (see specs/plans/2026-09-01-instrument-capability-duration-estimates.md
+        # Non-goals).
         # is lock acquired? send abort signal
         if self._lock.locked():
             await self.abort()

--- a/pyobs/robotic/scheduler/ondemandscheduler.py
+++ b/pyobs/robotic/scheduler/ondemandscheduler.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.time import TimeDelta
 
 from pyobs.object import Object
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.robotic.storage.observationarchive import ObservationArchive
 from pyobs.utils.time import Time
 
@@ -59,7 +60,12 @@ class OnDemandScheduler(TaskScheduler):
         self._global_constraints: list[Constraint] = [Constraint.create(self, c) for c in constraints]
 
     async def schedule(
-        self, tasks: list[Task], projects: list[Project], start: Time, end: Time
+        self,
+        tasks: list[Task],
+        projects: list[Project],
+        start: Time,
+        end: Time,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> AsyncIterator[Observation]:
         if self._observer is None:
             raise RuntimeError("No observer given.")
@@ -75,7 +81,9 @@ class OnDemandScheduler(TaskScheduler):
         data.archive.freeze()
 
         # schedule from start to end
-        async for task in self.schedule_in_interval(tasks, projects_dict, start, end, data):
+        async for task in self.schedule_in_interval(
+            tasks, projects_dict, start, end, data, instrument_capabilities=instrument_capabilities
+        ):
             # evolve archive -- night is keyed by the task's own scheduled time, not "now", since
             # a run can schedule up to schedule_range ahead into a different night (see
             # ObservationArchiveEvolution.evolve()'s docstring/comment for why)
@@ -95,6 +103,7 @@ class OnDemandScheduler(TaskScheduler):
         end: Time,
         data: DataProvider,
         step: float = 300,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> AsyncIterator[Observation]:
         time = start
         while time < end:
@@ -105,7 +114,9 @@ class OnDemandScheduler(TaskScheduler):
                 task.reset_resolved_target()
 
             # schedule first in this interval, could be one or two
-            async for scheduled_task in self.schedule_first_in_interval(tasks, projects, time, end, data):  # type: ignore[arg-type]
+            async for scheduled_task in self.schedule_first_in_interval(
+                tasks, projects, time, end, data, instrument_capabilities=instrument_capabilities  # type: ignore[arg-type]
+            ):
                 # yield it to caller
                 yield scheduled_task
 
@@ -128,44 +139,73 @@ class OnDemandScheduler(TaskScheduler):
         end: Time,
         data: DataProvider,
         step: float = 300,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> AsyncIterator[Observation]:
         # find current best task
-        task, merit = await self.find_next_best_task(tasks, projects, start, end, data)
+        task, merit = await self.find_next_best_task(
+            tasks, projects, start, end, data, instrument_capabilities=instrument_capabilities
+        )
 
         if task is not None and merit is not None:
             # check, whether there is another task within its duration that  will have a higher merit
             better_task, better_time, better_merit = await self.check_for_better_task(
-                task, projects, merit, tasks, start, end, data, step=step
+                task,
+                projects,
+                merit,
+                tasks,
+                start,
+                end,
+                data,
+                step=step,
+                instrument_capabilities=instrument_capabilities,
             )
 
             if better_task is not None and better_time is not None and better_merit is not None:
                 # can we maybe postpone the better task to run both?
                 postpone_time = await self.can_postpone_task(
-                    task, projects, better_task, better_merit, start, end, data
+                    task,
+                    projects,
+                    better_task,
+                    better_merit,
+                    start,
+                    end,
+                    data,
+                    instrument_capabilities=instrument_capabilities,
                 )
                 if postpone_time is not None:
                     # yes, we can! schedule both
-                    yield self.create_scheduled_task(task, merit, start)
-                    yield self.create_scheduled_task(better_task, better_merit, postpone_time)
+                    yield self.create_scheduled_task(
+                        task, merit, start, instrument_capabilities=instrument_capabilities
+                    )
+                    yield self.create_scheduled_task(
+                        better_task, better_merit, postpone_time, instrument_capabilities=instrument_capabilities
+                    )
                 else:
                     # just schedule better_task
-                    yield self.create_scheduled_task(better_task, better_merit, better_time)
+                    yield self.create_scheduled_task(
+                        better_task, better_merit, better_time, instrument_capabilities=instrument_capabilities
+                    )
 
                     # and find other tasks for in between, new end time is better_time
-                    async for between_task in self.schedule_in_interval(tasks, projects, start, better_time, data):
+                    async for between_task in self.schedule_in_interval(
+                        tasks, projects, start, better_time, data, instrument_capabilities=instrument_capabilities
+                    ):
                         yield between_task
 
             else:
                 # this seems to be the best task for now, schedule it
-                yield self.create_scheduled_task(task, merit, start)
+                yield self.create_scheduled_task(task, merit, start, instrument_capabilities=instrument_capabilities)
 
-    def create_scheduled_task(self, task: Task, merit: float, time: Time) -> Observation:
+    def create_scheduled_task(
+        self, task: Task, merit: float, time: Time, instrument_capabilities: InstrumentCapabilities | None = None
+    ) -> Observation:
         from pyobs.robotic import Observation
 
         return Observation(
             task=task,
             start=time,
-            end=time + TimeDelta(task.estimate_duration(time=time) * u.second),
+            end=time
+            + TimeDelta(task.estimate_duration(time=time, instrument_capabilities=instrument_capabilities) * u.second),
             priority=merit,
             target=task.target,
         )
@@ -213,7 +253,13 @@ class OnDemandScheduler(TaskScheduler):
         return total_merit
 
     async def evaluate_constraints_and_merits(
-        self, tasks: list[Task], projects: dict[str, Project], start: Time, end: Time, data: DataProvider
+        self,
+        tasks: list[Task],
+        projects: dict[str, Project],
+        start: Time,
+        end: Time,
+        data: DataProvider,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> list[float]:
         # evaluate all merit functions at given time
         merits: list[float] = []
@@ -230,7 +276,13 @@ class OnDemandScheduler(TaskScheduler):
                     # no merits? evaluate to 1
                     merit = 1.0
 
-                elif start + TimeDelta(task.estimate_duration(time=start) * u.second) > end:
+                elif (
+                    start
+                    + TimeDelta(
+                        task.estimate_duration(time=start, instrument_capabilities=instrument_capabilities) * u.second
+                    )
+                    > end
+                ):
                     # if task is too long for the given slot, we evaluate its merits to zero
                     merit = 0.0
 
@@ -255,11 +307,19 @@ class OnDemandScheduler(TaskScheduler):
         return merits
 
     async def find_next_best_task(
-        self, tasks: list[Task], projects: dict[str, Project], start: Time, end: Time, data: DataProvider
+        self,
+        tasks: list[Task],
+        projects: dict[str, Project],
+        start: Time,
+        end: Time,
+        data: DataProvider,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> tuple[Task | None, float]:
 
         # evaluate all merit functions at given time
-        merits = await run_cpu_bound(self.evaluate_constraints_and_merits, tasks, projects, start, end, data)
+        merits = await run_cpu_bound(
+            self.evaluate_constraints_and_merits, tasks, projects, start, end, data, instrument_capabilities
+        )
 
         # find max one
         idx = np.argmax(merits)
@@ -278,12 +338,17 @@ class OnDemandScheduler(TaskScheduler):
         end: Time,
         data: DataProvider,
         step: float = 300,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> tuple[Task | None, Time | None, float | None]:
         # exclude the already-selected task so it can't be picked as "better"
         other_tasks = [t for t in tasks if t is not task]
         t = start + TimeDelta(step * u.second)
-        while t < start + TimeDelta(task.estimate_duration(time=start) * u.second):
-            merits = await run_cpu_bound(self.evaluate_constraints_and_merits, other_tasks, projects, t, end, data)
+        while t < start + TimeDelta(
+            task.estimate_duration(time=start, instrument_capabilities=instrument_capabilities) * u.second
+        ):
+            merits = await run_cpu_bound(
+                self.evaluate_constraints_and_merits, other_tasks, projects, t, end, data, instrument_capabilities
+            )
             for i, m in enumerate(merits):
                 if m > merit:
                     return other_tasks[i], t, m
@@ -299,13 +364,24 @@ class OnDemandScheduler(TaskScheduler):
         start: Time,
         end: Time,
         data: DataProvider,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> Time | None:
         # new start time of better_task would be after the execution of task
-        better_start: Time = start + TimeDelta(task.estimate_duration(time=start) * u.second)
+        better_start: Time = start + TimeDelta(
+            task.estimate_duration(time=start, instrument_capabilities=instrument_capabilities) * u.second
+        )
 
         # evaluate merit of better_task at new start time
         merit = (
-            await run_cpu_bound(self.evaluate_constraints_and_merits, [better_task], projects, better_start, end, data)
+            await run_cpu_bound(
+                self.evaluate_constraints_and_merits,
+                [better_task],
+                projects,
+                better_start,
+                end,
+                data,
+                instrument_capabilities,
+            )
         )[0]
 
         # if it got better, return it, otherwise return Nones

--- a/pyobs/robotic/scheduler/taskscheduler.py
+++ b/pyobs/robotic/scheduler/taskscheduler.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from pyobs.object import Object
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.utils.time import Time
 
 if TYPE_CHECKING:
@@ -19,7 +20,12 @@ class TaskScheduler(Object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     async def schedule(
-        self, tasks: list[Task], projects: list[Project], start: Time, end: Time
+        self,
+        tasks: list[Task],
+        projects: list[Project],
+        start: Time,
+        end: Time,
+        instrument_capabilities: InstrumentCapabilities | None = None,
     ) -> AsyncIterator[Observation]:
         # if we don't yield once here, mypy doesn't like this, see:
         # https://github.com/python/mypy/issues/5385

--- a/pyobs/robotic/storage/taskarchive.py
+++ b/pyobs/robotic/storage/taskarchive.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 from pyobs.object import Object
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.robotic.task import Project, Task
 from pyobs.utils.time import Time
 
@@ -43,6 +44,13 @@ class TaskArchive(Object, metaclass=ABCMeta):
             Task with given ID.
         """
         ...
+
+    def get_instrument_capabilities(self) -> InstrumentCapabilities | None:
+        """Planning-time instrument capability data (readout/filter-change/slew/rotate rates),
+        if this backend has any. None for every backend but the portal one -- this data only
+        ever exists for pyobs-portal's `instruments` app.
+        """
+        return None
 
 
 __all__ = ["TaskArchive"]

--- a/pyobs/robotic/task.py
+++ b/pyobs/robotic/task.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ConfigDict, Field, PrivateAttr
 
 from pyobs.interfaces import FitsHeaderEntry
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.robotic.scheduler import DataProvider
 from pyobs.robotic.scheduler.targets import Target
 from pyobs.robotic.scripts import Script
@@ -26,6 +27,7 @@ class TaskData:
     observation_archive: ObservationArchive | None = None
     task_archive: TaskArchive | None = None
     target: Target | None = None
+    instrument_capabilities: InstrumentCapabilities | None = None
 
     @property
     def resolved_target(self) -> Target | None:
@@ -118,9 +120,13 @@ class Task(PolymorphicBaseModel):
             return {}
         return self._running_script.get_fits_headers(namespaces)
 
-    def estimate_duration(self, time: Time | None = None) -> float:
+    def estimate_duration(
+        self, time: Time | None = None, instrument_capabilities: InstrumentCapabilities | None = None
+    ) -> float:
         if self.script:
-            return self.create_script().estimate_duration(TaskData(task=self), time)
+            return self.create_script().estimate_duration(
+                TaskData(task=self, instrument_capabilities=instrument_capabilities), time
+            )
         return self.duration
 
     async def resolve_target(self, time: Time, task: Task, data: DataProvider) -> bool:

--- a/tests/modules/robotic/test_scheduler.py
+++ b/tests/modules/robotic/test_scheduler.py
@@ -597,6 +597,44 @@ async def test_schedule_worker_schedules_and_submits_tasks(mocker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_schedule_worker_forwards_instrument_capabilities(mocker) -> None:
+    scheduler = make_scheduler(min_safety_time=1.0)
+    scheduler._need_update = True
+    scheduler._initial_update_done = True
+    scheduler._schedule.get_current_observation = AsyncMock(return_value=None)
+    scheduler._schedule.clear_schedule = AsyncMock()
+    scheduler._schedule.add_observations = AsyncMock()
+
+    capabilities = MagicMock()
+    scheduler._task_archive.get_instrument_capabilities = MagicMock(return_value=capabilities)
+
+    received_kwargs: dict = {}
+
+    async def fake_schedule(*args, **kwargs):
+        received_kwargs.update(kwargs)
+        return
+        yield  # pragma: no cover -- unreachable, only makes this an async generator
+
+    scheduler._scheduler.schedule = fake_schedule
+
+    call_count = 0
+
+    async def fake_sleep(t: float) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError()
+
+    mocker.patch("pyobs.modules.robotic.scheduler.asyncio.sleep", side_effect=fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await scheduler._schedule_worker()
+
+    scheduler._task_archive.get_instrument_capabilities.assert_called_once()
+    assert received_kwargs.get("instrument_capabilities") is capabilities
+
+
+@pytest.mark.asyncio
 async def test_schedule_worker_uses_running_observation_end_as_start(mocker) -> None:
     scheduler = make_scheduler()
     scheduler._need_update = True

--- a/tests/robotic/scheduler/test_ondemandscheduler.py
+++ b/tests/robotic/scheduler/test_ondemandscheduler.py
@@ -8,12 +8,26 @@ from astropy.coordinates import EarthLocation
 from astropy.time import TimeDelta
 
 from pyobs.robotic import Task
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.robotic.scheduler import DataProvider
 from pyobs.robotic.scheduler.constraints import Constraint
 from pyobs.robotic.scheduler.merits import ConstantMerit, TimeWindowMerit
 from pyobs.robotic.scheduler.merits.timewindow import TimeWindow
 from pyobs.robotic.scheduler.ondemandscheduler import OnDemandScheduler
+from pyobs.robotic.scripts import Script
+from pyobs.robotic.task import TaskData
 from pyobs.utils.time import Time
+
+
+class _CapabilitiesEchoingScript(Script):
+    """Returns 1.0 if TaskData.instrument_capabilities was forwarded, else 0.0 -- used to check
+    that instrument_capabilities reaches Task.estimate_duration() through the scheduler's call
+    chain, without needing a real InstrumentCapabilities instance at every layer."""
+
+    def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
+        if data is not None and data.instrument_capabilities is not None:
+            return 1.0
+        return 0.0
 
 
 @pytest.mark.asyncio
@@ -310,3 +324,52 @@ async def test_check_for_better_task_does_not_block_event_loop() -> None:
 
     assert better == tasks[0]
     assert heartbeats >= 4
+
+
+def test_create_scheduled_task_forwards_instrument_capabilities() -> None:
+    scheduler = OnDemandScheduler()
+    start = Time.now()
+    task = Task(
+        id=1,
+        name="1",
+        duration=100,
+        script={"class": "tests.robotic.scheduler.test_ondemandscheduler._CapabilitiesEchoingScript"},
+    )
+
+    without_caps = scheduler.create_scheduled_task(task, merit=1.0, time=start)
+    assert (without_caps.end - without_caps.start).sec == pytest.approx(0.0)
+
+    with_caps = scheduler.create_scheduled_task(
+        task, merit=1.0, time=start, instrument_capabilities=InstrumentCapabilities([])
+    )
+    assert (with_caps.end - with_caps.start).sec == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_schedule_threads_instrument_capabilities_end_to_end() -> None:
+    """schedule() is the only entry point pyobs/modules/robotic/scheduler.py calls -- confirm
+    instrument_capabilities makes it all the way from there down to Task.estimate_duration()."""
+    observer = Observer(
+        location=EarthLocation.from_geodetic(lon=20.8108 * u.deg, lat=-32.3758 * u.deg, height=1798 * u.m)
+    )
+    scheduler = OnDemandScheduler(observer=observer)
+    start = Time.now()
+    # short window -- the echoing script's 1s duration means schedule() keeps finding a next
+    # slot for the same task, so this only needs to be wide enough for one, not exhaustively long
+    end = start + TimeDelta(2 * u.second)
+
+    task = Task(
+        id=1,
+        name="1",
+        duration=100,
+        merits=[ConstantMerit(merit=10)],
+        script={"class": "tests.robotic.scheduler.test_ondemandscheduler._CapabilitiesEchoingScript"},
+    )
+
+    observations = [
+        obs
+        async for obs in scheduler.schedule([task], [], start, end, instrument_capabilities=InstrumentCapabilities([]))
+    ]
+
+    assert len(observations) >= 1
+    assert (observations[0].end - observations[0].start).sec == pytest.approx(1.0)

--- a/tests/robotic/storage/memory/test_memory_archives.py
+++ b/tests/robotic/storage/memory/test_memory_archives.py
@@ -359,3 +359,8 @@ async def test_task_remove_task(task_archive) -> None:
 
 def test_task_remove_task_noop_if_not_found(task_archive) -> None:
     task_archive.remove_task(999)  # should not raise
+
+
+def test_get_instrument_capabilities_defaults_to_none(task_archive) -> None:
+    # only PortalTaskArchive overrides this -- every other backend inherits the None default.
+    assert task_archive.get_instrument_capabilities() is None

--- a/tests/robotic/test_task.py
+++ b/tests/robotic/test_task.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from pyobs.robotic import Task
+from pyobs.robotic.instruments import InstrumentCapabilities
 from pyobs.robotic.observation import Observation
 from pyobs.robotic.scheduler.constraints import AirmassConstraint
 from pyobs.robotic.scheduler.targets import SiderealTarget
@@ -19,6 +20,17 @@ from pyobs.utils.time import Time
 class _TimedScript(Script):
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         return 42.0
+
+
+class _CapabilitiesEchoingScript(Script):
+    """Reports whether TaskData.instrument_capabilities was forwarded, via the return value --
+    used to test that Task.estimate_duration()'s parameter reaches the script, without needing a
+    real InstrumentCapabilities instance."""
+
+    def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
+        if data is not None and data.instrument_capabilities is not None:
+            return 1.0
+        return 0.0
 
 
 class _AlwaysCanRunScript(Script):
@@ -93,6 +105,17 @@ def test_estimate_duration_delegates_to_script() -> None:
         script={"class": "tests.robotic.test_task._TimedScript"},
     )
     assert task.estimate_duration() == 42.0
+
+
+def test_estimate_duration_forwards_instrument_capabilities_to_script() -> None:
+    task = Task(
+        id=1,
+        name="test",
+        duration=300.0,
+        script={"class": "tests.robotic.test_task._CapabilitiesEchoingScript"},
+    )
+    assert task.estimate_duration() == 0.0
+    assert task.estimate_duration(instrument_capabilities=InstrumentCapabilities([])) == 1.0
 
 
 # ── can_run ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
§A.2-A.7 of `specs/plans/2026-09-01-instrument-capability-duration-estimates.md` — the plumbing that carries an `InstrumentCapabilities | None` (from pyobs-core#864) from the one real caller down to `Task.estimate_duration()`, with no consumer yet and every backend still returning `None`, so **this changes no runtime behavior**.

- `TaskData.instrument_capabilities: InstrumentCapabilities | None` (`task.py`)
- `TaskArchive.get_instrument_capabilities() -> None` by default; every non-portal backend (filesystem, memory, lco) inherits it unchanged
- `Task.estimate_duration()` gains the parameter, forwarded into `TaskData`
- `TaskScheduler.schedule()` gains it in the abstract signature. `AstroplanScheduler` accepts it for interface consistency but doesn't use it (reads the stored `Task.duration` field, not a live estimate — see the plan's Non-goals)
- `OnDemandScheduler` threads it through the full call chain: `schedule` → `schedule_in_interval` → `schedule_first_in_interval` → `find_next_best_task`/`check_for_better_task`/`can_postpone_task`/`create_scheduled_task` → the 4 `task.estimate_duration()` call sites
- `pyobs/modules/robotic/scheduler.py`'s `_schedule_worker` — the only real caller of `schedule()` outside tests — now supplies `self._task_archive.get_instrument_capabilities()`

## Not in this PR
- §A.4: `PortalTaskArchive`'s concrete fetch/cache override (still returns `None` via the base class default)
- §A.8: the 5 leaf scripts actually reading `instrument_capabilities`

Both tracked in the plan doc as follow-up work.

## Test plan
- [x] New tests: `TaskData`/`Task.estimate_duration()` forwarding, `TaskArchive` default, `OnDemandScheduler.create_scheduled_task()` + full `schedule()` end-to-end threading, `pyobs/modules/robotic/scheduler.py`'s `_schedule_worker` forwarding `get_instrument_capabilities()`
- [x] `pytest tests/` (excluding `integration`/`xmpp`) — 1866 passed, no regressions
- [x] `ruff check` / `black --check` / `pyrefly check` — clean (pre-existing, unrelated pyrefly noise on 2 test files confirmed identical on `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XoNCe7YyJELc8xup1zVdE