### PR TITLE
Add camera/filter-wheel model fields, fix nullable module_name bug

### DIFF
--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -10,12 +10,29 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from pyobs.utils.serialization import BaseModel
 
 
-class Filter(BaseModel):
+class _ForwardCompatibleModel(BaseModel):
+    """Base for the capability models below, relaxing `BaseModel`'s `extra="forbid"` to
+    `extra="ignore"`.
+
+    A running process (e.g. `mastermind`) can be on an older pyobs-core release than whatever
+    portal it polls -- the portal gaining a field (as it will over time; `model`/`sensor_type`
+    already did once) must not turn into a hard parse failure that starves it of every other
+    field in the response. `extra="forbid"` is a deliberate, useful default elsewhere in pyobs
+    (catching config typos, `2026-08-15-pydantic-extra-validation.md`) but wrong here: this
+    module only ever consumes portal-controlled data, not user-authored config, and the two
+    sides (portal, and every fleet site's own pyobs-core version) are never guaranteed to be on
+    the same release.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class Filter(_ForwardCompatibleModel):
     """A single filter position in a filter wheel."""
 
     name: str
@@ -23,7 +40,7 @@ class Filter(BaseModel):
     updated_at: str | None = None
 
 
-class BinningOption(BaseModel):
+class BinningOption(_ForwardCompatibleModel):
     """Readout time for one binning mode of a camera."""
 
     x: int
@@ -32,25 +49,31 @@ class BinningOption(BaseModel):
     updated_at: str | None = None
 
 
-class FilterWheelCapability(BaseModel):
-    """Planning-time capability data for one filter wheel.
+class FilterWheelCapability(_ForwardCompatibleModel):
+    """Planning-time capability data for one filter wheel, keyed by `module_name`.
 
-    `module_name` is nullable -- not every filter wheel is its own addressable module (some
-    cameras expose filter selection through the camera module itself), per pyobs-portal#142.
+    `module_name` is required, same as every other device here -- a wheel with filter selection
+    exposed through the camera's own module (no independent XMPP identity) should be entered with
+    the *camera's* module_name, not left blank. It used to be nullable (pyobs-portal#142) but a
+    blank value made the row permanently unreachable via `InstrumentCapabilities.filter_wheel()`,
+    which indexes by module_name -- there was no valid case for it in practice.
     """
 
     name: str = ""
-    module_name: str | None = None
+    module_name: str
+    model: str = ""
     filter_change_time_s: float | None = None
     updated_at: str | None = None
     filters: list[Filter] = Field(default_factory=list)
 
 
-class CameraCapability(BaseModel):
+class CameraCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one camera, keyed by `module_name`."""
 
     module_name: str
     code: str
+    model: str = ""
+    sensor_type: str = ""
     pixel_size_um: float | None = None
     sensor_width_px: int | None = None
     sensor_height_px: int | None = None
@@ -79,7 +102,7 @@ class CameraCapability(BaseModel):
 DEFAULT_SLEW_DISTANCE_DEG = 90.0
 
 
-class TelescopeCapability(BaseModel):
+class TelescopeCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one telescope, keyed by `module_name`."""
 
     module_name: str
@@ -103,7 +126,7 @@ class TelescopeCapability(BaseModel):
         return distance_deg / self.slew_rate_deg_per_s
 
 
-class DomeCapability(BaseModel):
+class DomeCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one dome, keyed by `module_name`."""
 
     module_name: str
@@ -120,7 +143,7 @@ class DomeCapability(BaseModel):
         return distance_deg / self.rotate_rate_deg_per_s
 
 
-class RoofCapability(BaseModel):
+class RoofCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one plain open/close roof, keyed by `module_name`.
 
     A plain roof (`IRoof`, no `IPointingAltAz`) has no rate/distance concept -- nothing to rotate
@@ -136,7 +159,7 @@ class RoofCapability(BaseModel):
     updated_at: str | None = None
 
 
-class Instrument(BaseModel):
+class Instrument(_ForwardCompatibleModel):
     """One telescope + dome/roof + camera(s) grouping, as returned by `GET /api/instruments/`.
 
     Purely an organizational grouping on the portal side -- it carries no module identity of its
