### PR TITLE
Add RoofCapability for plain open/close roof timing

### DIFF
--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -120,8 +120,24 @@ class DomeCapability(BaseModel):
         return distance_deg / self.rotate_rate_deg_per_s
 
 
+class RoofCapability(BaseModel):
+    """Planning-time capability data for one plain open/close roof, keyed by `module_name`.
+
+    A plain roof (`IRoof`, no `IPointingAltAz`) has no rate/distance concept -- nothing to rotate
+    toward a target, just a fixed open/close cycle time. Distinct from `DomeCapability` (a
+    rotating dome): a site has one or the other, never both, but nothing here enforces that.
+    `open_close_time_s` is already a duration, not a rate, so unlike `estimate_slew_time_s()`/
+    `estimate_rotate_time_s()` there's no distance parameter to combine it with -- callers use it
+    directly.
+    """
+
+    module_name: str
+    open_close_time_s: float | None = None
+    updated_at: str | None = None
+
+
 class Instrument(BaseModel):
-    """One telescope + dome + camera(s) grouping, as returned by `GET /api/instruments/`.
+    """One telescope + dome/roof + camera(s) grouping, as returned by `GET /api/instruments/`.
 
     Purely an organizational grouping on the portal side -- it carries no module identity of its
     own; each device below carries its own `module_name`. `InstrumentCapabilities` is what
@@ -134,6 +150,7 @@ class Instrument(BaseModel):
     cameras: list[CameraCapability] = Field(default_factory=list)
     telescope: TelescopeCapability | None = None
     dome: DomeCapability | None = None
+    roof: RoofCapability | None = None
 
 
 class InstrumentCapabilities:
@@ -151,6 +168,7 @@ class InstrumentCapabilities:
         self._cameras_by_code: dict[str, CameraCapability] = {}
         self._telescopes: dict[str, TelescopeCapability] = {}
         self._domes: dict[str, DomeCapability] = {}
+        self._roofs: dict[str, RoofCapability] = {}
         self._filter_wheels: dict[str, FilterWheelCapability] = {}
 
         for instrument in instruments:
@@ -164,6 +182,8 @@ class InstrumentCapabilities:
                 self._telescopes[instrument.telescope.module_name] = instrument.telescope
             if instrument.dome is not None:
                 self._domes[instrument.dome.module_name] = instrument.dome
+            if instrument.roof is not None:
+                self._roofs[instrument.roof.module_name] = instrument.roof
 
     @classmethod
     def from_api_response(cls, data: list[dict[str, Any]]) -> InstrumentCapabilities:
@@ -186,6 +206,10 @@ class InstrumentCapabilities:
         """The `DomeCapability` whose own `module_name` matches, or None."""
         return self._domes.get(module_name)
 
+    def roof(self, module_name: str) -> RoofCapability | None:
+        """The `RoofCapability` whose own `module_name` matches, or None."""
+        return self._roofs.get(module_name)
+
     def filter_wheel(self, module_name: str) -> FilterWheelCapability | None:
         """The `FilterWheelCapability` whose own `module_name` matches, or None."""
         return self._filter_wheels.get(module_name)
@@ -199,6 +223,7 @@ __all__ = [
     "CameraCapability",
     "TelescopeCapability",
     "DomeCapability",
+    "RoofCapability",
     "Instrument",
     "InstrumentCapabilities",
 ]

--- a/pyobs/robotic/scripts/calibration/pointing.py
+++ b/pyobs/robotic/scripts/calibration/pointing.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
-from pyobs.interfaces import IDome, IPointingAltAz, IReady
+from pyobs.interfaces import IDome, IPointingAltAz, IReady, IRoof
 from pyobs.robotic.scripts import Script
 from pyobs.robotic.utils.skyflats.pointing import SkyFlatsBasePointing
 
