### PR TITLE
feat: consume instrument_capabilities in 4 leaf scripts (§A.8)

### DIFF
--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -70,7 +70,13 @@ class CameraCapability(BaseModel):
 # destination-minus-start-position distance a real estimate would need. See
 # specs/plans/2026-09-01-instrument-capability-duration-estimates.md's "Representative slew/rotate
 # distance" note; pyobs-core#858/#859 track replacing this with a real distance.
-_TYPICAL_SLEW_DEG = 90.0
+#
+# A default, not a hardcoded constant inside estimate_slew_time_s() below: #858/#859's real
+# distances will likely differ per script (a flat-field PointingScript slew and an
+# ImagingScript/AutoFocusScript target slew aren't the same kind of move), and this keeps that
+# future per-caller distance a parameter on the estimate rather than a policy decision baked into
+# what's meant to stay a pure mirror of the portal's data.
+DEFAULT_SLEW_DISTANCE_DEG = 90.0
 
 
 class TelescopeCapability(BaseModel):
@@ -83,14 +89,18 @@ class TelescopeCapability(BaseModel):
     slew_rate_deg_per_s: float | None = None
     updated_at: str | None = None
 
-    def estimate_slew_time_s(self) -> float | None:
-        """First-pass slew-duration estimate: `_TYPICAL_SLEW_DEG` divided by the real slew rate.
-        None if `slew_rate_deg_per_s` isn't declared (or isn't positive) -- callers fall back to
-        their own flat constant in that case, same as when no capability data exists at all.
+    def estimate_slew_time_s(self, distance_deg: float = DEFAULT_SLEW_DISTANCE_DEG) -> float | None:
+        """First-pass slew-duration estimate: `distance_deg` divided by the real slew rate. None
+        if `slew_rate_deg_per_s` isn't declared (or isn't positive) -- callers fall back to their
+        own flat constant in that case, same as when no capability data exists at all.
+
+        `distance_deg` defaults to `DEFAULT_SLEW_DISTANCE_DEG`, the same first-pass placeholder
+        every caller uses today; a caller can pass its own once #858/#859 give it a real,
+        script-specific distance instead of this shared guess.
         """
         if self.slew_rate_deg_per_s is None or self.slew_rate_deg_per_s <= 0:
             return None
-        return _TYPICAL_SLEW_DEG / self.slew_rate_deg_per_s
+        return distance_deg / self.slew_rate_deg_per_s
 
 
 class DomeCapability(BaseModel):
@@ -173,6 +183,7 @@ class InstrumentCapabilities:
 
 
 __all__ = [
+    "DEFAULT_SLEW_DISTANCE_DEG",
     "Filter",
     "BinningOption",
     "FilterWheelCapability",

--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -65,6 +65,14 @@ class CameraCapability(BaseModel):
     filter_wheels: list[FilterWheelCapability] = Field(default_factory=list)
 
 
+# First-pass placeholder distance for slew-duration estimates -- there's no "current pointing"
+# concept at estimate time, only a real slew *rate*, so this stands in for the actual
+# destination-minus-start-position distance a real estimate would need. See
+# specs/plans/2026-09-01-instrument-capability-duration-estimates.md's "Representative slew/rotate
+# distance" note; pyobs-core#858/#859 track replacing this with a real distance.
+_TYPICAL_SLEW_DEG = 90.0
+
+
 class TelescopeCapability(BaseModel):
     """Planning-time capability data for one telescope, keyed by `module_name`."""
 
@@ -74,6 +82,15 @@ class TelescopeCapability(BaseModel):
     mount_type: str = ""
     slew_rate_deg_per_s: float | None = None
     updated_at: str | None = None
+
+    def estimate_slew_time_s(self) -> float | None:
+        """First-pass slew-duration estimate: `_TYPICAL_SLEW_DEG` divided by the real slew rate.
+        None if `slew_rate_deg_per_s` isn't declared (or isn't positive) -- callers fall back to
+        their own flat constant in that case, same as when no capability data exists at all.
+        """
+        if self.slew_rate_deg_per_s is None or self.slew_rate_deg_per_s <= 0:
+            return None
+        return _TYPICAL_SLEW_DEG / self.slew_rate_deg_per_s
 
 
 class DomeCapability(BaseModel):

--- a/pyobs/robotic/scripts/calibration/darkbias.py
+++ b/pyobs/robotic/scripts/calibration/darkbias.py
@@ -282,9 +282,20 @@ class DarkBiasScript(Script):
         peek_cached_science_exptimes_for_night(). Falls back to a placeholder single-series
         estimate at _FALLBACK_MATCH_EXPTIME if nothing is cached yet -- e.g. can_run() hasn't
         run for this site/night within the cache's TTL.
+
+        readout uses the camera's matching BinningOption.readout_time_s (data.instrument_capabilities)
+        when available, falling back to the flat 5.0 s fudge otherwise.
         """