@@ -176,8 +199,7 @@ class InstrumentCapabilities:
                 self._cameras[camera.module_name] = camera
                 self._cameras_by_code[camera.code] = camera
                 for wheel in camera.filter_wheels:
-                    if wheel.module_name is not None:
-                        self._filter_wheels[wheel.module_name] = wheel
+                    self._filter_wheels[wheel.module_name] = wheel
             if instrument.telescope is not None:
                 self._telescopes[instrument.telescope.module_name] = instrument.telescope
             if instrument.dome is not None:

--- a/pyobs/robotic/instruments.py
+++ b/pyobs/robotic/instruments.py
@@ -52,15 +52,19 @@ class BinningOption(_ForwardCompatibleModel):
 class FilterWheelCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one filter wheel, keyed by `module_name`.
 
-    `module_name` is required, same as every other device here -- a wheel with filter selection
-    exposed through the camera's own module (no independent XMPP identity) should be entered with
-    the *camera's* module_name, not left blank. It used to be nullable (pyobs-portal#142) but a
-    blank value made the row permanently unreachable via `InstrumentCapabilities.filter_wheel()`,
-    which indexes by module_name -- there was no valid case for it in practice.
+    `module_name` is required and non-empty, same as every other device here -- a wheel with
+    filter selection exposed through the camera's own module (no independent XMPP identity)
+    should be entered with the *camera's* module_name, not left blank. It used to be nullable
+    (pyobs-portal#142) but a blank value made the row permanently unreachable via
+    `InstrumentCapabilities.filter_wheel()`, which indexes by module_name -- there was no valid
+    case for it in practice. `min_length=1` closes the same gap for `""`, which `str` alone
+    wouldn't catch (only non-`None`, not non-empty) and which the portal side's `blank=False`
+    can't fully guarantee either (pre-#142 `blank=True` rows, or a direct ORM write bypassing
+    `full_clean()`).
     """
 
     name: str = ""
-    module_name: str
+    module_name: str = Field(min_length=1)
     model: str = ""
     filter_change_time_s: float | None = None
     updated_at: str | None = None
@@ -70,7 +74,7 @@ class FilterWheelCapability(_ForwardCompatibleModel):
 class CameraCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one camera, keyed by `module_name`."""
 
-    module_name: str
+    module_name: str = Field(min_length=1)
     code: str
     model: str = ""
     sensor_type: str = ""
@@ -105,7 +109,7 @@ DEFAULT_SLEW_DISTANCE_DEG = 90.0
 class TelescopeCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one telescope, keyed by `module_name`."""
 
-    module_name: str
+    module_name: str = Field(min_length=1)
     aperture_mm: float | None = None
     focal_length_mm: float | None = None
     mount_type: str = ""
@@ -129,7 +133,7 @@ class TelescopeCapability(_ForwardCompatibleModel):
 class DomeCapability(_ForwardCompatibleModel):
     """Planning-time capability data for one dome, keyed by `module_name`."""
 
-    module_name: str
+    module_name: str = Field(min_length=1)
     rotate_rate_deg_per_s: float | None = None
     updated_at: str | None = None
 
@@ -154,7 +158,7 @@ class RoofCapability(_ForwardCompatibleModel):
     directly.
     """
 
-    module_name: str
+    module_name: str = Field(min_length=1)
     open_close_time_s: float | None = None
     updated_at: str | None = None
 