@@ -22,6 +22,9 @@ class PointingScript(Script):
     telescope: Annotated[str, IPointingAltAz, IReady] = Field(description="Name of the telescope module to point.")
     dome: Annotated[str | None, IDome] = Field(
         default=None, description="Name of the dome module, if the site has a rotating dome (omit for a plain roof)."
+    )
+    roof: Annotated[str | None, IRoof] = Field(
+        default=None, description="Name of the roof module, if the site has a plain open/close roof (omit for a dome)."
     )
     pointing: SkyFlatsBasePointing = Field(description="Strategy used to compute the flat-field pointing.")
 
@@ -55,16 +58,18 @@ class PointingScript(Script):
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         """Estimate duration of slewing to the flat-field pointing.
 
-        Telescope and dome move in parallel, so time-to-ready is the slower of the two, not their
-        sum -- falls back to the flat 60.0 fudge only when neither yields a real estimate.
+        Telescope and dome/roof move in parallel, so time-to-ready is the slowest of the three,
+        not their sum -- falls back to the flat 60.0 fudge only when none yields a real estimate.
         """
         capabilities = data.instrument_capabilities if data is not None else None
         telescope = capabilities.telescope(self.telescope) if capabilities is not None else None
         slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
         dome = capabilities.dome(self.dome) if capabilities is not None and self.dome else None
         rotate_time = dome.estimate_rotate_time_s() if dome is not None else None
+        roof = capabilities.roof(self.roof) if capabilities is not None and self.roof else None
+        roof_time = roof.open_close_time_s if roof is not None else None
 
-        times = [t for t in (slew_time, rotate_time) if t is not None]
+        times = [t for t in (slew_time, rotate_time, roof_time) if t is not None]
         return max(times) if times else 60.0
 
 

--- a/pyobs/robotic/scripts/imaging/autofocus.py
+++ b/pyobs/robotic/scripts/imaging/autofocus.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
-from pyobs.interfaces import IAutoFocus, IDome, IMotion, IPointingRaDec, IReady, ITelescope
+from pyobs.interfaces import IAutoFocus, IDome, IMotion, IPointingRaDec, IReady, IRoof, ITelescope
 from pyobs.robotic.scripts import Script
 from pyobs.utils.time import Time
 
@@ -26,6 +26,9 @@ class AutoFocusScript(Script):
     )
     dome: Annotated[str | None, IDome] = Field(
         default=None, description="Name of the dome module, if the site has a rotating dome (omit for a plain roof)."
+    )
+    roof: Annotated[str | None, IRoof] = Field(
+        default=None, description="Name of the roof module, if the site has a plain open/close roof (omit for a dome)."
     )
     count: int = Field(default=5, description="Number of focus steps to take in the series.")
     step: float = Field(default=0.1, description="Focus step size.")
@@ -94,16 +97,18 @@ class AutoFocusScript(Script):
     def estimate_duration(self, data: TaskData | None = None, time: Time | None = None) -> float:
         """Estimate duration of the autofocus run.
 
-        Telescope and dome move in parallel, so time-to-ready is the slower of the two, not their
-        sum -- falls back to the flat 60.0 fudge only when neither yields a real estimate.
+        Telescope and dome/roof move in parallel, so time-to-ready is the slowest of the three,
+        not their sum -- falls back to the flat 60.0 fudge only when none yields a real estimate.
         """
         capabilities = data.instrument_capabilities if data is not None else None
         telescope = capabilities.telescope(self.telescope) if capabilities is not None else None
         slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
         dome = capabilities.dome(self.dome) if capabilities is not None and self.dome else None
         rotate_time = dome.estimate_rotate_time_s() if dome is not None else None
+        roof = capabilities.roof(self.roof) if capabilities is not None and self.roof else None
+        roof_time = roof.open_close_time_s if roof is not None else None
 
-        times = [t for t in (slew_time, rotate_time) if t is not None]
+        times = [t for t in (slew_time, rotate_time, roof_time) if t is not None]
         return self.count * self.exposure_time + (max(times) if times else 60.0)
 
 