-        # TODO: get a better estimate for readout overhead
         readout = 5.0
+        capabilities = data.instrument_capabilities if data is not None else None
+        camera = capabilities.camera(self.camera) if capabilities is not None else None
+        if camera is not None:
+            x, y = self.binning
+            for binning_option in camera.binnings:
+                if binning_option.x == x and binning_option.y == y and binning_option.readout_time_s is not None:
+                    readout = binning_option.readout_time_s
+                    break
+
         if self.exptimes is not None:
             return sum(self.count * (e + readout) for e in self.exptimes)
 

--- a/pyobs/robotic/scripts/calibration/pointing.py
+++ b/pyobs/robotic/scripts/calibration/pointing.py
@@ -51,8 +51,10 @@ class PointingScript(Script):
 
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         """Estimate duration of slewing to the flat-field pointing."""
-        # TODO: get a better estimate for slewing
-        return 60.0
+        capabilities = data.instrument_capabilities if data is not None else None
+        telescope = capabilities.telescope(self.telescope) if capabilities is not None else None
+        slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
+        return slew_time if slew_time is not None else 60.0
 
 
 __all__ = ["PointingScript"]

--- a/pyobs/robotic/scripts/imaging/autofocus.py
+++ b/pyobs/robotic/scripts/imaging/autofocus.py
@@ -90,8 +90,10 @@ class AutoFocusScript(Script):
 
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         """Estimate duration of the autofocus run."""
-        # TODO: get a better estimate for slewing
-        return self.count * self.exposure_time + 60.0
+        capabilities = data.instrument_capabilities if data is not None else None
+        telescope = capabilities.telescope(self.telescope) if capabilities is not None else None
+        slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
+        return self.count * self.exposure_time + (slew_time if slew_time is not None else 60.0)
 
 
 __all__ = ["AutoFocusScript"]

--- a/pyobs/robotic/scripts/imaging/imaging.py
+++ b/pyobs/robotic/scripts/imaging/imaging.py
@@ -21,7 +21,6 @@ from pyobs.interfaces import (
     ITelescope,
     IWindow,
 )
-from pyobs.robotic.instruments import CameraCapability
 from pyobs.robotic.scheduler.targets import SiderealTarget, Target
 from pyobs.robotic.scripts import Script
 from pyobs.robotic.utils.exptime import ExposureTimeProvider
@@ -30,6 +29,7 @@ from pyobs.utils.parallel import Future
 from pyobs.utils.time import Time
 
 if TYPE_CHECKING:
+    from pyobs.robotic.instruments import CameraCapability
     from pyobs.robotic.task import TaskData
 
 
@@ -377,6 +377,12 @@ class ImagingScript(Script):
         rate wherever `data.instrument_capabilities` has a matching, populated row -- falling
         back to today's flat fudge constants at every point that's missing (no `data`, no
         capabilities, no matching module, or the specific field not set on the matched row).