--- a/specs/plans/2026-09-04-camera-filterwheel-descriptive-fields.md
+++ b/specs/plans/2026-09-04-camera-filterwheel-descriptive-fields.md
@@ -1,0 +1,71 @@
+# Plan: Camera/filter-wheel descriptive fields, required module_name, forward-compatible parsing
+
+Status: implemented, pending PR merge (Repos: pyobs-core, pyobs-portal)
+
+Surfaced while filling in MONET-South's real capability data (`monet/pyobs-monet#3`) through the
+portal admin: no field existed to record which physical camera/sensor/filter-wheel model is
+actually installed, `FilterWheelCapability.module_name` turned out to be a real bug (see below),
+and adding the two new fields immediately broke a running `mastermind` on an older pyobs-core
+release, surfacing a design gap the original 2026-09-01 plan had flagged but left undecided.
+
+## 1. Descriptive fields
+
+`CameraCapability` gains `model` (e.g. "FLI ProLine PL23042") and `sensor_type` (e.g. "e2v
+CCD230-42, back-illuminated CCD"); `FilterWheelCapability` gains `model` (e.g. "FLI CFW-2-7").
+Both blank-ok strings, no behavioral effect — pure reference data, mirrored 1:1 between
+pyobs-portal's Django models and pyobs-core's pydantic models.
+
+## 2. FilterWheelCapability.module_name: nullable → required
+
+`module_name` was nullable, documented as "for a wheel with no addressable module of its own (e.g.
+integrated into the camera)". In practice this was a bug, not a feature: pyobs-core's
+`InstrumentCapabilities.__init__` only indexes filter wheels with a non-`None` module_name
+(`if wheel.module_name is not None: self._filter_wheels[...] = wheel`), so a null-module_name row
+was **silently unreachable** by any script or scheduler lookup — dead data. The "integrated into
+the camera" case this was meant to cover (e.g. `pyobs_sbig.SbigFilterCamera` exposing filter
+control through the camera's own module, per `filter_wheel: AUTO` in its config) is correctly
+handled by entering the *camera's* module_name on the `FilterWheelCapability` row, not leaving it
+blank — there was no real case left for null.
+
+Changed to required on both sides (`str`, no default) — matches `CameraCapability`/
+`TelescopeCapability`/`DomeCapability`/`RoofCapability`'s own `module_name` exactly. No existing
+production data had a null value (confirmed before making the schema change), so this is a plain
+migration, no backfill needed.
+
+## 3. Forward-compatible parsing (`extra="ignore"` for the capability models)
+
+Landed the two field additions above straight into pyobs-portal, and a running `mastermind` on an
+still-current-at-the-time pyobs-core release started logging parse failures polling
+`/api/instruments/` — because every model in `pyobs/robotic/instruments.py` inherits
+`pyobs.utils.serialization.BaseModel`'s `extra="forbid"`, an unrecognized field anywhere in the
+payload fails the *entire* response's validation, not just that field. `PortalTaskArchive`
+already catches this and degrades to the last-good cache (`_poll_instrument_capabilities`'s broad
+`except Exception`), so nothing crashed, but it turned an ordinary field addition into a logged
+error and a stale cache until the site's own pyobs-core got upgraded — exactly the risk flagged,
+but left undecided, in the original 2026-09-01 plan's design notes ("extra='forbid' on the
+§A.1 models degrade-to-None conflict").
+
+Fixed at the source: every model in `pyobs/robotic/instruments.py` now inherits a new
+`_ForwardCompatibleModel` base (`BaseModel` subclass, `model_config = ConfigDict(extra="ignore")`)
+instead of `BaseModel` directly. `extra="forbid"` stays the right default everywhere else in pyobs
+(catching config typos, `2026-08-15-pydantic-extra-validation.md`) — scoped narrowly here because
+this module only ever consumes portal-controlled data, and the portal and any given fleet site's
+pyobs-core version are never guaranteed to be on the same release. A portal response with a field
+an older client doesn't recognize now parses successfully (that field dropped, everything else
+intact) instead of rejecting the whole response.
+
+## Test plan
+
+- [x] pyobs-portal: `model`/`sensor_type` round-trip in serializer shape test; `module_name`
+      global-uniqueness test rewritten for the now-required field (was "None is fine, multiple
+      allowed" — no longer a valid case) — `pyobs_portal/instruments/tests.py`, 25 tests in the
+      app, 152 in the full suite.
+- [x] pyobs-core: `model`/`sensor_type`/wheel-`model` round-trip; `FilterWheelCapability` with
+      `module_name=None` now raises `ValidationError` (was silently unreachable, now a hard
+      failure at parse time instead of silent data loss); a payload with unrecognized fields
+      mixed in with recognized ones now parses successfully and updates the cache (rewrote
+      `test_instrument_capabilities_poll_keeps_last_good_on_unparseable_payload`, which tested
+      the old `extra="forbid"` behavior directly, into
+      `test_instrument_capabilities_poll_tolerates_unrecognized_fields`) —
+      `tests/robotic/test_instruments.py`, `tests/robotic/storage/portal/test_portal_archives.py`,
+      504 tests in the full `tests/robotic/` suite.

--- a/specs/plans/2026-09-04-camera-filterwheel-descriptive-fields.md
+++ b/specs/plans/2026-09-04-camera-filterwheel-descriptive-fields.md
@@ -54,18 +54,57 @@ pyobs-core version are never guaranteed to be on the same release. A portal resp
 an older client doesn't recognize now parses successfully (that field dropped, everything else
 intact) instead of rejecting the whole response.
 
