### PR TITLE
fix: Comm.unregister_event() cancels already-scheduled handler tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ v2.5.0
   ``HIERARCH <MODULE> VERSION <PACKAGE>`` card per loaded ``pyobs-*`` package into FITS headers,
   reusing ``loaded_pyobs_packages()`` (added for #759). Closes #739. See
   ``specs/design/package_versions_fits_header.md``.
+* Fixes ``Comm.unregister_event()`` not cancelling a handler dispatch that
+  ``_send_event_to_module()`` had already scheduled via ``asyncio.create_task()`` before the
+  unregister call -- the task ran later regardless, against whatever the handler was bound to
+  (observed in pyobs-gui as a ``libshiboken: Internal C++ object already deleted`` error on
+  client disconnect). Closes #871.
 
 v2.4.1 (2026-09-03)
 *********************

--- a/pyobs/comm/comm.py
+++ b/pyobs/comm/comm.py
@@ -39,6 +39,7 @@ class Comm:
         self._log_queue: asyncio.Queue[LogEvent] = asyncio.Queue()
         self._logging_task: asyncio.Task[Any] | None = None
         self._event_handlers: dict[type[Event], list[Callable[[Event, str], Coroutine[Any, Any, bool]]]] = {}
+        self._event_handler_tasks: dict[tuple[type[Event], Callable[..., Any]], set[asyncio.Task[Any]]] = {}
         self._events_sent: set[type[Event]] = set()
         self._events_subscribed: set[type[Event]] = set()
         self._closing = asyncio.Event()
@@ -479,6 +480,15 @@ class Comm:
                     self._events_subscribed.discard(ev)
                     unsubscribed.append(ev)
 
+                # cancel any dispatch for this handler that _send_event_to_module() already
+                # scheduled via asyncio.create_task() but that hasn't run yet -- otherwise it
+                # fires later against whatever the handler is bound to, even though the handler
+                # is gone from _event_handlers as of this call (see issue #871)
+                pending = self._event_handler_tasks.pop((ev, handler), None)
+                if pending is not None:
+                    for task in pending:
+                        task.cancel()
+
         # only event classes that just lost their last handler need the comm layer to actually
         # tear anything down (e.g. XmppComm unsubscribing from peers' event nodes)
         if unsubscribed and not event_class.local:
@@ -690,16 +700,26 @@ class Comm:
                 ret = handler(event, from_client)
                 if asyncio.iscoroutine(ret):
                     task = asyncio.create_task(ret)
+                    self._event_handler_tasks.setdefault((event.__class__, handler), set()).add(task)
                     task.add_done_callback(functools.partial(self._log_handler_exception, handler=handler, event=event))
 
-    @staticmethod
-    def _log_handler_exception(task: asyncio.Task[Any], handler: Callable[..., Any], event: Event) -> None:
+    def _log_handler_exception(self, task: asyncio.Task[Any], handler: Callable[..., Any], event: Event) -> None:
         """Log an event handler's exception with context, instead of leaving it to asyncio's own
         "Task exception was never retrieved" warning at garbage-collection time, which gives no
         indication of which handler or event actually failed -- every event handler is dispatched
         as a fire-and-forget task (see _send_event_to_module), so this is the only place any of
         them get their exceptions surfaced at all.
+
+        Also drops the task from _event_handler_tasks, the bookkeeping unregister_event() uses to
+        cancel still-pending dispatches for a handler being removed -- without this, a
+        long-running module would accumulate an entry per (event_class, handler) forever.
         """
+        tasks = self._event_handler_tasks.get((event.__class__, handler))
+        if tasks is not None:
+            tasks.discard(task)
+            if not tasks:
+                del self._event_handler_tasks[(event.__class__, handler)]
+
         if task.cancelled():
             return
         exc = task.exception()

--- a/pyobs/comm/comm.py
+++ b/pyobs/comm/comm.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 StateCallback = Callable[[Any], None]
 PresenceCallback = Callable[["ModuleState", str], None]
+EventHandler = Callable[[Event, str], Coroutine[Any, Any, bool]]
 
 log = logging.getLogger(__name__)
 
@@ -38,8 +39,8 @@ class Comm:
         self._module: Module | None = None
         self._log_queue: asyncio.Queue[LogEvent] = asyncio.Queue()
         self._logging_task: asyncio.Task[Any] | None = None
-        self._event_handlers: dict[type[Event], list[Callable[[Event, str], Coroutine[Any, Any, bool]]]] = {}
-        self._event_handler_tasks: dict[tuple[type[Event], Callable[..., Any]], set[asyncio.Task[Any]]] = {}
+        self._event_handlers: dict[type[Event], list[EventHandler]] = {}
+        self._event_handler_tasks: dict[tuple[type[Event], EventHandler], set[asyncio.Task[Any]]] = {}
         self._events_sent: set[type[Event]] = set()
         self._events_subscribed: set[type[Event]] = set()
         self._closing = asyncio.Event()
@@ -423,9 +424,7 @@ class Comm:
                 event_classes.append(cls[1])
         return event_classes
 
-    async def register_event(
-        self, event_class: type[Event], handler: Callable[[Event, str], Coroutine[Any, Any, bool]] | None = None
-    ) -> None:
+    async def register_event(self, event_class: type[Event], handler: EventHandler | None = None) -> None:
         """Register an event type. If a handler is given, we also receive those events, otherwise we just
         send them.
 
@@ -456,14 +455,21 @@ class Comm:
         if not event_class.local:
             await self._register_events(event_classes, handler)
 
-    async def unregister_event(
-        self, event_class: type[Event], handler: Callable[[Event, str], Coroutine[Any, Any, bool]]
-    ) -> None:
+    async def unregister_event(self, event_class: type[Event], handler: EventHandler) -> None:
         """Remove a handler previously added via register_event().
 
         Leaves the event type itself registered as *sent* if the module also declared it via a
         handler-less register_event() call, only stops calling this handler and, once no handler
         is left for the event, drops it from what's advertised as *subscribed*.
+
+        Also cancels any dispatch of this handler that _send_event_to_module() already scheduled
+        via asyncio.create_task() but that hasn't run yet, so a handler bound to something torn
+        down right before this call can never fire against it afterwards (issue #871). If that
+        dispatch had already started and is currently suspended at an await, cancellation raises
+        CancelledError into it there. This guarantee only holds if the caller awaits
+        unregister_event() directly in the same synchronous stretch as the teardown it's guarding
+        -- scheduling it as a separate task (e.g. `asyncio.create_task(unregister_event(...))`)
+        can still lose the race against an already-scheduled dispatch.
 
         Args:
             event_class: Class of event that was registered.
@@ -494,9 +500,7 @@ class Comm:
         if unsubscribed and not event_class.local:
             await self._unregister_events(unsubscribed)
 
-    async def _register_events(
-        self, events: list[type[Event]], handler: Callable[[Event, str], Coroutine[Any, Any, bool]] | None = None
-    ) -> None:
+    async def _register_events(self, events: list[type[Event]], handler: EventHandler | None = None) -> None:
         pass
 
     async def _unregister_events(self, events: list[type[Event]]) -> None:
@@ -703,7 +707,7 @@ class Comm:
                     self._event_handler_tasks.setdefault((event.__class__, handler), set()).add(task)
                     task.add_done_callback(functools.partial(self._log_handler_exception, handler=handler, event=event))
 
-    def _log_handler_exception(self, task: asyncio.Task[Any], handler: Callable[..., Any], event: Event) -> None:
+    def _log_handler_exception(self, task: asyncio.Task[Any], handler: EventHandler, event: Event) -> None:
         """Log an event handler's exception with context, instead of leaving it to asyncio's own
         "Task exception was never retrieved" warning at garbage-collection time, which gives no
         indication of which handler or event actually failed -- every event handler is dispatched

--- a/specs/plans/2026-09-03-comm-unregister-event-task-cancellation.md
+++ b/specs/plans/2026-09-03-comm-unregister-event-task-cancellation.md
@@ -1,18 +1,21 @@
 # Plan: Comm.unregister_event() cancels already-scheduled handler tasks (#871)
 
-Status: implemented
+Status: implemented (PR #876)
 
 Issue: pyobs-core#871
 
 ## Problem
 
-`Comm._send_event_to_module()` (`pyobs/comm/comm.py:678-693`) dispatches an event to each
-registered handler by calling it to get a coroutine, then fire-and-forgets it via
-`asyncio.create_task(ret)`. `create_task()` only schedules the coroutine — it doesn't run it
-inline. If a handler's owner is torn down and calls `unregister_event()` in the same synchronous
-stretch, before the scheduled task gets a turn, `unregister_event()` (`comm.py:458-485`) removes
-the handler from `self._event_handlers` but has no record of the task already created for it. The
-task still runs later, against whatever the handler is bound to.
+Line numbers below are as of the issue being filed, pre-fix — see `pyobs/comm/comm.py` directly
+for current ones.
+
+`Comm._send_event_to_module()` (pre-fix `comm.py:678-693`) dispatches an event to each registered
+handler by calling it to get a coroutine, then fire-and-forgets it via `asyncio.create_task(ret)`.
+`create_task()` only schedules the coroutine — it doesn't run it inline. If a handler's owner is
+torn down and calls `unregister_event()` in the same synchronous stretch, before the scheduled
+task gets a turn, `unregister_event()` (pre-fix `comm.py:458-485`) removes the handler from
+`self._event_handlers` but has no record of the task already created for it. The task still runs
+later, against whatever the handler is bound to.
 
 Observed in pyobs-gui: `DataDisplayWidget._on_new_data` (a `NewImageEvent`/`NewSpectrumEvent`
 handler, `pyobs_gui/datadisplaywidget.py:175`) touches `self.checkAutoUpdate` after the widget was
@@ -33,30 +36,47 @@ Track in-flight dispatch tasks per `(event_class, handler)` and cancel them in
   `add_done_callback` (still calling `_log_handler_exception`) also discard the task from that set
   and remove the set once empty, so the dict doesn't grow unbounded over a long-running module.
 - In `unregister_event()`'s existing per-`ev` loop (the one that mirrors `register_event()`'s
-  derived-event expansion, `comm.py:474-480`), when a handler is actually removed for a given
-  `ev`, pop `self._event_handler_tasks.get((ev, handler))` and cancel every task still pending —
-  keying by the same `ev`, not the outer `event_class`, so a handler registered against several
-  derived event types only loses tasks for the type actually being unregistered.
+  derived-event expansion), when a handler is actually removed for a given `ev`, pop
+  `self._event_handler_tasks.get((ev, handler))` and cancel every task still pending — keying by
+  the same `ev`, not the outer `event_class`, so a handler registered against several derived event
+  types only loses tasks for the type actually being unregistered.
 - Cancellation is `task.cancel()`, not awaiting it — `unregister_event()` doesn't need to block on
   the handler unwinding, and `_log_handler_exception`'s existing `task.cancelled()` check already
   no-ops for cancelled tasks.
+- Docstring update on `unregister_event()`: state the new cancellation behavior explicitly,
+  including that it also interrupts a handler already suspended at an `await` (raises
+  `CancelledError` there), and that the guarantee only holds if the caller awaits
+  `unregister_event()` inline in the same synchronous stretch as the teardown — a fire-and-forget
+  `asyncio.create_task(unregister_event(...))` can still lose the race.
+- New `EventHandler` type alias (`Callable[[Event, str], Coroutine[Any, Any, bool]]`) replacing the
+  repeated inline signature on `_event_handlers`, `register_event()`, `unregister_event()`,
+  `_register_events()`, and the new `_event_handler_tasks`/`_log_handler_exception` handler
+  parameter — pure typing cleanup, no behavior change.
 
 No change to `register_event()`, `_register_events`/`_unregister_events` (XMPP pubsub
-subscription teardown), or any other `create_task` site — `comm.py:83` and `comm.py:145` are
-unrelated one-shot tasks, and this is the only fire-and-forget dispatch loop in the module.
+subscription teardown), or any other `create_task` site elsewhere in the module — this is the only
+fire-and-forget dispatch loop in `comm.py`.
 
 ## Testing
 
-`tests/comm/test_comm.py` (or wherever `Comm` unit tests live):
+`tests/comm/test_events.py` (existing home for `register_event`/`unregister_event` coverage):
 
-- Register an async handler that raises if called, dispatch an event via
-  `_send_event_to_module()`, immediately call `unregister_event()` before yielding control to the
-  event loop (no `await` in between), then let the loop run one tick — assert the task was
-  cancelled and the handler body never actually ran.
-- A handler still registered for a *different* derived event type keeps its pending task when one
-  event type is unregistered (keying-by-`ev` isn't overbroad).
+- Dispatch an event via `_send_event_to_module()`, immediately call `unregister_event()` before
+  yielding control to the event loop (no `await` in between), then let the loop run one tick —
+  assert the task was cancelled and the handler body never actually ran.
+- Two events dispatched to the same `(event_class, handler)` before unregistering — both pending
+  tasks in the tracking set get cancelled, not just one.
+- A handler still registered for a *different* event type keeps its pending task when one event
+  type is unregistered (keying-by-`ev` isn't overbroad).
+- A dispatch that completes normally (not cancelled) has its `(event_class, handler)` entry
+  removed from `_event_handler_tasks` once done — the memory-hygiene claim in
+  `_log_handler_exception`'s docstring.
 - Existing dispatch/exception-logging tests continue to pass unchanged (`_log_handler_exception`
   behavior for non-cancelled exceptions is untouched).
+
+A `_bare_comm()` helper in the test module builds a minimal `Comm.__new__(Comm)` with just the
+attributes these tests touch, so a future addition to that internal state only needs updating in
+one place instead of in every test.
 
 ## pyobs-gui note
 

--- a/specs/plans/2026-09-03-comm-unregister-event-task-cancellation.md
+++ b/specs/plans/2026-09-03-comm-unregister-event-task-cancellation.md
@@ -1,10 +1,8 @@
 # Plan: Comm.unregister_event() cancels already-scheduled handler tasks (#871)
 
-Status: proposed
+Status: implemented
 
 Issue: pyobs-core#871
-
-Repos: pyobs-core, pyobs-gui
 
 ## Problem
 
@@ -60,44 +58,18 @@ unrelated one-shot tasks, and this is the only fire-and-forget dispatch loop in 
 - Existing dispatch/exception-logging tests continue to pass unchanged (`_log_handler_exception`
   behavior for non-cancelled exceptions is untouched).
 
-## pyobs-gui implications (investigated, not a code-removal task)
+## pyobs-gui note
 
-The issue text cites `StatusItem._state_subscriptions` and
-`MainWindow.discard_all_widgets()` as prior ad-hoc workarounds for this race. Checked both against
-the actual current code:
-
-- **`StatusItem`/`StatusWidget._state_subscriptions`** (`pyobs_gui/statuswidget.py:304-321`) is
-  unrelated to this bug. State updates are delivered synchronously —
-  `pyobs/comm/xmpp/xmppcomm.py:1032` (`callback(state_obj)`) and
-  `pyobs/comm/local/localcomm.py:90/109` call the callback directly, with no
-  `asyncio.create_task` in between — so there's no scheduled task for `unregister_event()`'s fix
-  to race with. This unsubscribe-on-discard code stays; it prevents a plain subscription leak, not
-  this race.
-- **`BaseWidget.discard()`/`register_event()` tracking** (`pyobs_gui/base.py:260-293`) and
-  **`MainWindow.discard_all_widgets()`** (`pyobs_gui/mainwindow.py:712-727`) are the actual event
-  path this fix touches, but neither is removable: they're what *calls*
-  `comm.unregister_event()` in the first place, and that call still has to happen or a handler
-  leaks forever (per `discard()`'s own docstring). What the core fix removes is the *ordering
-  requirement* — today `discard_all_widgets()` must run before Qt destroys the widget, or a task
-  already scheduled from `_send_event_to_module()` slips through; after this fix,
-  `unregister_event()` itself cancels that task, so a same-tick discard-then-destroy is safe.
-  `DataDisplayWidget._on_new_data` (`pyobs_gui/datadisplaywidget.py:175`) has no defensive
-  guard to remove — it directly touches `self.checkAutoUpdate` today and simply crashes (caught,
-  logged) under the race, so there's nothing to delete there either.
-
-Follow-up in pyobs-gui, once pinned to a pyobs-core release containing this fix:
-
-- Confirm the `libshiboken: Internal C++ object already deleted` log line stops appearing under
-  the same disconnect/reconnect sequence that originally surfaced it.
-- Update `discard()`'s and `discard_all_widgets()`'s docstrings to note that the strict
-  before-Qt-destroys-the-widget ordering is now a defense-in-depth guard against other teardown
-  bugs, not a requirement for the event-handler race specifically.
-- No deletion of `_registered_event_handlers` tracking, `discard()`, or `_state_subscriptions` —
-  investigation above found none of it dead code.
+The issue cites `StatusItem._state_subscriptions` and `MainWindow.discard_all_widgets()` as prior
+workarounds for this race. Checked: only `discard_all_widgets()`/`BaseWidget.discard()`
+(`pyobs_gui/base.py:260-293`, `pyobs_gui/mainwindow.py:712-727`) are on the affected event path,
+and neither is removable — they're what calls `unregister_event()` at all. This fix just drops the
+requirement that they run strictly before Qt destroys the widget. `_state_subscriptions`
+(`pyobs_gui/statuswidget.py:304-321`) is unrelated — state updates dispatch synchronously, no
+`create_task` involved — so it stays untouched. No pyobs-gui code changes follow from this plan;
+at most a docstring update once pyobs-gui is pinned to a release with this fix.
 
 ## Rollout
 
 Pure `pyobs-core` internal change, no public API change (`unregister_event()`'s signature is
 unchanged). No server or XMPP protocol impact. Rollback is reverting the `comm.py` diff.
-pyobs-gui docstring updates land in a separate, small follow-up PR once pyobs-gui bumps its
-pyobs-core pin.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -224,6 +224,4 @@ Implementation plans, checklist-style. Newest at the bottom.
   pyobs-iagvt, pyobs-monet, pyobs-monti)
 - [2026-09-03-comm-unregister-event-task-cancellation.md](2026-09-03-comm-unregister-event-task-cancellation.md) —
   `Comm.unregister_event()` cancels already-scheduled handler tasks, closing the stale-widget race
-  in `_send_event_to_module()`; pyobs-gui side is docstring updates only, not code removal (both
-  `_state_subscriptions` and `discard_all_widgets()` investigated and found still necessary).
-  **proposed** (issue #871; Repos: pyobs-core, pyobs-gui)
+  in `_send_event_to_module()`. **implemented** (issue #871)

--- a/tests/comm/test_events.py
+++ b/tests/comm/test_events.py
@@ -23,13 +23,21 @@ from pyobs.comm.comm import Comm
 from pyobs.events import LogEvent, ModuleOpenedEvent
 
 
-@pytest.mark.asyncio
-async def test_unregister_event_removes_handler() -> None:
+def _bare_comm() -> Comm:
+    """A Comm with just enough state for register_event()/unregister_event()/
+    _send_event_to_module(), without running Comm.__init__ (which pulls in
+    logging/proxy/state machinery none of these tests need)."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
     comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
+    return comm
+
+
+@pytest.mark.asyncio
+async def test_unregister_event_removes_handler() -> None:
+    comm = _bare_comm()
     handler = AsyncMock(return_value=True)
 
     await comm.register_event(ModuleOpenedEvent, handler)
@@ -41,11 +49,7 @@ async def test_unregister_event_removes_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_unregister_event_stops_delivery() -> None:
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler = AsyncMock(return_value=True)
 
     await comm.register_event(ModuleOpenedEvent, handler)
@@ -59,11 +63,7 @@ async def test_unregister_event_stops_delivery() -> None:
 async def test_unregister_event_only_removes_matching_handler() -> None:
     """Two independent subscribers (e.g. two widget instances for the same
     event type) don't interfere with each other's teardown."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler_a = AsyncMock(return_value=True)
     handler_b = AsyncMock(return_value=True)
 
@@ -78,11 +78,7 @@ async def test_unregister_event_only_removes_matching_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_unregister_event_unknown_handler_does_not_raise() -> None:
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
 
     # never registered -- must be a no-op, not an error
     await comm.unregister_event(ModuleOpenedEvent, AsyncMock())
@@ -93,11 +89,7 @@ async def test_unregister_event_drops_subscribed_role_when_last_handler_removed(
     """Once the last handler for an event is unregistered, the event must no longer be
     advertised as subscribed -- otherwise disco#info keeps telling peers this module still
     wants to receive an event nothing here handles anymore."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler = AsyncMock(return_value=True)
 
     await comm.register_event(ModuleOpenedEvent, handler)
@@ -111,11 +103,7 @@ async def test_unregister_event_drops_subscribed_role_when_last_handler_removed(
 async def test_unregister_event_keeps_subscribed_role_while_other_handlers_remain() -> None:
     """Two independent subscribers for the same event: one tearing down must not un-declare
     the event for the other."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler_a = AsyncMock(return_value=True)
     handler_b = AsyncMock(return_value=True)
 
@@ -131,11 +119,7 @@ async def test_unregister_event_keeps_subscribed_role_while_other_handlers_remai
 async def test_unregister_event_leaves_sent_role_untouched() -> None:
     """A module that both sends an event (handler-less register_event()) and separately
     subscribes to it keeps advertising it as sent even after its subscription is torn down."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler = AsyncMock(return_value=True)
 
     await comm.register_event(ModuleOpenedEvent)
@@ -151,11 +135,7 @@ async def test_unregister_event_cancels_pending_dispatch_task() -> None:
     """A handler dispatch already scheduled via _send_event_to_module() before
     unregister_event() runs in the same synchronous stretch (no await in between)
     must not fire later against a handler that's already torn down -- issue #871."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     ran = False
 
     async def handler(event: object, sender: str) -> bool:
@@ -180,14 +160,39 @@ async def test_unregister_event_cancels_pending_dispatch_task() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unregister_event_cancels_every_pending_task_for_handler() -> None:
+    """Two events for the same (event_class, handler) can be in flight at once (e.g. two
+    NewImageEvents arriving back-to-back before the widget is torn down) -- unregistering
+    must cancel all of them, not just one, so the tracking set's cancel-loop is exercised
+    with more than a single element."""
+    comm = _bare_comm()
+    run_count = 0
+
+    async def handler(event: object, sender: str) -> bool:
+        nonlocal run_count
+        run_count += 1
+        return True
+
+    await comm.register_event(ModuleOpenedEvent, handler)
+
+    comm._send_event_to_module(ModuleOpenedEvent(), "camera")
+    comm._send_event_to_module(ModuleOpenedEvent(), "camera")
+    tasks = list(comm._event_handler_tasks[(ModuleOpenedEvent, handler)])
+    assert len(tasks) == 2
+
+    await comm.unregister_event(ModuleOpenedEvent, handler)
+    assert (ModuleOpenedEvent, handler) not in comm._event_handler_tasks
+
+    await asyncio.sleep(0)
+    assert all(task.cancelled() for task in tasks)
+    assert run_count == 0
+
+
+@pytest.mark.asyncio
 async def test_unregister_event_leaves_other_event_types_task_pending() -> None:
     """Unregistering a handler for one event type must not cancel its still-pending
     dispatch for a different event type the same handler is also registered for."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
 
     async def handler(event: object, sender: str) -> bool:
         return True
@@ -209,14 +214,33 @@ async def test_unregister_event_leaves_other_event_types_task_pending() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_handler_task_bookkeeping_cleared_after_completion() -> None:
+    """A dispatch task's (event_class, handler) bookkeeping entry must disappear once the
+    task completes normally, not just on cancellation -- otherwise _event_handler_tasks
+    grows one entry per handler forever on a long-running module, each holding a strong
+    reference to that handler (and, transitively, whatever object it's bound to)."""
+    comm = _bare_comm()
+
+    async def handler(event: object, sender: str) -> bool:
+        return True
+
+    await comm.register_event(ModuleOpenedEvent, handler)
+
+    comm._send_event_to_module(ModuleOpenedEvent(), "camera")
+    task = next(iter(comm._event_handler_tasks[(ModuleOpenedEvent, handler)]))
+
+    # _log_handler_exception (registered as this task's done-callback before this point)
+    # runs its cleanup before our own await below resumes, since done-callbacks fire in
+    # the order they were added.
+    await task
+    assert (ModuleOpenedEvent, handler) not in comm._event_handler_tasks
+
+
+@pytest.mark.asyncio
 async def test_unregister_event_expands_derived_events() -> None:
     """unregister must mirror the exact same derived-events expansion register_event
     uses, so it can find everything a matching register_event() call added."""
-    comm = Comm.__new__(Comm)
-    comm._event_handlers = {}
-    comm._event_handler_tasks = {}
-    comm._events_sent = set()
-    comm._events_subscribed = set()
+    comm = _bare_comm()
     handler = AsyncMock(return_value=True)
 
     await comm.register_event(LogEvent, handler)

--- a/tests/comm/test_events.py
+++ b/tests/comm/test_events.py
@@ -14,6 +14,7 @@ list and never actually reach _event_handlers.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -26,6 +27,7 @@ from pyobs.events import LogEvent, ModuleOpenedEvent
 async def test_unregister_event_removes_handler() -> None:
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler = AsyncMock(return_value=True)
@@ -41,6 +43,7 @@ async def test_unregister_event_removes_handler() -> None:
 async def test_unregister_event_stops_delivery() -> None:
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler = AsyncMock(return_value=True)
@@ -58,6 +61,7 @@ async def test_unregister_event_only_removes_matching_handler() -> None:
     event type) don't interfere with each other's teardown."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler_a = AsyncMock(return_value=True)
@@ -76,6 +80,7 @@ async def test_unregister_event_only_removes_matching_handler() -> None:
 async def test_unregister_event_unknown_handler_does_not_raise() -> None:
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
 
@@ -90,6 +95,7 @@ async def test_unregister_event_drops_subscribed_role_when_last_handler_removed(
     wants to receive an event nothing here handles anymore."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler = AsyncMock(return_value=True)
@@ -107,6 +113,7 @@ async def test_unregister_event_keeps_subscribed_role_while_other_handlers_remai
     the event for the other."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler_a = AsyncMock(return_value=True)
@@ -126,6 +133,7 @@ async def test_unregister_event_leaves_sent_role_untouched() -> None:
     subscribes to it keeps advertising it as sent even after its subscription is torn down."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler = AsyncMock(return_value=True)
@@ -139,11 +147,74 @@ async def test_unregister_event_leaves_sent_role_untouched() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unregister_event_cancels_pending_dispatch_task() -> None:
+    """A handler dispatch already scheduled via _send_event_to_module() before
+    unregister_event() runs in the same synchronous stretch (no await in between)
+    must not fire later against a handler that's already torn down -- issue #871."""
+    comm = Comm.__new__(Comm)
+    comm._event_handlers = {}
+    comm._event_handler_tasks = {}
+    comm._events_sent = set()
+    comm._events_subscribed = set()
+    ran = False
+
+    async def handler(event: object, sender: str) -> bool:
+        nonlocal ran
+        ran = True
+        return True
+
+    await comm.register_event(ModuleOpenedEvent, handler)
+
+    comm._send_event_to_module(ModuleOpenedEvent(), "camera")
+    tasks = comm._event_handler_tasks[(ModuleOpenedEvent, handler)]
+    assert len(tasks) == 1
+    task = next(iter(tasks))
+
+    # unregister in the same synchronous stretch, before the scheduled task gets a turn
+    await comm.unregister_event(ModuleOpenedEvent, handler)
+    assert (ModuleOpenedEvent, handler) not in comm._event_handler_tasks
+
+    await asyncio.sleep(0)
+    assert task.cancelled()
+    assert ran is False
+
+
+@pytest.mark.asyncio
+async def test_unregister_event_leaves_other_event_types_task_pending() -> None:
+    """Unregistering a handler for one event type must not cancel its still-pending
+    dispatch for a different event type the same handler is also registered for."""
+    comm = Comm.__new__(Comm)
+    comm._event_handlers = {}
+    comm._event_handler_tasks = {}
+    comm._events_sent = set()
+    comm._events_subscribed = set()
+
+    async def handler(event: object, sender: str) -> bool:
+        return True
+
+    await comm.register_event(LogEvent, handler)
+    await comm.register_event(ModuleOpenedEvent, handler)
+
+    comm._send_event_to_module(LogEvent("t", "INFO", "f.py", "fn", 1, "msg"), "camera")
+    comm._send_event_to_module(ModuleOpenedEvent(), "camera")
+
+    await comm.unregister_event(LogEvent, handler)
+
+    assert (LogEvent, handler) not in comm._event_handler_tasks
+    assert (ModuleOpenedEvent, handler) in comm._event_handler_tasks
+    other_task = next(iter(comm._event_handler_tasks[(ModuleOpenedEvent, handler)]))
+    assert not other_task.cancelled()
+
+    await asyncio.sleep(0)  # let both tasks finish so nothing's left pending at teardown
+
+
+@pytest.mark.asyncio
 async def test_unregister_event_expands_derived_events() -> None:
     """unregister must mirror the exact same derived-events expansion register_event
     uses, so it can find everything a matching register_event() call added."""
     comm = Comm.__new__(Comm)
     comm._event_handlers = {}
+    comm._event_handler_tasks = {}
     comm._events_sent = set()
     comm._events_subscribed = set()
     handler = AsyncMock(return_value=True)

--- a/tests/comm/test_presence.py
+++ b/tests/comm/test_presence.py
@@ -390,6 +390,7 @@ async def test_got_online_completes_despite_broken_presence_callback() -> None:
     comm._peer_sent_events = {}
     comm._presence_callbacks = {"camera": [MagicMock(side_effect=RuntimeError("Signal source has been deleted"))]}
     comm._event_handlers = {ModuleOpenedEvent: [handler]}
+    comm._event_handler_tasks = {}
     comm._get_interfaces = AsyncMock(return_value=["IModule"])
 
     msg = {"from": MagicMock(full="camera@localhost/pyobs", username="camera"), "show": "", "status": ""}


### PR DESCRIPTION
## Summary

- `Comm._send_event_to_module()` fire-and-forgets each handler dispatch via `asyncio.create_task()`, which only schedules the coroutine — it doesn't run inline.
- If a handler's owner tears down and calls `unregister_event()` in the same synchronous stretch, before the scheduled task gets a turn, the task ran anyway against a possibly torn-down target (observed in pyobs-gui as `RuntimeError: libshiboken: Internal C++ object already deleted`).
- Tracks in-flight dispatch tasks per `(event_class, handler)` and cancels any still pending for a handler `unregister_event()` actually removes, closing the race at the dispatch layer.

Plan: `specs/plans/2026-09-03-comm-unregister-event-task-cancellation.md`

Closes #871

## Test plan

- [x] New regression tests in `tests/comm/test_events.py`: task scheduled then unregistered before the event loop yields gets cancelled and its body never runs; a handler's pending task for a *different* event type is unaffected.
- [x] `uv run pytest tests/comm/ -m "not integration and not xmpp"` — 182 passed
- [x] `uv run pytest -m "not integration and not xmpp"` (full suite) — 1912 passed
- [x] `uv run ruff check`, `uv run black --check`, `uv run pyrefly check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SjkJ4CSYmbqB3fhef5JwJ