+
+        Two simplifications carried over from today's flat constants, not new: the slew term is
+        added unconditionally, even for a bias/dark-only sequence that never actually points at
+        anything; and each actual filter transition costs one flat `filter_change_time_s`
+        (the portal's own one-position-step estimate) regardless of how many wheel positions
+        that particular change actually spans.
         """
         capabilities = data.instrument_capabilities if data is not None else None
         camera = capabilities.camera(self.camera) if capabilities is not None else None

--- a/pyobs/robotic/scripts/imaging/imaging.py
+++ b/pyobs/robotic/scripts/imaging/imaging.py
@@ -21,6 +21,7 @@ from pyobs.interfaces import (
     ITelescope,
     IWindow,
 )
+from pyobs.robotic.instruments import CameraCapability
 from pyobs.robotic.scheduler.targets import SiderealTarget, Target
 from pyobs.robotic.scripts import Script
 from pyobs.robotic.utils.exptime import ExposureTimeProvider
@@ -134,6 +135,24 @@ class ImagingScript(Script):
                 if instr.optical_filter is not None
             }
         )
+
+    def _filter_change_count(self) -> int:
+        """Number of times the optical filter actually changes across the full sequence
+        (instrument_configs repeated `repeats` times, back-to-back). A config with no
+        optical_filter set (use the camera's current filter) never counts as a change, since
+        there's no way to know whether that's actually a different filter."""
+        filters = [ic.optical_filter for ic in self.configuration.instrument_configs] * self.configuration.repeats
+        return sum(1 for a, b in zip(filters, filters[1:]) if a is not None and b is not None and a != b)
+
+    @staticmethod
+    def _readout_time_s(camera: CameraCapability | None, instrument_config: InstrumentConfig) -> float:
+        if camera is None:
+            return 0.0
+        x, y = instrument_config.binning
+        for binning in camera.binnings:
+            if binning.x == x and binning.y == y and binning.readout_time_s is not None:
+                return binning.readout_time_s
+        return 0.0
 
     async def can_run(self, data: TaskData | None) -> bool:
         """Whether this config can currently run.
@@ -352,19 +371,43 @@ class ImagingScript(Script):
         return hdr
 
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
-        """Estimate the duration of this script in seconds."""
-        # TODO: get some good estimates for slewing/filter/acquisition etc
+        """Estimate the duration of this script in seconds.
+
+        Uses real per-binning readout time, per-wheel filter-change time, and telescope slew
+        rate wherever `data.instrument_capabilities` has a matching, populated row -- falling
+        back to today's flat fudge constants at every point that's missing (no `data`, no
+        capabilities, no matching module, or the specific field not set on the matched row).
+        """
+        capabilities = data.instrument_capabilities if data is not None else None
+        camera = capabilities.camera(self.camera) if capabilities is not None else None
+
         duration = (
             sum(
-                (ic.exposure_time if isinstance(ic.exposure_time, float) else ic.exposure_time.default_exposure_time)
+                (
+                    (
+                        ic.exposure_time
+                        if isinstance(ic.exposure_time, float)
+                        else ic.exposure_time.default_exposure_time
+                    )
+                    + self._readout_time_s(camera, ic)
+                )
                 * ic.count
                 for ic in self.configuration.instrument_configs
             )
             * self.configuration.repeats
-            + 60.0
         )
+
+        telescope = capabilities.telescope(self.telescope) if capabilities is not None and self.telescope else None
+        slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
+        duration += slew_time if slew_time is not None else 60.0
+
         if self.configuration.acquisition_config.enabled:
             duration += 30.0
+
+        filter_wheel = capabilities.filter_wheel(self.filters) if capabilities is not None and self.filters else None
+        if filter_wheel is not None and filter_wheel.filter_change_time_s is not None:
+            duration += filter_wheel.filter_change_time_s * self._filter_change_count()
+
         return duration
 
 

--- a/tests/robotic/scripts/test_autofocus.py
+++ b/tests/robotic/scripts/test_autofocus.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pyobs.robotic.instruments import Instrument, InstrumentCapabilities, TelescopeCapability
 from pyobs.robotic.scheduler.targets import SiderealTarget
 from pyobs.robotic.scripts.imaging.autofocus import AutoFocusScript
 from pyobs.robotic.task import TaskData
@@ -143,3 +144,35 @@ async def test_run_stops_telescope_in_finally() -> None:
 
     # ITelescope always implements IMotion, so stop_motion is always called
     telescope.stop_motion.assert_called_once()
+
+
+# ── estimate_duration ────────────────────────────────────────────────────────
+
+
+def test_estimate_duration_falls_back_without_capabilities() -> None:
+    script = make_script(count=3, exposure_time=2.0)
+    assert script.estimate_duration(None) == 3 * 2.0 + 60.0
+
+
+def test_estimate_duration_uses_real_slew_rate_when_available() -> None:
+    script = make_script(count=3, exposure_time=2.0)
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    duration = script.estimate_duration(data)
+    slew_time = telescope_capability.estimate_slew_time_s()
+    assert slew_time is not None
+
+    assert duration == 3 * 2.0 + slew_time
+    assert duration != 3 * 2.0 + 60.0  # sanity: the real rate actually changed the estimate
+
+
+def test_estimate_duration_falls_back_when_telescope_module_not_matched() -> None:
+    script = make_script(count=3, exposure_time=2.0)
+    capabilities = InstrumentCapabilities(
+        [Instrument(telescope=TelescopeCapability(module_name="a-different-telescope", slew_rate_deg_per_s=3.0))]
+    )
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    assert script.estimate_duration(data) == 3 * 2.0 + 60.0

--- a/tests/robotic/scripts/test_darkbias.py
+++ b/tests/robotic/scripts/test_darkbias.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import astropy.units as u
 import pytest
 
+from pyobs.robotic.instruments import BinningOption, CameraCapability, Instrument, InstrumentCapabilities
 from pyobs.robotic.scripts.calibration.darkbias import DarkBiasScript
+from pyobs.robotic.task import TaskData
 from pyobs.robotic.utils.archive import Archive, FrameInfo
 from pyobs.robotic.utils.calibration import clear_cache
 from pyobs.utils.enums import ImageType
@@ -341,6 +343,31 @@ async def test_runs_series_longest_first() -> None:
 async def test_estimate_duration_sums_over_exptimes_list() -> None:
     script = make_script(count=2, exptimes=[30.0, 600.0])
     assert script.estimate_duration(None) == 2 * (30.0 + 5.0) + 2 * (600.0 + 5.0)
+
+
+def _capabilities_with_readout(readout_time_s: float, binning: tuple[int, int] = (1, 1)) -> InstrumentCapabilities:
+    camera = CameraCapability(
+        module_name="camera",
+        code="ef01",
+        binnings=[BinningOption(x=binning[0], y=binning[1], readout_time_s=readout_time_s)],
+    )
+    return InstrumentCapabilities([Instrument(cameras=[camera])])
+
+
+@pytest.mark.asyncio
+async def test_estimate_duration_uses_real_readout_time_when_available() -> None:
+    script = make_script(count=2, exptimes=[30.0, 600.0])
+    data = TaskData(task=MagicMock(), instrument_capabilities=_capabilities_with_readout(3.5))
+    assert script.estimate_duration(data) == 2 * (30.0 + 3.5) + 2 * (600.0 + 3.5)
+
+
+@pytest.mark.asyncio
+async def test_estimate_duration_falls_back_when_binning_not_declared() -> None:
+    # capability data exists for the camera, but not for this script's binning (2x2) -- falls
+    # back to the flat 5.0s fudge, same as if there were no capability data at all
+    script = make_script(count=2, exptimes=[30.0], binning=(2, 2))
+    data = TaskData(task=MagicMock(), instrument_capabilities=_capabilities_with_readout(3.5, binning=(1, 1)))
+    assert script.estimate_duration(data) == 2 * (30.0 + 5.0)
 
 
 # ── match_science_exptimes ────────────────────────────────────────────────────

--- a/tests/robotic/scripts/test_imaging.py
+++ b/tests/robotic/scripts/test_imaging.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 from pydantic import ValidationError
 
-from pyobs.robotic.scripts.imaging.imaging import Configuration
+from pyobs.robotic.instruments import (
+    BinningOption,
+    CameraCapability,
+    FilterWheelCapability,
+    Instrument,
+    InstrumentCapabilities,
+    TelescopeCapability,
+)
+from pyobs.robotic.scripts.imaging.imaging import Configuration, ImagingScript, InstrumentConfig
+from pyobs.robotic.task import TaskData
 
 
 def test_misplaced_guiding_config_inside_instrument_configs_raises() -> None:
@@ -23,3 +34,171 @@ def test_misplaced_guiding_config_inside_instrument_configs_raises() -> None:
                 ],
             }
         )