+**`Task`/`Project` are deliberately not covered by this carve-out** — they keep `extra="forbid"`,
+same as `2026-08-15-pydantic-extra-validation.md` decided ("declare the missing fields, use
+`forbid` here too, no carve-out"), and `PortalTaskArchive` already follows that: `updated_at` and
+`public` were each added to the strict models in lockstep with the portal
+(`test_task_get_tasks_from_portal_accepts_updated_at`,
+`test_task_get_projects_from_portal_accepts_public`). Both are also portal-parsed and also
+degrade-to-last-good on failure, so the identical incident *could* recur there the next time
+`/api/tasks/` or `/api/projects/` grows a field before the pyobs-core mirror lands — worth naming
+explicitly so a future field addition doesn't rediscover this the way the `mastermind` incident
+did. The distinction that justifies treating them differently: `Task`/`Project` are curated,
+config-like payloads deliberately kept in lockstep with the portal schema (a mismatch there is
+closer to the "config typo" case `extra="forbid"` exists to catch), where the capability models
+here are open-ended reference data a human can add fields to at will, with no expectation that
+every pyobs-core release tracks every field. If that trade-off stops feeling right in practice,
+the fix is the same shape as this one: add the missing field to the mirror and keep it in lockstep,
+not relax `Task`/`Project` too.
+
+**Robustness note**: `module_name` on every capability model here (not just
+`FilterWheelCapability`) also got `Field(min_length=1)` — plain `str` only enforces non-`None`,
+not non-empty, so an empty-string `module_name` would have reproduced the exact same
+silently-unreachable-row bug §2 above just fixed, in a new disguise. The portal side's
+`blank=False` prevents new empty values through the admin, but can't fully guarantee it (a
+pre-#142 row could already hold `""`, or a direct ORM write bypasses `full_clean()`).
+
+## Deploy ordering
+
+pyobs-core must merge/release before pyobs-portal deploys this — same as the roof-capability pair
+(#877/#149) before it. Currently-released pyobs-core still parses with `extra="forbid"` and has no
+`model`/`sensor_type` fields; if the portal deploys first, the next `mastermind` (or any other
+site still on the old release) polling it reproduces the exact incident this pair fixes: a logged
+parse error every poll, serving a stale cache until that site's pyobs-core is upgraded. pyobs-core
+#882 removes the breakage only once it actually ships to PyPI and the site upgrades to it.
+
 ## Test plan
 
 - [x] pyobs-portal: `model`/`sensor_type` round-trip in serializer shape test; `module_name`
       global-uniqueness test rewritten for the now-required field (was "None is fine, multiple
-      allowed" — no longer a valid case) — `pyobs_portal/instruments/tests.py`, 25 tests in the
-      app, 152 in the full suite.
+      allowed" — no longer a valid case); `sensor_type` added to `list_display` alongside
+      `search_fields` (was searchable but not visible in the list view) —
+      `pyobs_portal/instruments/tests.py`, 25 tests in the app, 152 in the full suite.
 - [x] pyobs-core: `model`/`sensor_type`/wheel-`model` round-trip; `FilterWheelCapability` with
-      `module_name=None` now raises `ValidationError` (was silently unreachable, now a hard
-      failure at parse time instead of silent data loss); a payload with unrecognized fields
-      mixed in with recognized ones now parses successfully and updates the cache (rewrote
+      `module_name=None` or `module_name=""` now raises `ValidationError` (both were silently
+      unreachable before, now a hard failure at parse time instead of silent data loss) —
+      `min_length=1` applied to every capability model's `module_name`, not just
+      `FilterWheelCapability`'s, closing the same empty-string gap everywhere; a payload with
+      unrecognized fields at every nesting level (Instrument/Camera/Binning/FilterWheel/Filter/
+      Telescope/Dome) now parses successfully and updates the cache (rewrote
       `test_instrument_capabilities_poll_keeps_last_good_on_unparseable_payload`, which tested
       the old `extra="forbid"` behavior directly, into
-      `test_instrument_capabilities_poll_tolerates_unrecognized_fields`) —
+      `test_instrument_capabilities_poll_tolerates_unrecognized_fields`); a companion test covers
+      the still-real failure mode `extra="ignore"` doesn't touch — a *structurally* invalid
+      payload (required field missing) still degrades to last-good, marker not advanced —
       `tests/robotic/test_instruments.py`, `tests/robotic/storage/portal/test_portal_archives.py`,
-      504 tests in the full `tests/robotic/` suite.
+      507 tests in the full `tests/robotic/` suite.

--- a/specs/plans/index.md
+++ b/specs/plans/index.md
@@ -237,3 +237,10 @@ Implementation plans, checklist-style. Newest at the bottom.
   `Pointing`/`Imaging`/`AutoFocusScript`, folded into the same `max()` first-task estimate. Real
   motivating fleet: MONET-N/S/MONTI are plain roofs, no rotating dome (`monet/pyobs-monet#3`).
   **implemented, pending PR merge** (issue #877; Repos: pyobs-core, pyobs-portal)
+- [2026-09-04-camera-filterwheel-descriptive-fields.md](2026-09-04-camera-filterwheel-descriptive-fields.md)
+  — `model`/`sensor_type` fields for reference data; `FilterWheelCapability.module_name` made
+  required (was nullable but silently unreachable — dead-data bug); every capability model in
+  `pyobs/robotic/instruments.py` switched to `extra="ignore"` so a portal ahead of a fleet site's
+  pyobs-core release degrades gracefully instead of a hard parse failure (surfaced live: a
+  running `mastermind` started erroring the moment the two new fields landed). **implemented,
+  pending PR merge** (no issue; Repos: pyobs-core, pyobs-portal)

--- a/tests/robotic/storage/portal/test_portal_archives.py
+++ b/tests/robotic/storage/portal/test_portal_archives.py
@@ -996,21 +996,28 @@ async def test_instrument_capabilities_poll_keeps_last_good_on_download_failure(
 
 
 @pytest.mark.asyncio
-async def test_instrument_capabilities_poll_keeps_last_good_on_unparseable_payload(mocker) -> None:
-    """A portal payload the (extra="forbid") pyobs-core models don't recognize must degrade like
-    any other fetch failure, not raise past _poll_instrument_capabilities()."""
+async def test_instrument_capabilities_poll_tolerates_unrecognized_fields(mocker) -> None:
+    """A portal running ahead of this pyobs-core release (e.g. the model/sensor_type fields
+    added to CameraCapability/FilterWheelCapability) must not turn into a hard parse failure --
+    the capability models use extra="ignore" (not BaseModel's default extra="forbid") for
+    exactly this: an unrecognized field is dropped, everything else still parses and the poll
+    succeeds normally, advancing the marker rather than falling back to the last-good cache."""
     archive = make_task_archive()
-    good = InstrumentCapabilities.from_api_response([{"display_name": "Good"}])
-    archive._instrument_capabilities = good
+    stale = InstrumentCapabilities.from_api_response([{"display_name": "Stale"}])
+    archive._instrument_capabilities = stale
     archive._instrument_capabilities_marker = T1
     mocker.patch.object(archive, "_last_instrument_update_time", AsyncMock(return_value=T2))
     mocker.patch(
         "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
-        AsyncMock(return_value=[{"some_unrecognized_future_field": 1}]),
+        AsyncMock(return_value=[{"display_name": "Fresh", "some_unrecognized_future_field": 1, "cameras": []}]),
     )
     await archive._poll_instrument_capabilities()
-    assert archive.get_instrument_capabilities() is good
-    assert archive._instrument_capabilities_marker == T1
+
+    capabilities = archive.get_instrument_capabilities()
+    assert capabilities is not stale
+    assert isinstance(capabilities, InstrumentCapabilities)
+    assert capabilities.instruments[0].display_name == "Fresh"
+    assert archive._instrument_capabilities_marker == T2
 
 
 @pytest.mark.asyncio

--- a/tests/robotic/storage/portal/test_portal_archives.py
+++ b/tests/robotic/storage/portal/test_portal_archives.py
@@ -1021,6 +1021,27 @@ async def test_instrument_capabilities_poll_tolerates_unrecognized_fields(mocker
 
 
 @pytest.mark.asyncio
+async def test_instrument_capabilities_poll_keeps_last_good_on_structurally_invalid_payload(mocker) -> None:
+    """extra="ignore" only forgives *unrecognized* fields -- a structurally invalid payload (a
+    required field missing, or the wrong type) still fails to parse and must degrade the same way
+    a download failure does: keep the last-good cache, marker not advanced, so the next poll
+    retries. This is the regression the unrecognized-fields test above can no longer cover."""
+    archive = make_task_archive()
+    good = InstrumentCapabilities.from_api_response([{"display_name": "Good"}])
+    archive._instrument_capabilities = good
+    archive._instrument_capabilities_marker = T1
+    mocker.patch.object(archive, "_last_instrument_update_time", AsyncMock(return_value=T2))
+    mocker.patch(
+        "pyobs.robotic.storage.portal.taskarchive.http_request_paginated",
+        # a camera missing its required module_name/code -- ValidationError, not extra="ignore"
+        AsyncMock(return_value=[{"display_name": "Bad", "cameras": [{"pixel_size_um": 5.4}]}]),
+    )
+    await archive._poll_instrument_capabilities()
+    assert archive.get_instrument_capabilities() is good
+    assert archive._instrument_capabilities_marker == T1
+
+
+@pytest.mark.asyncio
 async def test_poll_calls_instrument_capabilities_poll(mocker) -> None:
     """_poll() (the background loop's entry point) must not forget to also poll instrument
     capabilities alongside tasks/projects."""

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from pyobs.robotic.instruments import (
     DomeCapability,
@@ -24,6 +25,8 @@ INSTRUMENT_RESPONSE: dict[str, Any] = {
         {
             "module_name": "iag50cam",
             "code": "ef01",
+            "model": "FLI ProLine PL23042",
+            "sensor_type": "e2v CCD230-42, back-illuminated CCD",
             "pixel_size_um": 5.4,
             "sensor_width_px": 4096,
             "sensor_height_px": 4096,
@@ -42,6 +45,7 @@ INSTRUMENT_RESPONSE: dict[str, Any] = {
                 {
                     "name": "",
                     "module_name": "iag50filt",
+                    "model": "FLI CFW-2-7",
                     "filter_change_time_s": 4.5,
                     "updated_at": "2026-09-02T18:34:16.453140Z",
                     "filters": [
@@ -75,9 +79,12 @@ def test_instrument_round_trips_portal_response() -> None:
     camera = instrument.cameras[0]
     assert camera.module_name == "iag50cam"
     assert camera.code == "ef01"
+    assert camera.model == "FLI ProLine PL23042"
+    assert camera.sensor_type == "e2v CCD230-42, back-illuminated CCD"
     assert [(b.x, b.y, b.readout_time_s) for b in camera.binnings] == [(1, 1, 3.2), (2, 2, 1.8)]
     wheel = camera.filter_wheels[0]
     assert wheel.module_name == "iag50filt"
+    assert wheel.model == "FLI CFW-2-7"
     assert wheel.filter_change_time_s == 4.5
     assert [f.name for f in wheel.filters] == ["R", "V"]
     assert instrument.telescope is not None
@@ -105,6 +112,22 @@ def test_instrument_with_plain_roof_round_trips() -> None:
     assert instrument.roof is not None
     assert instrument.roof.module_name == "iag50roof"
     assert instrument.roof.open_close_time_s == 45.0
+
+
+def test_instrument_tolerates_unknown_fields() -> None:
+    # a running process can be on an older pyobs-core release than whatever portal it polls --
+    # an unrecognized field (the portal gained one, or will) must degrade gracefully, not raise.
+    response = {
+        **INSTRUMENT_RESPONSE,
+        "some_future_field": "unexpected",
+        "cameras": [{**INSTRUMENT_RESPONSE["cameras"][0], "some_future_camera_field": 123}],
+        "telescope": {**INSTRUMENT_RESPONSE["telescope"], "some_future_telescope_field": True},
+    }
+    instrument = Instrument.model_validate(response)
+    assert instrument.display_name == "GOE 50cm"
+    assert instrument.cameras[0].module_name == "iag50cam"
+    assert instrument.telescope is not None
+    assert instrument.telescope.module_name == "iag50telescope"
 
 
 def test_instrument_with_no_telescope_or_dome() -> None:
@@ -159,10 +182,9 @@ class TestInstrumentCapabilities:
         assert wheel is not None
         assert wheel.filter_change_time_s == 4.5
 
-    def test_filter_wheel_with_no_module_name_is_not_indexed(self) -> None:
-        # pyobs-portal#142: module_name is nullable on FilterWheelCapability -- a wheel with none
-        # set has no key to look it up by, and must not silently collide with another None-named
-        # entry.
+    def test_filter_wheel_requires_module_name(self) -> None:
+        # module_name used to be nullable (pyobs-portal#142) -- dropped since a blank value made
+        # the row permanently unreachable via filter_wheel() lookup, with no valid use case left.
         response = {
             **INSTRUMENT_RESPONSE,
             "cameras": [
@@ -180,8 +202,8 @@ class TestInstrumentCapabilities:
                 }
             ],
         }
-        capabilities = InstrumentCapabilities.from_api_response([response])
-        assert capabilities.filter_wheel("iag50filt") is None
+        with pytest.raises(ValidationError):
+            InstrumentCapabilities.from_api_response([response])
 
     def test_multiple_instruments_aggregate_into_one_lookup(self) -> None:
         other = {

--- a/tests/robotic/test_instruments.py
+++ b/tests/robotic/test_instruments.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from pyobs.robotic.instruments import (
+    CameraCapability,
     DomeCapability,
     Instrument,
     InstrumentCapabilities,
@@ -116,18 +117,45 @@ def test_instrument_with_plain_roof_round_trips() -> None:
 
 def test_instrument_tolerates_unknown_fields() -> None:
     # a running process can be on an older pyobs-core release than whatever portal it polls --
-    # an unrecognized field (the portal gained one, or will) must degrade gracefully, not raise.
+    # an unrecognized field (the portal gained one, or will) must degrade gracefully, not raise,
+    # at every nesting level (every model here shares the same _ForwardCompatibleModel base).
     response = {
         **INSTRUMENT_RESPONSE,
         "some_future_field": "unexpected",
-        "cameras": [{**INSTRUMENT_RESPONSE["cameras"][0], "some_future_camera_field": 123}],
+        "cameras": [
+            {
+                **INSTRUMENT_RESPONSE["cameras"][0],
+                "some_future_camera_field": 123,
+                "binnings": [{**INSTRUMENT_RESPONSE["cameras"][0]["binnings"][0], "some_future_binning_field": 1}],
+                "filter_wheels": [
+                    {
+                        **INSTRUMENT_RESPONSE["cameras"][0]["filter_wheels"][0],
+                        "some_future_wheel_field": 1,
+                        "filters": [
+                            {
+                                **INSTRUMENT_RESPONSE["cameras"][0]["filter_wheels"][0]["filters"][0],
+                                "some_future_filter_field": 1,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
         "telescope": {**INSTRUMENT_RESPONSE["telescope"], "some_future_telescope_field": True},
+        "dome": {**INSTRUMENT_RESPONSE["dome"], "some_future_dome_field": True},
     }
     instrument = Instrument.model_validate(response)
     assert instrument.display_name == "GOE 50cm"
-    assert instrument.cameras[0].module_name == "iag50cam"
+    camera = instrument.cameras[0]
+    assert camera.module_name == "iag50cam"
+    assert camera.binnings[0].x == 1
+    wheel = camera.filter_wheels[0]
+    assert wheel.module_name == "iag50filt"
+    assert wheel.filters[0].name == "R"
     assert instrument.telescope is not None
     assert instrument.telescope.module_name == "iag50telescope"
+    assert instrument.dome is not None
+    assert instrument.dome.module_name == "iag50dome"
 
 
 def test_instrument_with_no_telescope_or_dome() -> None:
@@ -205,6 +233,31 @@ class TestInstrumentCapabilities:
         with pytest.raises(ValidationError):
             InstrumentCapabilities.from_api_response([response])
 
+    def test_filter_wheel_rejects_empty_module_name(self) -> None:
+        # str alone only enforces non-None, not non-empty -- min_length=1 closes the same
+        # unreachable-row gap for "" that the None case above closes for null. A pre-#142 row
+        # (blank=True allowed "") or a direct ORM write bypassing the portal's full_clean() could
+        # still produce one.
+        response = {
+            **INSTRUMENT_RESPONSE,
+            "cameras": [
+                {
+                    **INSTRUMENT_RESPONSE["cameras"][0],
+                    "filter_wheels": [
+                        {
+                            "name": "unnamed",
+                            "module_name": "",
+                            "filter_change_time_s": 1.0,
+                            "updated_at": None,
+                            "filters": [],
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValidationError):
+            InstrumentCapabilities.from_api_response([response])
+
     def test_multiple_instruments_aggregate_into_one_lookup(self) -> None:
         other = {
             **INSTRUMENT_RESPONSE,
@@ -218,6 +271,19 @@ class TestInstrumentCapabilities:
         assert capabilities.camera("guidecam") is not None
         assert capabilities.telescope("guidetelescope") is not None
         assert len(capabilities.instruments) == 2
+
+
+def test_module_name_min_length_applies_to_every_capability_model() -> None:
+    # broadened from FilterWheelCapability alone -- str only enforces non-None, and the
+    # unreachable-empty-string gap applies equally to every module_name field here.
+    for cls, kwargs in [
+        (CameraCapability, {"module_name": "", "code": "ef01"}),
+        (TelescopeCapability, {"module_name": ""}),
+        (DomeCapability, {"module_name": ""}),
+        (RoofCapability, {"module_name": ""}),
+    ]:
+        with pytest.raises(ValidationError):
+            cls(**kwargs)
 
 
 class TestTelescopeCapabilityEstimateSlewTime:


### PR DESCRIPTION
## Summary
- `CameraCapability` gains `model` (e.g. "FLI ProLine PL23042") and `sensor_type` (e.g. "e2v CCD230-42, back-illuminated CCD"); `FilterWheelCapability` gains `model` (e.g. "FLI CFW-2-7"). Pure reference data, no behavior change.
- `FilterWheelCapability.module_name`: nullable → required. It was documented as "for a wheel with no addressable module of its own", but `InstrumentCapabilities.__init__` only ever indexes non-null module names — a null row was **silently unreachable** by any script/scheduler lookup. The "integrated into the camera" case it was meant for is correctly handled by entering the *camera's* own module_name instead, not leaving it blank.
- Every model in `pyobs/robotic/instruments.py` now inherits a new `_ForwardCompatibleModel` base (`extra="ignore"` instead of `BaseModel`'s `extra="forbid"`). Discovered live: adding the two fields above to pyobs-portal immediately broke a running `mastermind` still on an older pyobs-core release — it degraded gracefully (kept serving the last-good cache, per existing design) but logged a parse error on every poll until upgraded. Scoped narrowly to this module (portal-controlled data, not user-authored config) — `extra="forbid"` stays the right default everywhere else in pyobs.

## Why
Surfaced while filling in MONET-South's real instrument capability data (`monet/pyobs-monet#3`) through the portal admin — wanted to record the actual camera/sensor model, hit the nullable-module_name bug while discussing why filter wheels have a `name` field and cameras don't, and hit the forward-compat gap the moment the new fields landed on a live portal.

Companion PR on the portal side: pyobs-portal side (same title).

## Test plan
- [x] `pytest tests/robotic/` — 504 passed
- [x] `ruff check` / `black --check` / `pyrefly check` — clean
- [x] Rewrote `test_instrument_capabilities_poll_keeps_last_good_on_unparseable_payload` (tested the old `extra="forbid"` behavior directly) into `test_instrument_capabilities_poll_tolerates_unrecognized_fields`, verifying the new degrade-gracefully-and-still-update behavior