--- a/pyobs/robotic/scripts/imaging/imaging.py
+++ b/pyobs/robotic/scripts/imaging/imaging.py
@@ -19,6 +19,7 @@ from pyobs.interfaces import (
     IImageType,
     IPointingRaDec,
     IReady,
+    IRoof,
     ITelescope,
     IWindow,
 )
@@ -115,6 +116,9 @@ class ImagingScript(Script):
     )
     dome: Annotated[str | None, IDome] = Field(
         default=None, description="Name of the dome module, if the site has a rotating dome (omit for a plain roof)."
+    )
+    roof: Annotated[str | None, IRoof] = Field(
+        default=None, description="Name of the roof module, if the site has a plain open/close roof (omit for a dome)."
     )
     filters: Annotated[str | None, IFilters] = Field(
         default=None, description="Name of the filter wheel module. Required if any instrument config sets a filter."
@@ -378,11 +382,11 @@ class ImagingScript(Script):
         """Estimate the duration of this script in seconds.
 
         Uses real per-binning readout time, per-wheel filter-change time, and telescope slew /
-        dome rotate rate wherever `data.instrument_capabilities` has a matching, populated row --
-        falling back to today's flat fudge constants at every point that's missing (no `data`, no
-        capabilities, no matching module, or the specific field not set on the matched row).
-        Telescope and dome move in parallel, so the slew/rotate term is the slower of the two, not
-        their sum.
+        dome rotate / roof open-close time wherever `data.instrument_capabilities` has a matching,
+        populated row -- falling back to today's flat fudge constants at every point that's
+        missing (no `data`, no capabilities, no matching module, or the specific field not set on
+        the matched row). Telescope and dome/roof move in parallel, so the slew/rotate/roof term
+        is the slowest of the three, not their sum.
 
         Two simplifications carried over from today's flat constants, not new: the slew term is
         added unconditionally, even for a bias/dark-only sequence that never actually points at
@@ -413,7 +417,9 @@ class ImagingScript(Script):
         slew_time = telescope.estimate_slew_time_s() if telescope is not None else None
         dome = capabilities.dome(self.dome) if capabilities is not None and self.dome else None
         rotate_time = dome.estimate_rotate_time_s() if dome is not None else None
-        times = [t for t in (slew_time, rotate_time) if t is not None]
+        roof = capabilities.roof(self.roof) if capabilities is not None and self.roof else None
+        roof_time = roof.open_close_time_s if roof is not None else None
+        times = [t for t in (slew_time, rotate_time, roof_time) if t is not None]
         duration += max(times) if times else 60.0
 
         if self.configuration.acquisition_config.enabled:

--- a/specs/plans/2026-09-04-roof-open-close-capability.md
+++ b/specs/plans/2026-09-04-roof-open-close-capability.md
@@ -1,0 +1,70 @@
+# Plan: Plain-roof open/close-time capability field
+
+Status: implemented, pending PR merge (Repos: pyobs-core, pyobs-portal)
+
+Split out of `2026-09-04-first-task-slew-rotate-distance.md` (pyobs-core#858's review discussion,
+2026-09-04) as pyobs-core#877: telescope slew time and rotating-dome rotate time both already had
+portal-side rate data to consume (`TelescopeCapability.slew_rate_deg_per_s`,
+`DomeCapability.rotate_rate_deg_per_s`); a plain open/close roof (`IRoof`, no `IPointingAltAz` --
+nothing to rotate toward a target) has no rate/distance concept at all, just a fixed cycle time,
+and no field for it existed anywhere -- neither pyobs-core's `instruments.py` nor pyobs-portal's
+`instruments` app. That's a portal-side model change first, bigger scope than #858's pure
+data-wiring, hence the split (closer in shape to the #139/#140/#142 model-field additions the
+original 2026-09-01 plan needed).
+
+**Real motivating need**: MONET-N/MONET-S/MONTI are all plain roofs, no rotating dome
+(`monet/pyobs-monet#3`), so this -- not #858's dome piece -- is what actually unblocks accurate
+first-task duration estimates for that fleet once the portal admin is filled in.
+
+## Design
+
+### pyobs-portal (`pyobs_portal/instruments/`)
+
+New `RoofCapability` model, parallel to `DomeCapability`: `module_name` (unique),
+`open_close_time_s` (nullable float), `OneToOneField(Instrument, related_name="roof")`,
+`updated_at`. Wired into:
+- `InstrumentSerializer` (new `roof` field) and `RoofCapabilitySerializer`.
+- `InstrumentAdmin` (`RoofCapabilityInline`, `StackedInline` like `DomeCapabilityInline`).
+- `INSTRUMENT_QUERYSET`'s `select_related` (no N+1 -- a JOIN, not an added query).
+- `last_instrument_update/`'s marker `Max()` (now eight models, not seven).
+- `instrument-config` group permissions, via a new data migration (0007) rather than editing the
+  already-applied 0002 migration -- add/change/delete on `roofcapability`, same shape as every
+  other capability model there.
+
+### pyobs-core (`pyobs/robotic/instruments.py` + the three scripts)
+
+`RoofCapability` pydantic model mirrors the portal shape. Unlike `TelescopeCapability`/
+`DomeCapability`, **no `estimate_*()` method** -- `open_close_time_s` is already a duration, not a
+rate to combine with a distance, so callers use it directly (same pattern as
+`FilterWheelCapability.filter_change_time_s`). `InstrumentCapabilities.roof(module_name)` lookup
+and `Instrument.roof` field mirror `dome`.
+
+`PointingScript`/`ImagingScript`/`AutoFocusScript` each gain a `roof: str | None` field
+(`Annotated[str | None, IRoof]`, default `None`), alongside the existing `telescope`/`dome`
+fields. `estimate_duration()` extends the existing `max(slew_time, rotate_time)` to a third
+candidate, `roof.open_close_time_s` when present -- telescope and dome/roof move in parallel, so
+time-to-ready is the slowest of the three, not their sum. A site has a dome or a roof, never both
+in practice, but nothing here enforces that; both fields can be set independently, same as
+telescope/dome already are.
+
+## Non-goals
+
+- **Live telescope/dome/roof position** -- out of scope here for the same reason it was dropped
+  from #858 (see that plan's History section): no observed accuracy problem justified it.
+- **Enforcing "dome xor roof" at the type level** -- not worth the validation complexity for a
+  constraint that's a real-world fact about hardware, not a data-integrity risk this app needs to
+  guard against (same reasoning as the portal model docstring's `module_name` uniqueness caveat).
+
+## Test plan
+
+- [x] pyobs-portal: `RoofCapability` cascade-delete, serializer round-trip (`roof: null` when
+      absent, populated when present), `INSTRUMENT_QUERYSET` N+1 guard now covers roof,
+      `last_instrument_update/` moves on a roof-only edit, `instrument-config` group permissions
+      include `roofcapability`, migration-idempotency guard for the 0007 data migration —
+      `pyobs_portal/instruments/tests.py`, 25 tests in the app, 152 in the full suite.
+- [x] pyobs-core: `RoofCapability` model (`open_close_time_s` used directly, no rate/distance
+      method), `InstrumentCapabilities.roof()` lookup, `Instrument.roof` round-trips a plain-roof
+      site (no dome) — `tests/robotic/test_instruments.py`.
+- [x] pyobs-core: `PointingScript`/`ImagingScript`/`AutoFocusScript.estimate_duration()` — roof
+      slower than telescope, telescope slower than roof, roof not configured (unaffected) — one
+      test per case per script.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -232,3 +232,8 @@ Implementation plans, checklist-style. Newest at the bottom.
   `max()`. Descoped from an original live-telescope-position design (see doc's History section)
   after review — no observed accuracy problem justified the added scheduler-threading risk.
   Plain-roof open/close time split out to #877. **implemented** (issue #858; Repos: pyobs-core)
+- [2026-09-04-roof-open-close-capability.md](2026-09-04-roof-open-close-capability.md) — new
+  `RoofCapability` model (pyobs-portal `instruments` app + pyobs-core mirror), `roof` field on
+  `Pointing`/`Imaging`/`AutoFocusScript`, folded into the same `max()` first-task estimate. Real
+  motivating fleet: MONET-N/S/MONTI are plain roofs, no rotating dome (`monet/pyobs-monet#3`).
+  **implemented, pending PR merge** (issue #877; Repos: pyobs-core, pyobs-portal)

--- a/tests/robotic/scripts/test_autofocus.py
+++ b/tests/robotic/scripts/test_autofocus.py
@@ -4,7 +4,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from pyobs.robotic.instruments import DomeCapability, Instrument, InstrumentCapabilities, TelescopeCapability
+from pyobs.robotic.instruments import (
+    DomeCapability,
+    Instrument,
+    InstrumentCapabilities,
+    RoofCapability,
+    TelescopeCapability,
+)
 from pyobs.robotic.scheduler.targets import SiderealTarget
 from pyobs.robotic.scripts.imaging.autofocus import AutoFocusScript
 from pyobs.robotic.task import TaskData
@@ -188,3 +194,15 @@ def test_estimate_duration_uses_dome_rotate_time_when_slower() -> None:
     duration = script.estimate_duration(data)
 
     assert duration == 3 * 2.0 + dome_capability.estimate_rotate_time_s()
+
+
+def test_estimate_duration_uses_roof_open_close_time_when_slower() -> None:
+    script = make_script(count=3, exposure_time=2.0, roof="roof1")
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)  # 30.0s
+    roof_capability = RoofCapability(module_name="roof1", open_close_time_s=90.0)  # slower
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability, roof=roof_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    duration = script.estimate_duration(data)
+
+    assert duration == 3 * 2.0 + 90.0

--- a/tests/robotic/scripts/test_imaging.py
+++ b/tests/robotic/scripts/test_imaging.py
@@ -12,6 +12,7 @@ from pyobs.robotic.instruments import (
     FilterWheelCapability,
     Instrument,
     InstrumentCapabilities,
+    RoofCapability,
     TelescopeCapability,
 )
 from pyobs.robotic.scripts.imaging.imaging import Configuration, ImagingScript, InstrumentConfig
@@ -142,6 +143,31 @@ def test_estimate_duration_uses_dome_rotate_time_when_slower() -> None:
     assert rotate_time is not None
 
     assert duration == 30.0 + rotate_time
+    assert duration != 30.0 + telescope_capability.estimate_slew_time_s()
+
+
+def test_estimate_duration_uses_roof_open_close_time_when_slower() -> None:
+    script = make_script(
+        telescope="tel1",
+        roof="roof1",
+        configuration={
+            "instrument_configs": [{"exposure_time": 30.0, "count": 1}],
+            "repeats": 1,
+            "acquisition_config": {"enabled": False},
+        },
+    )
+    telescope_capability = TelescopeCapability(module_name="tel1", slew_rate_deg_per_s=3.0)  # 30.0s
+    roof_capability = RoofCapability(module_name="roof1", open_close_time_s=90.0)  # slower
+    data = TaskData(
+        task=MagicMock(),
+        instrument_capabilities=InstrumentCapabilities(
+            [Instrument(telescope=telescope_capability, roof=roof_capability)]
+        ),
+    )
+
+    duration = script.estimate_duration(data)
+
+    assert duration == 30.0 + 90.0
     assert duration != 30.0 + telescope_capability.estimate_slew_time_s()
 
 

--- a/tests/robotic/scripts/test_pointing.py
+++ b/tests/robotic/scripts/test_pointing.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from pyobs.robotic.instruments import DomeCapability, Instrument, InstrumentCapabilities, TelescopeCapability
+from pyobs.robotic.instruments import (
+    DomeCapability,
+    Instrument,
+    InstrumentCapabilities,
+    RoofCapability,
+    TelescopeCapability,
+)
 from pyobs.robotic.scripts.calibration.pointing import PointingScript
 from pyobs.robotic.task import TaskData
 from pyobs.robotic.utils.skyflats.pointing.static import SkyFlatsStaticPointing
@@ -72,6 +78,41 @@ def test_estimate_duration_ignores_dome_when_not_configured() -> None:
     telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)
     dome_capability = DomeCapability(module_name="dome1", rotate_rate_deg_per_s=100.0)  # would dominate if used
     capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability, dome=dome_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    assert script.estimate_duration(data) == telescope_capability.estimate_slew_time_s()
+
+
+def test_estimate_duration_uses_roof_open_close_time_when_slower() -> None:
+    script = make_script(roof="roof1")
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)  # 30.0s
+    roof_capability = RoofCapability(module_name="roof1", open_close_time_s=90.0)  # slower
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability, roof=roof_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    duration = script.estimate_duration(data)
+
+    assert duration == 90.0
+    assert duration != telescope_capability.estimate_slew_time_s()
+
+
+def test_estimate_duration_uses_telescope_slew_time_when_slower_than_roof() -> None:
+    script = make_script(roof="roof1")
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=1.0)  # 90.0s, slower
+    roof_capability = RoofCapability(module_name="roof1", open_close_time_s=20.0)
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability, roof=roof_capability)])
+    data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
+
+    duration = script.estimate_duration(data)
+
+    assert duration == telescope_capability.estimate_slew_time_s()
+
+
+def test_estimate_duration_ignores_roof_when_not_configured() -> None:
+    script = make_script()  # no roof field set
+    telescope_capability = TelescopeCapability(module_name="telescope", slew_rate_deg_per_s=3.0)
+    roof_capability = RoofCapability(module_name="roof1", open_close_time_s=1000.0)  # would dominate if used
+    capabilities = InstrumentCapabilities([Instrument(telescope=telescope_capability, roof=roof_capability)])
     data = TaskData(task=MagicMock(), instrument_capabilities=capabilities)
 
     assert script.estimate_duration(data) == telescope_capability.estimate_slew_time_s()

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -4,7 +4,13 @@ from typing import Any
 
 import pytest
 
-from pyobs.robotic.instruments import DomeCapability, Instrument, InstrumentCapabilities, TelescopeCapability
+from pyobs.robotic.instruments import (
+    DomeCapability,
+    Instrument,
+    InstrumentCapabilities,
+    RoofCapability,
+    TelescopeCapability,
+)
 
 # One Instrument's InstrumentSerializer output, dumped from a live pyobs-portal instance
 # (pyobs-portal#142's schema: module_name lives on CameraCapability/TelescopeCapability/
@@ -59,6 +65,7 @@ INSTRUMENT_RESPONSE: dict[str, Any] = {
         "rotate_rate_deg_per_s": 2.5,
         "updated_at": "2026-09-02T18:34:16.454272Z",
     },
+    "roof": None,
 }
 
 
@@ -79,6 +86,25 @@ def test_instrument_round_trips_portal_response() -> None:
     assert instrument.dome is not None
     assert instrument.dome.module_name == "iag50dome"
     assert instrument.dome.rotate_rate_deg_per_s == 2.5
+    assert instrument.roof is None
+
+
+def test_instrument_with_plain_roof_round_trips() -> None:
+    # a plain-roof site has no dome at all -- MONET-N/S per monet/pyobs-monet#3
+    response = {
+        **INSTRUMENT_RESPONSE,
+        "dome": None,
+        "roof": {
+            "module_name": "iag50roof",
+            "open_close_time_s": 45.0,
+            "updated_at": "2026-09-04T09:00:00.000000Z",
+        },
+    }
+    instrument = Instrument.model_validate(response)
+    assert instrument.dome is None
+    assert instrument.roof is not None
+    assert instrument.roof.module_name == "iag50roof"
+    assert instrument.roof.open_close_time_s == 45.0
 
 
 def test_instrument_with_no_telescope_or_dome() -> None:
@@ -86,6 +112,7 @@ def test_instrument_with_no_telescope_or_dome() -> None:
     instrument = Instrument.model_validate(response)
     assert instrument.telescope is None
     assert instrument.dome is None
+    assert instrument.roof is None
 
 
 class TestInstrumentCapabilities:
@@ -114,6 +141,18 @@ class TestInstrumentCapabilities:
         dome = self.capabilities.dome("iag50dome")
         assert dome is not None
         assert dome.rotate_rate_deg_per_s == 2.5
+
+    def test_roof_lookup_by_module_name(self) -> None:
+        response = {
+            **INSTRUMENT_RESPONSE,
+            "dome": None,
+            "roof": {"module_name": "iag50roof", "open_close_time_s": 45.0, "updated_at": None},
+        }
+        capabilities = InstrumentCapabilities.from_api_response([response])
+        roof = capabilities.roof("iag50roof")
+        assert roof is not None
+        assert roof.open_close_time_s == 45.0
+        assert capabilities.roof("iag50dome") is None
 
     def test_filter_wheel_lookup_by_module_name(self) -> None:
         wheel = self.capabilities.filter_wheel("iag50filt")
@@ -195,3 +234,14 @@ class TestDomeCapabilityEstimateRotateTime:
     def test_distance_deg_overrides_the_default(self) -> None:
         dome = DomeCapability(module_name="dome1", rotate_rate_deg_per_s=2.5)
         assert dome.estimate_rotate_time_s(distance_deg=10.0) == pytest.approx(4.0)
+
+
+class TestRoofCapability:
+    def test_open_close_time_s_defaults_to_none(self) -> None:
+        assert RoofCapability(module_name="roof1").open_close_time_s is None
+
+    def test_open_close_time_s_used_directly_not_a_rate(self) -> None:
+        # unlike TelescopeCapability/DomeCapability, this is already a duration -- no
+        # estimate_*() method, no distance parameter to combine it with.
+        roof = RoofCapability(module_name="roof1", open_close_time_s=45.0)
+        assert roof.open_close_time_s == 45.0


### PR DESCRIPTION
## Summary
- New `RoofCapability` pydantic model (`pyobs/robotic/instruments.py`), mirroring `DomeCapability`'s shape but with **no `estimate_*()` method** — `open_close_time_s` is already a duration, not a rate to combine with a distance, used directly (same as `FilterWheelCapability.filter_change_time_s`).
- `InstrumentCapabilities.roof(module_name)` lookup + `Instrument.roof` field, mirroring `dome`.
- New `roof: str | None` field on `PointingScript`/`ImagingScript`/`AutoFocusScript`, alongside the existing `telescope`/`dome` fields.
- `estimate_duration()` in each script extends the existing `max(slew_time, rotate_time)` to a third candidate, `roof.open_close_time_s` when present.

## Why
A plain roof (`IRoof`, no `IPointingAltAz`) has no rate/distance concept the existing `DomeCapability` can express. Split out of pyobs-core#858's review discussion as #877. Real motivating fleet: MONET-N/MONET-S/MONTI are all plain roofs, no rotating dome (`monet/pyobs-monet#3`), so this is what actually unblocks accurate first-task duration estimates there once the portal admin is filled in.

Companion PR on the portal side: pyobs/pyobs-portal#149 (new `RoofCapability` Django model + serializer + admin + migrations).

## Test plan
- [x] `pytest tests/robotic/` — 503 passed (494 previous + 9 new)
- [x] `ruff check` / `black --check` / `pyrefly check` — clean

Closes #877.