+
+
+# ── estimate_duration ────────────────────────────────────────────────────────
+
+
+def make_script(**kwargs) -> ImagingScript:
+    return ImagingScript.model_validate({"camera": "camera", **kwargs}, context={"comm": MagicMock()})
+
+
+def test_estimate_duration_falls_back_without_capabilities() -> None:
+    script = make_script(
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 2}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        }
+    )
+    # no readout, no filter-change, flat 60.0 slew fudge -- exactly today's formula
+    assert script.estimate_duration(None) == 30.0 * 2 + 60.0
+
+
+def test_estimate_duration_adds_real_readout_time() -> None:
+    script = make_script(
+        camera="cam1",
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 2, "binning": (2, 2)}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        },
+    )
+    camera_capability = CameraCapability(
+        module_name="cam1", code="ef01", binnings=[BinningOption(x=2, y=2, readout_time_s=3.5)]
+    )
+    data = TaskData(
+        task=MagicMock(), instrument_capabilities=InstrumentCapabilities([Instrument(cameras=[camera_capability])])
+    )
+
+    duration = script.estimate_duration(data)
+
+    assert duration == (30.0 + 3.5) * 2 + 60.0
+
+
+def test_estimate_duration_no_readout_added_when_binning_not_declared() -> None:
+    script = make_script(
+        camera="cam1",
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 2, "binning": (2, 2)}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        },
+    )
+    camera_capability = CameraCapability(
+        module_name="cam1", code="ef01", binnings=[BinningOption(x=1, y=1, readout_time_s=3.5)]
+    )
+    data = TaskData(
+        task=MagicMock(), instrument_capabilities=InstrumentCapabilities([Instrument(cameras=[camera_capability])])
+    )
+
+    assert script.estimate_duration(data) == 30.0 * 2 + 60.0
+
+
+def test_estimate_duration_uses_real_slew_rate() -> None:
+    script = make_script(
+        telescope="tel1",
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 1}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        },
+    )
+    telescope_capability = TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=3.0)
+    data = TaskData(
+        task=MagicMock(), instrument_capabilities=InstrumentCapabilities([Instrument(telescope=telescope_capability)])
+    )
+
+    duration = script.estimate_duration(data)
+    slew_time = telescope_capability.estimate_slew_time_s()
+    assert slew_time is not None
+
+    assert duration == 30.0 + slew_time
+    assert duration != 30.0 + 60.0
+
+
+def test_estimate_duration_acquisition_fudge_still_applies() -> None:
+    script = make_script(
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 1}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": True},
+        }
+    )
+    assert script.estimate_duration(None) == 30.0 + 60.0 + 30.0
+
+
+def test_estimate_duration_adds_filter_change_time_for_actual_transitions() -> None:
+    # R, V, V, R across one repeat -> 2 actual transitions (R->V, V->R); the middle V->V pair
+    # isn't a change
+    script = make_script(
+        filters="wheel1",
+        configuration={
+            "instrument_configs": [
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "R"},
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "V"},
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "V"},
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "R"},
+            ],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        },
+    )
+    filter_wheel = FilterWheelCapability(module_name="wheel1", filter_change_time_s=4.0)
+    camera_capability = CameraCapability(module_name="camera", code="ef01", filter_wheels=[filter_wheel])
+    data = TaskData(
+        task=MagicMock(), instrument_capabilities=InstrumentCapabilities([Instrument(cameras=[camera_capability])])
+    )
+
+    duration = script.estimate_duration(data)
+
+    assert duration == 40.0 + 60.0 + 2 * 4.0
+
+
+def test_estimate_duration_no_filter_change_time_when_filters_unset() -> None:
+    script = make_script(
+        configuration={
+            "instrument_configs": [
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "R"},
+                {"exposure_time": 10.0, "count": 1, "optical_filter": "V"},
+            ],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        }
+    )
+    # capability data exists, but self.filters is unset -- no filter wheel to look up
+    filter_wheel = FilterWheelCapability(module_name="wheel1", filter_change_time_s=4.0)
+    camera_capability = CameraCapability(module_name="camera", code="ef01", filter_wheels=[filter_wheel])
+    data = TaskData(
+        task=MagicMock(), instrument_capabilities=InstrumentCapabilities([Instrument(cameras=[camera_capability])])
+    )
+
+    assert script.estimate_duration(data) == 20.0 + 60.0
+
+
+def test_filter_change_count_ignores_transitions_touching_unset_filter() -> None:
+    script = make_script(
+        configuration={
+            "instrument_configs": [
+                InstrumentConfig(exposure_time=1.0, optical_filter="R"),
+                InstrumentConfig(exposure_time=1.0, optical_filter=None),
+                InstrumentConfig(exposure_time=1.0, optical_filter="V"),
+            ],
+            "repeats": 1,
+        }
+    )
+    assert script._filter_change_count() == 0
+
+
+def test_filter_change_count_wraps_across_repeats() -> None:
+    script = make_script(
+        configuration={
+            "instrument_configs": [
+                InstrumentConfig(exposure_time=1.0, optical_filter="R"),
+                InstrumentConfig(exposure_time=1.0, optical_filter="V"),
+            ],
+            "repeats": 2,
+        }
+    )
+    # R, V | R, V -- transitions: R->V, V->R, R->V = 3
+    assert script._filter_change_count() == 3

--- a/tests/robotic/scripts/test_pointing.py
+++ b/tests/robotic/scripts/test_pointing.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pyobs.robotic.instruments import Instrument, InstrumentCapabilities, TelescopeCapability
+from pyobs.robotic.scripts.calibration.pointing import PointingScript
+from pyobs.robotic.task import TaskData
+from pyobs.robotic.utils.skyflats.pointing.static import SkyFlatsStaticPointing
+
+
+def make_script(**kwargs) -> PointingScript:
+    return PointingScript.model_validate(
+        {"telescope": "telescope", "pointing": SkyFlatsStaticPointing(), **kwargs}, context={"comm": MagicMock()}
+    )
+
+
+def test_estimate_duration_falls_back_without_capabilities() -> None:
+    script = make_script()
+    assert script.estimate_duration(None) == 60.0
+
+
+def test_estimate_duration_uses_real_slew_rate_when_available() -> None:
+    script = make_script()
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    duration = script.estimate_duration(data)
+
+    assert duration == telescope_capability.estimate_slew_time_s()
+    assert duration != 60.0  # sanity: the real rate actually changed the estimate
+
+
+def test_estimate_duration_falls_back_when_telescope_module_not_matched() -> None:
+    script = make_script()
+    capabilities = InstrumentCapabilities(
+        [Instrument(telescope=TelescopeCapability(module_name="a-different-telescope", slew_rate_deg_per_s=3.0))]
+    )
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    assert script.estimate_duration(data) == 60.0

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyobs.robotic.instruments import Instrument, InstrumentCapabilities
+import pytest
+
+from pyobs.robotic.instruments import Instrument, InstrumentCapabilities, TelescopeCapability
 
 # One Instrument's InstrumentSerializer output, dumped from a live pyobs-portal instance
 # (pyobs-portal#142's schema: module_name lives on CameraCapability/TelescopeCapability/
@@ -155,3 +157,18 @@ class TestInstrumentCapabilities:
         assert capabilities.camera("guidecam") is not None
         assert capabilities.telescope("guidetelescope") is not None
         assert len(capabilities.instruments) == 2
+
+
+class TestTelescopeCapabilityEstimateSlewTime:
+    def test_returns_typical_distance_over_rate(self) -> None:
+        telescope = TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=3.0)
+        # 90.0 deg (the documented placeholder distance) / 3.0 deg/s
+        assert telescope.estimate_slew_time_s() == pytest.approx(30.0)
+
+    def test_none_when_rate_not_declared(self) -> None:
+        telescope = TelescopeCapability(module_name="tel1")
+        assert telescope.estimate_slew_time_s() is None
+
+    def test_none_when_rate_is_zero_or_negative(self) -> None:
+        assert TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=0.0).estimate_slew_time_s() is None
+        assert TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=-1.0).estimate_slew_time_s() is None

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -172,3 +172,7 @@ class TestTelescopeCapabilityEstimateSlewTime:
     def test_none_when_rate_is_zero_or_negative(self) -> None:
         assert TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=0.0).estimate_slew_time_s() is None
         assert TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=-1.0).estimate_slew_time_s() is None
+
+    def test_distance_deg_overrides_the_default(self) -> None:
+        telescope = TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=3.0)
+        assert telescope.estimate_slew_time_s(distance_deg=15.0) == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
§A.8 of `specs/plans/2026-09-01-instrument-capability-duration-estimates.md` — the last piece of §A. Four scripts now read `data.instrument_capabilities` and use real portal-declared numbers wherever available, falling back to today's flat fudge constants whenever the lookup misses at any level (no `data`, no capabilities, no matching `module_name` row, or the specific field not set on the matched row):

- **`ImagingScript`**: adds real per-binning readout time (previously not counted at all) and real per-wheel filter-change time (also previously absent — now counted once per actual filter transition across the full `instrument_configs * repeats` sequence; a config with no `optical_filter` set never counts as a transition, since there's no way to know whether that's actually a change). Telescope slew replaces the flat `60.0` fudge.
- **`PointingScript` / `AutoFocusScript`**: telescope slew replaces their flat `60.0` fudges.
- **`DarkBiasScript`**: camera's matching `BinningOption.readout_time_s` replaces the flat `5.0`s readout fudge.
- **`SelectorScript`**: unchanged, per the plan's Non-goals (unclear which capability field, if any, actually fits "mode change" duration).

New `TelescopeCapability.estimate_slew_time_s()` (`pyobs/robotic/instruments.py`) centralizes the "typical slew distance / real rate" placeholder shared by all three telescope-slewing scripts, instead of duplicating the constant and the None-rate fallback three times.

## Not in this PR
§A.4 (`PortalTaskArchive`'s concrete fetch/cache) — needs a new pyobs-portal marker endpoint that doesn't exist yet, tracked as its own follow-up. Every backend still returns `None` for `get_instrument_capabilities()` today, so **this PR changes no runtime behavior** until real capability data is actually wired up to reach these scripts.

## Test plan
- [x] 20 new tests across `test_instruments.py` (`TelescopeCapability.estimate_slew_time_s()`) and all 4 scripts' test files (real-value path, missing-module fallback, missing-field fallback, filter-change transition counting including the "None never counts as a change" and cross-repeat-boundary cases)
- [x] `pytest tests/` (excluding `integration`/`xmpp`) — 1886 passed (up from 1866), no regressions
- [x] `ruff check` / `black --check` / `pyrefly check` — clean (30 pre-existing, unrelated pyrefly errors on 2 test files confirmed identical on `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XoNCe7YyJELc8xup1zVdE